### PR TITLE
test: increase test coverage from 51% to 88%

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -394,6 +394,72 @@ func writeResponse(t *testing.T, w http.ResponseWriter, body string, gzipBody bo
 	}
 }
 
+func TestNewForTesting(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	c := NewForTesting(httpClient, "http://test.example")
+	if c.baseURL != "http://test.example" {
+		t.Errorf("expected baseURL http://test.example, got %s", c.baseURL)
+	}
+	if c.xsrfToken != "test-token" {
+		t.Errorf("expected xsrfToken test-token, got %s", c.xsrfToken)
+	}
+}
+
+func TestPostDataTablesDataDecodeError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"draw":1,"data":"not an array"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestClient(server.URL)
+	var got []string
+	err := c.PostDataTables(context.Background(), "/test", "draw=1", &got)
+	assertErrorContains(t, err, "decode DataTables data")
+}
+
+func TestPostJSONDecodeError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `not json at all`)
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestClient(server.URL)
+	var got struct{ Name string }
+	err := c.PostJSON(context.Background(), "/test", struct{}{}, &got)
+	assertErrorContains(t, err, "decode JSON response")
+}
+
+func TestPostFormDecodeError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `not json`)
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestClient(server.URL)
+	var got struct{ Name string }
+	err := c.PostForm(context.Background(), "/test", url.Values{"key": {"val"}}, &got)
+	assertErrorContains(t, err, "decode form response")
+}
+
+func TestDoRequestConnectionError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	server.Close()
+
+	c := newTestClient(server.URL)
+	err := c.PostJSON(context.Background(), "/test", struct{}{}, &struct{}{})
+	assertErrorContains(t, err, "post JSON request")
+}
+
 func assertErrorContains(t *testing.T, err error, want string) {
 	t.Helper()
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -460,6 +460,28 @@ func TestDoRequestConnectionError(t *testing.T) {
 	assertErrorContains(t, err, "post JSON request")
 }
 
+func TestReadResponseBodyGzipError(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		Body:   io.NopCloser(strings.NewReader("not-gzip-data")),
+		Header: http.Header{"Content-Encoding": []string{"gzip"}},
+	}
+	_, err := readResponseBody(resp)
+	assertErrorContains(t, err, "open gzip response body")
+}
+
+func TestPostMultipartConnectionError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	server.Close()
+
+	c := newTestClient(server.URL)
+	err := c.PostMultipart(context.Background(), "/test", map[string]string{"key": "val"})
+	assertErrorContains(t, err, "post multipart request")
+}
+
 func assertErrorContains(t *testing.T, err error, want string) {
 	t.Helper()
 

--- a/internal/commands/alert_test.go
+++ b/internal/commands/alert_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -111,7 +112,9 @@ func TestRunAlertEdit(t *testing.T) {
 func TestRunAlertCreateWithTickers(t *testing.T) {
 	// Verifies that buildAlertConfigFields auto-selects SelectedTickers when
 	// tickers are specified but ticker-group is left at the default.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(server.Close)
@@ -123,6 +126,9 @@ func TestRunAlertCreateWithTickers(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+	if !strings.Contains(string(capturedBody), "SelectedTickers") {
+		t.Errorf("expected request body to reference SelectedTickers, got: %s", capturedBody)
+	}
 }
 
 func TestAlertConfigsCLI(t *testing.T) {
@@ -162,7 +168,16 @@ func TestRunAlertCreateEditServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
-	err := root.Run(ctx, []string{"app", "alert", "create", "--name", "Test"})
-	assertErrContains(t, err, "save alert config")
+
+	t.Run("create", func(t *testing.T) {
+		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
+		err := root.Run(ctx, []string{"app", "alert", "create", "--name", "Test"})
+		assertErrContains(t, err, "save alert config")
+	})
+
+	t.Run("edit", func(t *testing.T) {
+		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
+		err := root.Run(ctx, []string{"app", "alert", "edit", "--key", "42"})
+		assertErrContains(t, err, "save alert config")
+	})
 }

--- a/internal/commands/alert_test.go
+++ b/internal/commands/alert_test.go
@@ -124,3 +124,45 @@ func TestRunAlertCreateWithTickers(t *testing.T) {
 		}
 	})
 }
+
+func TestAlertConfigsCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
+		if err := root.Run(ctx, []string{"app", "alert", "configs"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestAlertDeleteCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
+		if err := root.Run(ctx, []string{"app", "alert", "delete", "--key", "42"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestRunAlertCreateEditServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
+	err := root.Run(ctx, []string{"app", "alert", "create", "--name", "Test"})
+	assertErrContains(t, err, "save alert config")
+}

--- a/internal/commands/chart_test.go
+++ b/internal/commands/chart_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	cli "github.com/urfave/cli/v3"
 )
 
 func TestRunPriceData(t *testing.T) {
@@ -138,4 +140,75 @@ func TestRunCompanyServerError(t *testing.T) {
 	ctx := contextWithTestClient(server.URL)
 	err := runCompany(ctx, "INVALID")
 	assertErrContains(t, err, "query company")
+}
+
+func TestRunPriceDataDecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[["not a price bar object"]]`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	err := runPriceData(ctx, &priceDataOptions{ticker: "AAPL", startDate: "2025-01-15", endDate: "2025-01-15"})
+	assertErrContains(t, err, "decode price bars")
+}
+
+func TestChartPriceDataCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[[{}]]`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
+		if err := root.Run(ctx, []string{"app", "chart", "price-data", "--ticker", "AAPL", "--start-date", "2025-01-15", "--end-date", "2025-01-15"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestChartSnapshotCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"Snapshot":{}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
+		if err := root.Run(ctx, []string{"app", "chart", "snapshot", "--ticker", "AAPL", "--date-key", "2025-01-15"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestChartLevelsCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
+		if err := root.Run(ctx, []string{"app", "chart", "levels", "--ticker", "AAPL", "--start-date", "2025-01-01", "--end-date", "2025-01-31"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestChartCompanyCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
+		if err := root.Run(ctx, []string{"app", "chart", "company", "--ticker", "AAPL"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	cli "github.com/urfave/cli/v3"
 )
 
 func TestRunSnapshots(t *testing.T) {
@@ -96,4 +98,52 @@ func TestRunExhaustionServerError(t *testing.T) {
 	ctx := contextWithTestClient(server.URL)
 	err := runExhaustion(ctx, "2025-01-15")
 	assertErrContains(t, err, "query exhaustion scores")
+}
+
+func TestMarketSnapshotsCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `"AAPL:255.30"`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
+		if err := root.Run(ctx, []string{"app", "market", "snapshots"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(output, "AAPL") {
+		t.Errorf("expected output to contain AAPL, got: %s", output)
+	}
+}
+
+func TestMarketEarningsCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
+		if err := root.Run(ctx, []string{"app", "market", "earnings", "--start-date", "2025-01-20", "--end-date", "2025-01-24"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestMarketExhaustionCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
+		if err := root.Run(ctx, []string{"app", "market", "exhaustion", "--date", "2025-01-15"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -101,7 +101,10 @@ func TestRunExhaustionServerError(t *testing.T) {
 }
 
 func TestMarketSnapshotsCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetAllSnapshots" {
+			t.Errorf("expected path /Trades/GetAllSnapshots, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, `"AAPL:255.30"`)
 	}))
 	t.Cleanup(server.Close)
@@ -119,7 +122,10 @@ func TestMarketSnapshotsCLI(t *testing.T) {
 }
 
 func TestMarketEarningsCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Earnings/GetEarnings" {
+			t.Errorf("expected path /Earnings/GetEarnings, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, dataTablesJSON(`[{}]`))
 	}))
 	t.Cleanup(server.Close)
@@ -134,7 +140,10 @@ func TestMarketEarningsCLI(t *testing.T) {
 }
 
 func TestMarketExhaustionCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ExecutiveSummary/GetExhaustionScores" {
+			t.Errorf("expected path /ExecutiveSummary/GetExhaustionScores, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, `{}`)
 	}))
 	t.Cleanup(server.Close)

--- a/internal/commands/run_helpers_test.go
+++ b/internal/commands/run_helpers_test.go
@@ -52,7 +52,7 @@ func TestRunDataTablesCommand(t *testing.T) {
 
 func TestRunDataTablesCommandPrettyJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+		fmt.Fprint(w, dataTablesJSON(`[{"A":1},{"B":2}]`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -67,7 +67,8 @@ func TestRunDataTablesCommandPrettyJSON(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
-	if !strings.Contains(output, "\n") {
+	// MarshalIndent uses two-space indentation; compact output never contains "  ".
+	if !strings.Contains(output, "\n  ") {
 		t.Errorf("expected indented output, got: %s", output)
 	}
 }

--- a/internal/commands/testhelpers_test.go
+++ b/internal/commands/testhelpers_test.go
@@ -31,13 +31,18 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatalf("create pipe: %v", err)
 	}
 	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
 	fn()
 	w.Close()
-	os.Stdout = old
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("read pipe: %v", err)
-	}
+	<-done
 	return buf.String()
 }
 

--- a/internal/commands/watchlist_test.go
+++ b/internal/commands/watchlist_test.go
@@ -152,3 +152,86 @@ func TestRunWatchlistEdit(t *testing.T) {
 		t.Errorf("expected output to contain updated, got: %s", output)
 	}
 }
+
+func TestWatchlistConfigsCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+		if err := root.Run(ctx, []string{"app", "watchlist", "configs"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestWatchlistTickersCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+		if err := root.Run(ctx, []string{"app", "watchlist", "tickers", "--watchlist-key", "1"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestWatchlistDeleteCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+		if err := root.Run(ctx, []string{"app", "watchlist", "delete", "--key", "1"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestWatchlistAddTickerCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+		if err := root.Run(ctx, []string{"app", "watchlist", "add-ticker", "--watchlist-key", "1", "--ticker", "NVDA"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestRunWatchlistTickersServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	err := runWatchlistTickers(ctx, 1)
+	assertErrContains(t, err, "query watchlist tickers")
+}
+
+func TestRunWatchlistCreateEditServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+	err := root.Run(ctx, []string{"app", "watchlist", "create", "--name", "Test"})
+	assertErrContains(t, err, "save watchlist config")
+}

--- a/internal/commands/watchlist_test.go
+++ b/internal/commands/watchlist_test.go
@@ -154,7 +154,10 @@ func TestRunWatchlistEdit(t *testing.T) {
 }
 
 func TestWatchlistConfigsCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/WatchListConfigs/GetWatchLists" {
+			t.Errorf("expected path /WatchListConfigs/GetWatchLists, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, dataTablesJSON(`[{}]`))
 	}))
 	t.Cleanup(server.Close)
@@ -169,7 +172,10 @@ func TestWatchlistConfigsCLI(t *testing.T) {
 }
 
 func TestWatchlistTickersCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/WatchLists/GetWatchListTickers" {
+			t.Errorf("expected path /WatchLists/GetWatchListTickers, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, dataTablesJSON(`[{}]`))
 	}))
 	t.Cleanup(server.Close)
@@ -184,7 +190,10 @@ func TestWatchlistTickersCLI(t *testing.T) {
 }
 
 func TestWatchlistDeleteCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/WatchListConfigs/DeleteWatchList" {
+			t.Errorf("expected path /WatchListConfigs/DeleteWatchList, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, `{"ok":true}`)
 	}))
 	t.Cleanup(server.Close)
@@ -199,7 +208,10 @@ func TestWatchlistDeleteCLI(t *testing.T) {
 }
 
 func TestWatchlistAddTickerCLI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Chart0/UpdateWatchList" {
+			t.Errorf("expected path /Chart0/UpdateWatchList, got %s", r.URL.Path)
+		}
 		fmt.Fprint(w, `{"ok":true}`)
 	}))
 	t.Cleanup(server.Close)
@@ -231,7 +243,16 @@ func TestRunWatchlistCreateEditServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
-	err := root.Run(ctx, []string{"app", "watchlist", "create", "--name", "Test"})
-	assertErrContains(t, err, "save watchlist config")
+
+	t.Run("create", func(t *testing.T) {
+		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+		err := root.Run(ctx, []string{"app", "watchlist", "create", "--name", "Test"})
+		assertErrContains(t, err, "save watchlist config")
+	})
+
+	t.Run("edit", func(t *testing.T) {
+		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
+		err := root.Run(ctx, []string{"app", "watchlist", "edit", "--key", "1"})
+		assertErrContains(t, err, "save watchlist config")
+	})
 }

--- a/internal/models/trade_test.go
+++ b/internal/models/trade_test.go
@@ -12,6 +12,7 @@ func TestAspNetDateUnmarshal(t *testing.T) {
 	tests := []struct {
 		name      string
 		input     string
+		wantErr   bool
 		wantValid bool
 		wantTime  time.Time
 	}{
@@ -41,13 +42,30 @@ func TestAspNetDateUnmarshal(t *testing.T) {
 			input:     `"/Date(-2208988800000)/"`,
 			wantValid: false,
 		},
+		{
+			name:    "invalid format",
+			input:   `"not-a-date"`,
+			wantErr: true,
+		},
+		{
+			name:    "non-string value",
+			input:   `12345`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var d AspNetDate
-			if err := json.Unmarshal([]byte(tt.input), &d); err != nil {
+			err := json.Unmarshal([]byte(tt.input), &d)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
 				t.Fatalf("unexpected unmarshal error: %v", err)
 			}
 			if d.Valid != tt.wantValid {
@@ -100,20 +118,29 @@ func TestFlexBoolUnmarshal(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
+		wantErr  bool
 		expected FlexBool
 	}{
-		{"true", "true", true},
-		{"false", "false", false},
-		{"1", "1", true},
-		{"0", "0", false},
-		{"null", "null", false},
+		{"true", "true", false, true},
+		{"false", "false", false, false},
+		{"1", "1", false, true},
+		{"0", "0", false, false},
+		{"null", "null", false, false},
+		{"invalid string", `"invalid"`, true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var b FlexBool
-			if err := json.Unmarshal([]byte(tt.input), &b); err != nil {
+			err := json.Unmarshal([]byte(tt.input), &b)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
 				t.Fatalf("unexpected unmarshal error: %v", err)
 			}
 			if b != tt.expected {
@@ -149,32 +176,4 @@ func TestFlexBoolMarshal(t *testing.T) {
 	}
 }
 
-func TestAspNetDateUnmarshalInvalidFormat(t *testing.T) {
-	t.Parallel()
 
-	var d AspNetDate
-	err := json.Unmarshal([]byte(`"not-a-date"`), &d)
-	if err == nil {
-		t.Fatal("expected error for invalid ASP.NET date format")
-	}
-}
-
-func TestAspNetDateUnmarshalNonString(t *testing.T) {
-	t.Parallel()
-
-	var d AspNetDate
-	err := json.Unmarshal([]byte(`12345`), &d)
-	if err == nil {
-		t.Fatal("expected error for non-string value")
-	}
-}
-
-func TestFlexBoolUnmarshalError(t *testing.T) {
-	t.Parallel()
-
-	var b FlexBool
-	err := json.Unmarshal([]byte(`"invalid"`), &b)
-	if err == nil {
-		t.Fatal("expected error for invalid FlexBool value")
-	}
-}

--- a/internal/models/trade_test.go
+++ b/internal/models/trade_test.go
@@ -148,3 +148,33 @@ func TestFlexBoolMarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestAspNetDateUnmarshalInvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	var d AspNetDate
+	err := json.Unmarshal([]byte(`"not-a-date"`), &d)
+	if err == nil {
+		t.Fatal("expected error for invalid ASP.NET date format")
+	}
+}
+
+func TestAspNetDateUnmarshalNonString(t *testing.T) {
+	t.Parallel()
+
+	var d AspNetDate
+	err := json.Unmarshal([]byte(`12345`), &d)
+	if err == nil {
+		t.Fatal("expected error for non-string value")
+	}
+}
+
+func TestFlexBoolUnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	var b FlexBool
+	err := json.Unmarshal([]byte(`"invalid"`), &b)
+	if err == nil {
+		t.Fatal("expected error for invalid FlexBool value")
+	}
+}


### PR DESCRIPTION
## Summary

- Add tests for all previously untested `run*` command execution functions and CLI Action closures across trade, chart, market, volume, alert, and watchlist packages
- Introduce test client injection via context (`NewForTesting` + `testClientKey`) to decouple tests from browser cookie extraction
- Add client decode error tests, model edge case tests, and shared test helpers

## Coverage

| Package | Before | After |
|---|---|---|
| `internal/commands` | 28.8% | 91.5% |
| `internal/client` | 77.8% | 82.4% |
| `internal/models` | 85.3% | 94.1% |
| **Overall** | **51.1%** | **87.5%** |

## Changes

**Infrastructure (2 modified, 1 new):**
- `internal/client/client.go` - `NewForTesting` constructor bypassing auth
- `internal/commands/helpers.go` - `testClientKey` context key + injection in `newCommandClient`
- `internal/commands/testhelpers_test.go` - shared test utilities

**Test files (7 new, 2 modified):**
- `run_helpers_test.go` - `runDataTablesCommand`, `newCommandClient` injection
- `run_trade_test.go` - all 7 trade subcommands (table-driven CLI invocation)
- `chart_test.go` - direct calls + CLI invocation for all 4 subcommands + decode error
- `market_test.go` - direct calls + CLI invocation for all 3 subcommands
- `volume_test.go` - `runVolume`, `parseVolumeOptions`, 3 subcommands (table-driven)
- `alert_test.go` - configs, delete, create, edit + CLI invocation + server error
- `watchlist_test.go` - all 6 operations + CLI invocation + server errors
- `client_test.go` - `NewForTesting`, decode errors for PostDataTables/PostJSON/PostForm, connection error
- `models/trade_test.go` - invalid date format, non-string input, FlexBool error

All tests use `httptest.NewServer` with context-injected test clients. No production code behavior changes.