### PR TITLE
fix: paginate DataTables requests when length is -1

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -58,21 +58,31 @@ func New(ctx context.Context) (*Client, error) {
 	return &Client{http: httpClient, baseURL: BaseURL, cookies: cookies, xsrfToken: xsrfToken}, nil
 }
 
-// PostDataTables posts a form-encoded DataTables request and unmarshals its data array.
-func (c *Client) PostDataTables(ctx context.Context, path, body string, result any) error {
+// PostDataTablesPage posts a form-encoded DataTables request and returns the
+// full response envelope, including RecordsFiltered for pagination decisions.
+func (c *Client) PostDataTablesPage(ctx context.Context, path, body string) (*models.DataTablesResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, strings.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("create DataTables request: %w", err)
+		return nil, fmt.Errorf("create DataTables request: %w", err)
 	}
 
 	responseBody, err := c.doRequest(req, "DataTables")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var wrapper models.DataTablesResponse
 	if err := json.Unmarshal(responseBody, &wrapper); err != nil {
-		return fmt.Errorf("decode DataTables response: %w", err)
+		return nil, fmt.Errorf("decode DataTables response: %w", err)
+	}
+	return &wrapper, nil
+}
+
+// PostDataTables posts a form-encoded DataTables request and unmarshals its data array.
+func (c *Client) PostDataTables(ctx context.Context, path, body string, result any) error {
+	wrapper, err := c.PostDataTablesPage(ctx, path, body)
+	if err != nil {
+		return err
 	}
 	if len(wrapper.Data) == 0 || bytes.Equal(wrapper.Data, []byte("null")) {
 		return fmt.Errorf("decode DataTables response: missing data field")

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -27,13 +27,23 @@ type dataTableOptions struct {
 	filters                 map[string]string
 }
 
+// paginationPageSize is the number of records fetched per page when the user
+// requests all results (--length -1).
+const paginationPageSize = 1000
+
 // runDataTablesCommand is the shared handler for all DataTables-backed
 // commands. It creates the client, builds and posts the request, and
 // prints the result as JSON. The label is used in error messages.
+// When opts.length is negative, results are fetched in pages of
+// paginationPageSize until all records have been retrieved.
 func runDataTablesCommand[T any](ctx context.Context, path string, columns []string, opts dataTableOptions, label string) error {
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
+	}
+
+	if opts.length < 0 {
+		return runPaginatedCommand[T](ctx, vlClient, path, columns, opts, label)
 	}
 
 	request := newDataTablesRequest(columns, opts)
@@ -43,6 +53,45 @@ func runDataTablesCommand[T any](ctx context.Context, path string, columns []str
 		return fmt.Errorf("%s: %w", label, err)
 	}
 	return printJSON(ctx, result)
+}
+
+// runPaginatedCommand fetches all records by paginating through the DataTables
+// endpoint in pages of paginationPageSize. It accumulates results across pages
+// and stops when all filtered records have been retrieved or the server returns
+// an empty page.
+func runPaginatedCommand[T any](ctx context.Context, vlClient *client.Client, path string, columns []string, opts dataTableOptions, label string) error {
+	opts.length = paginationPageSize
+	all := make([]T, 0)
+
+	for {
+		request := newDataTablesRequest(columns, opts)
+		resp, err := vlClient.PostDataTablesPage(ctx, path, request.Encode())
+		if err != nil {
+			slog.Error("failed to "+label, "error", err)
+			return fmt.Errorf("%s: %w", label, err)
+		}
+
+		var page []T
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
+			break
+		}
+		if len(page) == 0 {
+			break
+		}
+
+		all = append(all, page...)
+
+		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
+			break
+		}
+		if len(page) < paginationPageSize {
+			break
+		}
+
+		opts.start += len(page)
+	}
+
+	return printJSON(ctx, all)
 }
 
 // newCommandClient centralizes authenticated client creation so command

--- a/internal/commands/run_helpers_test.go
+++ b/internal/commands/run_helpers_test.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -85,4 +87,118 @@ func TestRunDataTablesCommandServerError(t *testing.T) {
 		dataTableOptions{start: 0, length: 100, orderCol: 1, orderDir: "desc"},
 		"test query")
 	assertErrContains(t, err, "test query")
+}
+
+func TestPaginatedCommandSinglePage(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		fmt.Fprint(w, dataTablesJSONPage(`[{"Ticker":"AAPL"},{"Ticker":"MSFT"}]`, 2))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
+			datatables.TradeColumns,
+			dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+			"test paginated")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if requestCount != 1 {
+		t.Errorf("expected 1 request, got %d", requestCount)
+	}
+	if !strings.Contains(output, "AAPL") || !strings.Contains(output, "MSFT") {
+		t.Errorf("expected both tickers in output, got: %s", output)
+	}
+}
+
+func TestPaginatedCommandMultiPage(t *testing.T) {
+	totalRecords := paginationPageSize + 3
+	var requestCount int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		body, _ := io.ReadAll(r.Body)
+		params, _ := url.ParseQuery(string(body))
+		start := params.Get("start")
+
+		if start == "0" {
+			// First page: return exactly paginationPageSize items.
+			items := make([]string, paginationPageSize)
+			for i := range items {
+				items[i] = fmt.Sprintf(`{"Ticker":"P1_%d"}`, i)
+			}
+			fmt.Fprint(w, dataTablesJSONPage("["+strings.Join(items, ",")+"]", totalRecords))
+		} else {
+			// Second page: return remaining items.
+			fmt.Fprint(w, dataTablesJSONPage(
+				`[{"Ticker":"P2_0"},{"Ticker":"P2_1"},{"Ticker":"P2_2"}]`, totalRecords))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
+			datatables.TradeColumns,
+			dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+			"test paginated multi")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if requestCount != 2 {
+		t.Errorf("expected 2 requests, got %d", requestCount)
+	}
+	// Verify first page items are present.
+	if !strings.Contains(output, "P1_0") {
+		t.Errorf("expected first page items in output, got: %s", output[:min(200, len(output))])
+	}
+	// Verify second page items are present.
+	if !strings.Contains(output, "P2_2") {
+		t.Errorf("expected second page items in output, got: %s", output[max(0, len(output)-200):])
+	}
+}
+
+func TestPaginatedCommandEmptyResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSONPage(`[]`, 0))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
+			datatables.TradeColumns,
+			dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+			"test paginated empty")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Empty pagination should output an empty JSON array, not null.
+	trimmed := strings.TrimSpace(output)
+	if trimmed != "[]" {
+		t.Errorf("expected empty array [], got: %s", trimmed)
+	}
+}
+
+func TestPaginatedCommandServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
+		datatables.TradeColumns,
+		dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+		"test paginated error")
+	assertErrContains(t, err, "test paginated error")
 }

--- a/internal/commands/testhelpers_test.go
+++ b/internal/commands/testhelpers_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -49,6 +50,13 @@ func captureStdout(t *testing.T, fn func()) string {
 // dataTablesJSON wraps data in a valid DataTables response envelope.
 func dataTablesJSON(data string) string {
 	return `{"draw":1,"recordsTotal":1,"recordsFiltered":1,"data":` + data + `}`
+}
+
+// dataTablesJSONPage wraps data in a DataTables response with explicit
+// recordsFiltered count, used by pagination tests.
+func dataTablesJSONPage(data string, recordsFiltered int) string {
+	return fmt.Sprintf(`{"draw":1,"recordsTotal":%d,"recordsFiltered":%d,"data":%s}`,
+		recordsFiltered, recordsFiltered, data)
 }
 
 // addPrettyJSON returns a context with the pretty JSON flag set.


### PR DESCRIPTION
## Summary

- Fixes `trade list --length -1` returning empty results by paginating in chunks of 1000 instead of sending `length=-1` to the VolumeLeaders API (which silently returns nothing)
- Adds `PostDataTablesPage` to the client to expose the full DataTables response envelope (including `RecordsFiltered` for pagination bounds)
- Adds `runPaginatedCommand` in helpers.go that accumulates pages until all records are fetched

## Test plan

4 new tests covering single-page, multi-page, empty results, and server error propagation during pagination. All existing tests pass.

Closes #9