### PR TITLE
fix: populate API-required params when using presets

### DIFF
--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	cli "github.com/urfave/cli/v3"
@@ -78,6 +80,118 @@ func TestTradeRunFunctions(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestTradeListPresetIncludesDefaults(t *testing.T) {
+	// Regression test for https://github.com/major/volumeleaders-agent/issues/8
+	// Presets must include CLI flag defaults for params the API requires
+	// (MaxVolume, MaxPrice, session toggles, etc.).
+	requiredParams := []string{
+		"MaxVolume", "MinVolume",
+		"MaxPrice", "MinPrice",
+		"MaxDollars", "MinDollars",
+		"IncludePremarket", "IncludeRTH", "IncludeAH",
+		"IncludeOpening", "IncludeClosing",
+		"IncludePhantom", "IncludeOffsetting",
+		"SecurityTypeKey", "MarketCap",
+		"DarkPools", "Sweeps", "LatePrints",
+		"SignaturePrints", "EvenShared",
+		"TradeRankSnapshot",
+	}
+
+	var body string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--preset", "Top-100 Rank",
+			"--start-date", "2025-04-01",
+			"--end-date", "2025-04-25",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, param := range requiredParams {
+		if !strings.Contains(body, param+"=") {
+			t.Errorf("preset request missing required param %q", param)
+		}
+	}
+}
+
+func TestTradeListPresetOverridesDefaults(t *testing.T) {
+	// The "Top-100 Rank" preset sets TradeRank=100 and MaxDollars=100000000000,
+	// overriding CLI defaults of TradeRank=-1 and MaxDollars=30000000000.
+	var body string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--preset", "Top-100 Rank",
+			"--start-date", "2025-04-01",
+			"--end-date", "2025-04-25",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Preset value should override CLI default.
+	if !strings.Contains(body, "TradeRank=100") {
+		t.Error("preset TradeRank=100 not found in request body")
+	}
+	if !strings.Contains(body, "MaxDollars=100000000000") {
+		t.Error("preset MaxDollars=100000000000 not found in request body")
+	}
+}
+
+func TestTradeListExplicitFlagOverridesPreset(t *testing.T) {
+	// An explicit CLI flag should override both the default and the preset.
+	var body string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--preset", "Top-100 Rank",
+			"--start-date", "2025-04-01",
+			"--end-date", "2025-04-25",
+			"--dark-pools", "1",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Explicit --dark-pools=1 should override the preset/default.
+	if !strings.Contains(body, "DarkPools=1") {
+		t.Error("explicit --dark-pools=1 not found in request body")
+	}
+	// Preset value should still be present.
+	if !strings.Contains(body, "TradeRank=100") {
+		t.Error("preset TradeRank=100 should still be present")
 	}
 }
 

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -224,13 +224,43 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	presetName := cmd.String("preset")
 	watchlistName := cmd.String("watchlist")
 
-	var filters map[string]string
+	// Build the full filter map from CLI flags (includes defaults for unset
+	// flags). Every key the API requires is present after this call.
+	opts := &tradesOptions{
+		tickers:      cmd.String("tickers"),
+		startDate:    cmd.String("start-date"),
+		endDate:      cmd.String("end-date"),
+		minVolume:    cmd.Int("min-volume"),
+		maxVolume:    cmd.Int("max-volume"),
+		minPrice:     cmd.Float("min-price"),
+		maxPrice:     cmd.Float("max-price"),
+		minDollars:   cmd.Float("min-dollars"),
+		maxDollars:   cmd.Float("max-dollars"),
+		conditions:   cmd.Int("conditions"),
+		vcd:          cmd.Int("vcd"),
+		securityType: cmd.Int("security-type"),
+		relativeSize: cmd.Int("relative-size"),
+		darkPools:    cmd.Int("dark-pools"),
+		sweeps:       cmd.Int("sweeps"),
+		latePrints:   cmd.Int("late-prints"),
+		sigPrints:    cmd.Int("sig-prints"),
+		evenShared:   cmd.Int("even-shared"),
+		tradeRank:    cmd.Int("trade-rank"),
+		rankSnapshot: cmd.Int("rank-snapshot"),
+		marketCap:    cmd.Int("market-cap"),
+		premarket:    cmd.Int("premarket"),
+		rth:          cmd.Int("rth"),
+		ah:           cmd.Int("ah"),
+		opening:      cmd.Int("opening"),
+		closing:      cmd.Int("closing"),
+		phantom:      cmd.Int("phantom"),
+		offsetting:   cmd.Int("offsetting"),
+		sector:       cmd.String("sector"),
+	}
+	filters := buildTradeFilters(opts)
 
 	if presetName != "" || watchlistName != "" {
-		// Start from preset/watchlist filters; only explicitly-set CLI
-		// flags will override them (via applyExplicitFlags below).
-		filters = make(map[string]string)
-
+		// Preset/watchlist values override the CLI defaults.
 		if presetName != "" {
 			preset, err := findPreset(presetName)
 			if err != nil {
@@ -251,41 +281,8 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 			}
 		}
 
+		// User-explicit CLI flags take final precedence.
 		applyExplicitFlags(cmd, filters)
-	} else {
-		// No preset or watchlist - use the standard flag-based filter build.
-		opts := &tradesOptions{
-			tickers:      cmd.String("tickers"),
-			startDate:    cmd.String("start-date"),
-			endDate:      cmd.String("end-date"),
-			minVolume:    cmd.Int("min-volume"),
-			maxVolume:    cmd.Int("max-volume"),
-			minPrice:     cmd.Float("min-price"),
-			maxPrice:     cmd.Float("max-price"),
-			minDollars:   cmd.Float("min-dollars"),
-			maxDollars:   cmd.Float("max-dollars"),
-			conditions:   cmd.Int("conditions"),
-			vcd:          cmd.Int("vcd"),
-			securityType: cmd.Int("security-type"),
-			relativeSize: cmd.Int("relative-size"),
-			darkPools:    cmd.Int("dark-pools"),
-			sweeps:       cmd.Int("sweeps"),
-			latePrints:   cmd.Int("late-prints"),
-			sigPrints:    cmd.Int("sig-prints"),
-			evenShared:   cmd.Int("even-shared"),
-			tradeRank:    cmd.Int("trade-rank"),
-			rankSnapshot: cmd.Int("rank-snapshot"),
-			marketCap:    cmd.Int("market-cap"),
-			premarket:    cmd.Int("premarket"),
-			rth:          cmd.Int("rth"),
-			ah:           cmd.Int("ah"),
-			opening:      cmd.Int("opening"),
-			closing:      cmd.Int("closing"),
-			phantom:      cmd.Int("phantom"),
-			offsetting:   cmd.Int("offsetting"),
-			sector:       cmd.String("sector"),
-		}
-		filters = buildTradeFilters(opts)
 	}
 
 	// Dates always come from CLI (required flags).


### PR DESCRIPTION
## Summary

- `trade list --preset` started from an empty filter map, so required API params (`MaxVolume`, `MaxPrice`, session toggles, etc.) were sent as null
- Now builds the full filter map via `buildTradeFilters()` first, then overlays preset/watchlist values, then applies explicit CLI flags
- Layering order matches the website behavior: defaults < preset < user flags

## Tests

Three regression tests added:
- `TestTradeListPresetIncludesDefaults` - verifies all required params are present in the request body when using a preset
- `TestTradeListPresetOverridesDefaults` - verifies preset values override CLI defaults
- `TestTradeListExplicitFlagOverridesPreset` - verifies explicit CLI flags override preset values

Closes #8