### PR TITLE
feat: add RelativeSize to trade list and preset-tickers subcommand

### DIFF
--- a/internal/commands/app_test.go
+++ b/internal/commands/app_test.go
@@ -50,7 +50,7 @@ func TestNewAppSubcommandCounts(t *testing.T) {
 	app := NewApp("0.0.0")
 
 	expected := map[string]int{
-		"trade":     8,
+		"trade":     9,
 		"volume":    3,
 		"chart":     4,
 		"market":    3,

--- a/internal/commands/presets.go
+++ b/internal/commands/presets.go
@@ -426,6 +426,70 @@ func watchlistConfigToFilters(cfg *models.WatchListConfig) map[string]string {
 	return filters
 }
 
+// newTradePresetTickersCommand returns the "trade preset-tickers" subcommand
+// that extracts ticker symbols from a named preset.
+func newTradePresetTickersCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "preset-tickers",
+		Usage:     "Extract ticker symbols from a preset",
+		UsageText: "volumeleaders-agent trade preset-tickers --preset NAME",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "preset",
+				Usage:    "Preset name (case-insensitive)",
+				Required: true,
+			},
+		},
+		Action: runTradePresetTickers,
+	}
+}
+
+func runTradePresetTickers(ctx context.Context, cmd *cli.Command) error {
+	p, err := findPreset(cmd.String("preset"))
+	if err != nil {
+		return err
+	}
+
+	info := models.PresetTickersInfo{
+		Preset: p.name,
+		Group:  p.group,
+	}
+
+	// Explicit ticker presets take precedence over sector filters if both are set.
+	switch {
+	case p.filters["Tickers"] != "":
+		info.Type = "tickers"
+		info.Tickers = splitTickers(p.filters["Tickers"])
+	case p.filters["SectorIndustry"] != "":
+		info.Type = "sector-filter"
+		info.SectorIndustry = p.filters["SectorIndustry"]
+	default:
+		info.Type = "unfiltered"
+	}
+
+	return printJSON(ctx, info)
+}
+
+// splitTickers parses a comma-separated ticker list defensively so preset
+// typos do not leak whitespace, empty symbols, or duplicate symbols to output.
+func splitTickers(tickers string) []string {
+	parts := strings.Split(tickers, ",")
+	result := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+
+	for _, part := range parts {
+		ticker := strings.TrimSpace(part)
+		if ticker == "" || seen[ticker] {
+			continue
+		}
+
+		seen[ticker] = true
+		result = append(result, ticker)
+	}
+
+	return result
+}
+
 // newTradePresetsCommand returns the "trade presets" subcommand that lists
 // all available built-in filter presets.
 func newTradePresetsCommand() *cli.Command {

--- a/internal/commands/presets_test.go
+++ b/internal/commands/presets_test.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/major/volumeleaders-agent/internal/models"
+	cli "github.com/urfave/cli/v3"
+)
+
+func TestRunTradePresetTickers(t *testing.T) {
+	originalPresets := tradePresets
+	t.Cleanup(func() { tradePresets = originalPresets })
+
+	tests := []struct {
+		name          string
+		presets       []tradePreset
+		presetArg     string
+		want          models.PresetTickersInfo
+		wantErrSubstr string
+	}{
+		{
+			name:          "missing preset returns error",
+			presets:       []tradePreset{},
+			presetArg:     "Missing",
+			wantErrSubstr: "preset \"Missing\" not found",
+		},
+		{
+			name:      "ticker preset returns normalized tickers",
+			presetArg: "Ticker Preset",
+			presets: []tradePreset{
+				{
+					name:  "Ticker Preset",
+					group: "Test Group",
+					filters: map[string]string{
+						"Tickers":        " AAPL, NVDA,,AAPL,MSFT ",
+						"SectorIndustry": "Technology",
+					},
+				},
+			},
+			want: models.PresetTickersInfo{
+				Preset:  "Ticker Preset",
+				Group:   "Test Group",
+				Type:    "tickers",
+				Tickers: []string{"AAPL", "NVDA", "MSFT"},
+			},
+		},
+		{
+			name:      "sector preset returns sector filter",
+			presetArg: "Sector Preset",
+			presets: []tradePreset{
+				{
+					name:  "Sector Preset",
+					group: "Test Group",
+					filters: map[string]string{
+						"SectorIndustry": "Healthcare",
+					},
+				},
+			},
+			want: models.PresetTickersInfo{
+				Preset:         "Sector Preset",
+				Group:          "Test Group",
+				Type:           "sector-filter",
+				SectorIndustry: "Healthcare",
+			},
+		},
+		{
+			name:      "unfiltered preset returns unfiltered type",
+			presetArg: "All Trades",
+			presets: []tradePreset{
+				{
+					name:    "All Trades",
+					group:   "Test Group",
+					filters: map[string]string{},
+				},
+			},
+			want: models.PresetTickersInfo{
+				Preset: "All Trades",
+				Group:  "Test Group",
+				Type:   "unfiltered",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tradePresets = tt.presets
+
+			root := &cli.Command{Commands: []*cli.Command{newTradePresetTickersCommand()}}
+			var runErr error
+			output := captureStdout(t, func() {
+				runErr = root.Run(context.Background(), []string{"app", "preset-tickers", "--preset", tt.presetArg})
+			})
+
+			assertErrContains(t, runErr, tt.wantErrSubstr)
+			if tt.wantErrSubstr != "" {
+				return
+			}
+
+			var got models.PresetTickersInfo
+			if err := json.Unmarshal([]byte(output), &got); err != nil {
+				t.Fatalf("unmarshal preset tickers output: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("preset tickers mismatch\nexpected: %#v\ngot:      %#v", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -41,6 +41,7 @@ func NewTradeCommand() *cli.Command {
 		Commands: []*cli.Command{
 			newTradeListCommand(),
 			newTradePresetsCommand(),
+			newTradePresetTickersCommand(),
 			newTradeClustersCommand(),
 			newTradeClusterBombsCommand(),
 			newTradeAlertsCommand(),

--- a/internal/datatables/datatables.go
+++ b/internal/datatables/datatables.go
@@ -12,8 +12,8 @@ import (
 var TradeColumns = []string{
 	"FullTimeString24", "FullTimeString24", "Ticker", "Current", "Trade",
 	"Sector", "Industry", "Volume", "Dollars", "DollarsMultiplier",
-	"CumulativeDistribution", "TradeRank", "LastComparibleTradeDate",
-	"LastComparibleTradeDate",
+	"CumulativeDistribution", "TradeRank", "RelativeSize",
+	"LastComparibleTradeDate", "LastComparibleTradeDate",
 }
 
 // TradeClusterColumns contains the DataTables column names used by the trade clusters endpoint.

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -6,3 +6,15 @@ type PresetInfo struct {
 	Group   string            `json:"Group"`
 	Filters map[string]string `json:"Filters"`
 }
+
+// PresetTickersInfo describes the ticker symbols associated with a preset.
+// Presets that use explicit ticker lists have Type "tickers" with a populated
+// Tickers slice. Presets that filter by sector have Type "sector-filter" with
+// a SectorIndustry value. Presets with neither have Type "unfiltered".
+type PresetTickersInfo struct {
+	Preset         string   `json:"Preset"`
+	Group          string   `json:"Group"`
+	Type           string   `json:"Type"`
+	Tickers        []string `json:"Tickers,omitempty"`
+	SectorIndustry string   `json:"SectorIndustry,omitempty"`
+}

--- a/internal/models/trade.go
+++ b/internal/models/trade.go
@@ -129,6 +129,7 @@ type Trade struct {
 	Volume                        int        `json:"Volume"`
 	AverageDailyVolume            int        `json:"AverageDailyVolume"`
 	PercentDailyVolume            float64    `json:"PercentDailyVolume"`
+	RelativeSize                  float64    `json:"RelativeSize"`
 	LastComparibleTradeDate       AspNetDate `json:"LastComparibleTradeDate"`
 	IPODate                       AspNetDate `json:"IPODate"`
 	OffsettingTradeDate           AspNetDate `json:"OffsettingTradeDate"`

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -1,6 +1,6 @@
 # trade
 
-Institutional trade discovery. 8 subcommands. See SKILL.md for shared flag defaults and metrics glossary.
+Institutional trade discovery. 9 subcommands. See SKILL.md for shared flag defaults and metrics glossary.
 
 ## trade presets
 
@@ -12,6 +12,27 @@ Groups: "Common" (general-purpose filters), "Disproportionately Large" (>=5x avg
 volumeleaders-agent trade presets
 volumeleaders-agent trade presets --pretty | jq '.[].Name'
 ```
+
+## trade preset-tickers
+
+Extract ticker symbols from a named preset. No authentication required. Returns a JSON object with the preset name, group, type, and either a ticker list or sector filter value.
+
+Required: `--preset NAME` (case-insensitive)
+
+Types: `"tickers"` (explicit ticker list), `"sector-filter"` (SectorIndustry-based), `"unfiltered"` (no ticker/sector restriction).
+
+```bash
+volumeleaders-agent trade preset-tickers --preset "Megacaps"
+# {"Preset":"Megacaps","Group":"Disproportionately Large","Type":"tickers","Tickers":["AAPL","AMZN","META","GOOG","GOOGL","MSFT","NFLX","NVDA","TSLA"]}
+
+volumeleaders-agent trade preset-tickers --preset "Bear Leverage"
+# {"Preset":"Bear Leverage","Group":"Disproportionately Large","Type":"sector-filter","SectorIndustry":"X Bear"}
+
+volumeleaders-agent trade preset-tickers --preset "All Trades"
+# {"Preset":"All Trades","Group":"Common","Type":"unfiltered"}
+```
+
+Output fields: `Preset`, `Group`, `Type`, `Tickers` (trimmed, deduplicated, omitted when empty), `SectorIndustry` (omitted when empty). If a preset defines both `Tickers` and `SectorIndustry`, ticker output takes precedence.
 
 ## trade list
 
@@ -36,7 +57,7 @@ volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-
 volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars,DollarsMultiplier,DarkPool,CumulativeDistribution
 ```
 
-Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`
+Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RelativeSize`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`
 
 ## trade clusters
 


### PR DESCRIPTION
## Summary

- Include `RelativeSize` field in trade list output by adding it to the `Trade` model and `TradeColumns` DataTables definition (closes #16)
- Add `trade preset-tickers` subcommand to extract ticker symbols from named presets without running a query, returning preset type (tickers/sector-filter/unfiltered) with associated data (closes #14)