### PR TITLE
feat: add trade list field selection

### DIFF
--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -25,6 +27,7 @@ type dataTableOptions struct {
 	start, length, orderCol int
 	orderDir                string
 	filters                 map[string]string
+	fields                  []string
 }
 
 // paginationPageSize is the number of records fetched per page when the user
@@ -52,7 +55,7 @@ func runDataTablesCommand[T any](ctx context.Context, path string, columns []str
 		slog.Error("failed to "+label, "error", err)
 		return fmt.Errorf("%s: %w", label, err)
 	}
-	return printJSON(ctx, result)
+	return printDataTablesResult(ctx, result, opts.fields)
 }
 
 // runPaginatedCommand fetches all records by paginating through the DataTables
@@ -91,7 +94,93 @@ func runPaginatedCommand[T any](ctx context.Context, vlClient *client.Client, pa
 		opts.start += len(page)
 	}
 
-	return printJSON(ctx, all)
+	return printDataTablesResult(ctx, all, opts.fields)
+}
+
+func printDataTablesResult[T any](ctx context.Context, result []T, fields []string) error {
+	if len(fields) == 0 {
+		return printJSON(ctx, result)
+	}
+
+	selected, err := selectJSONFields(result, fields)
+	if err != nil {
+		return err
+	}
+	return printJSON(ctx, selected)
+}
+
+func selectJSONFields[T any](items []T, fields []string) ([]map[string]json.RawMessage, error) {
+	selected := make([]map[string]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		data, err := json.Marshal(item)
+		if err != nil {
+			return nil, fmt.Errorf("marshal item for field selection: %w", err)
+		}
+
+		var allFields map[string]json.RawMessage
+		if err := json.Unmarshal(data, &allFields); err != nil {
+			return nil, fmt.Errorf("decode item for field selection: %w", err)
+		}
+
+		row := make(map[string]json.RawMessage, len(fields))
+		for _, field := range fields {
+			row[field] = allFields[field]
+		}
+		selected = append(selected, row)
+	}
+	return selected, nil
+}
+
+func parseJSONFieldList[T any](value string) ([]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	validFields := jsonFieldNames[T]()
+	valid := make(map[string]struct{}, len(validFields))
+	for _, field := range validFields {
+		valid[field] = struct{}{}
+	}
+
+	fields := make([]string, 0, strings.Count(value, ",")+1)
+	seen := make(map[string]struct{})
+	for field := range strings.SplitSeq(value, ",") {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if _, ok := valid[field]; !ok {
+			return nil, fmt.Errorf("invalid field %q; valid fields: %s", field, strings.Join(validFields, ","))
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		fields = append(fields, field)
+	}
+	return fields, nil
+}
+
+func jsonFieldNames[T any]() []string {
+	var zero T
+	typeOf := reflect.TypeOf(zero)
+	for typeOf.Kind() == reflect.Pointer {
+		typeOf = typeOf.Elem()
+	}
+
+	fields := make([]string, 0, typeOf.NumField())
+	for i := range typeOf.NumField() {
+		field := typeOf.Field(i)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		switch name {
+		case "", "-":
+			continue
+		default:
+			fields = append(fields, name)
+		}
+	}
+	slices.Sort(fields)
+	return fields
 }
 
 // newCommandClient centralizes authenticated client creation so command

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -81,6 +82,59 @@ func TestTradeRunFunctions(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestTradeListFieldsFiltersOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"SPY","Dollars":26025000,"Volume":50000}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-01-01",
+			"--end-date", "2025-01-31",
+			"--fields", "Ticker,Dollars",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one row, got %d", len(got))
+	}
+	if _, ok := got[0]["Ticker"]; !ok {
+		t.Fatal("expected Ticker field")
+	}
+	if _, ok := got[0]["Dollars"]; !ok {
+		t.Fatal("expected Dollars field")
+	}
+	if _, ok := got[0]["Volume"]; ok {
+		t.Fatal("did not expect Volume field")
+	}
+}
+
+func TestTradeListFieldsRejectsInvalidField(t *testing.T) {
+	ctx := contextWithTestClient("http://127.0.0.1")
+	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "list",
+		"--start-date", "2025-01-01",
+		"--end-date", "2025-01-31",
+		"--fields", "Ticker,NotAField",
+	})
+	assertErrContains(t, err, "invalid field \"NotAField\"")
+	assertErrContains(t, err, "Ticker")
 }
 
 func TestTradeListPresetIncludesDefaults(t *testing.T) {

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -224,7 +225,7 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	watchlistName := cmd.String("watchlist")
 	fields, err := parseJSONFieldList[models.Trade](cmd.String("fields"))
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing fields flag: %w", err)
 	}
 
 	// Build the full filter map from CLI flags (includes defaults for unset

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -12,16 +12,15 @@ import (
 // --- Option structs ---
 
 type tradesOptions struct {
-	tickers, startDate, endDate, sector           string
-	minVolume, maxVolume                          int
-	conditions, vcd, securityType, relativeSize   int
-	darkPools, sweeps, latePrints, sigPrints      int
+	tickers, startDate, endDate, sector            string
+	minVolume, maxVolume                           int
+	conditions, vcd, securityType, relativeSize    int
+	darkPools, sweeps, latePrints, sigPrints       int
 	evenShared, tradeRank, rankSnapshot, marketCap int
-	premarket, rth, ah, opening, closing          int
-	phantom, offsetting                           int
-	minPrice, maxPrice, minDollars, maxDollars    float64
+	premarket, rth, ah, opening, closing           int
+	phantom, offsetting                            int
+	minPrice, maxPrice, minDollars, maxDollars     float64
 }
-
 
 type tradeLevelOptions struct {
 	ticker, startDate, endDate string
@@ -32,7 +31,6 @@ type tradeLevelOptions struct {
 	minPrice, maxPrice         float64
 	minDollars, maxDollars     float64
 }
-
 
 // NewTradeCommand returns the "trade" command group with all subcommands.
 func NewTradeCommand() *cli.Command {
@@ -92,6 +90,7 @@ volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-
 				&cli.StringFlag{Name: "sector", Usage: "Sector/Industry filter"},
 				&cli.StringFlag{Name: "preset", Usage: "Apply a built-in filter preset (see: trade presets)"},
 				&cli.StringFlag{Name: "watchlist", Usage: "Apply filters from a saved watchlist by name"},
+				&cli.StringFlag{Name: "fields", Usage: "Comma-separated trade fields to include in output"},
 			},
 			paginationFlags(100, 1, "desc"),
 		),
@@ -223,6 +222,10 @@ volumeleaders-agent trade level-touches --tickers NVDA,AMD --trade-level-rank 5`
 func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	presetName := cmd.String("preset")
 	watchlistName := cmd.String("watchlist")
+	fields, err := parseJSONFieldList[models.Trade](cmd.String("fields"))
+	if err != nil {
+		return err
+	}
 
 	// Build the full filter map from CLI flags (includes defaults for unset
 	// flags). Every key the API requires is present after this call.
@@ -290,7 +293,7 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	filters["EndDate"] = cmd.String("end-date")
 
 	return runDataTablesCommand[models.Trade](ctx, "/Trades/GetTrades", datatables.TradeColumns,
-		dataTableOptions{start: cmd.Int("start"), length: cmd.Int("length"), orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"), filters: filters},
+		dataTableOptions{start: cmd.Int("start"), length: cmd.Int("length"), orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"), filters: filters, fields: fields},
 		"query trades")
 }
 
@@ -454,5 +457,3 @@ func buildTradeLevelFilters(opts *tradeLevelOptions) map[string]string {
 		"TradeLevelCount": intStr(opts.tradeLevelCount),
 	}
 }
-
-

--- a/internal/commands/trade_test.go
+++ b/internal/commands/trade_test.go
@@ -2,8 +2,62 @@ package commands
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/major/volumeleaders-agent/internal/models"
 )
+
+func TestParseJSONFieldList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:  "empty list returns nil",
+			value: "",
+		},
+		{
+			name:  "valid fields keep requested order",
+			value: "Date,Ticker,Dollars",
+			want:  []string{"Date", "Ticker", "Dollars"},
+		},
+		{
+			name:  "spaces and duplicates are normalized",
+			value: " Ticker, Dollars, Ticker ",
+			want:  []string{"Ticker", "Dollars"},
+		},
+		{
+			name:    "invalid field returns valid names",
+			value:   "Ticker,NotAField",
+			wantErr: "invalid field \"NotAField\"; valid fields:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseJSONFieldList[models.Trade](tt.value)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("fields mismatch\nexpected: %#v\ngot:      %#v", tt.want, got)
+			}
+		})
+	}
+}
 
 func TestBuildTradeFiltersPreservesAPIKeys(t *testing.T) {
 	t.Parallel()

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -18,11 +18,13 @@ volumeleaders-agent trade presets --pretty | jq '.[].Name'
 Query individual institutional block trades. The primary trade discovery command.
 
 Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
+Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
 
 **`--preset NAME`**: Apply a built-in filter preset by name (case-insensitive). The preset sets baseline filters; any explicitly-provided CLI flags override the preset values. Use `trade presets` to list available names.
 
 **`--watchlist NAME`**: Apply filters from a saved user watchlist by name (case-insensitive). Fetches the watchlist config at runtime and converts its settings to trade filters. Use `watchlist configs` to list available names.
+
+**`--fields FIELD1,FIELD2`**: Return only the listed trade fields in each JSON object. Field names are case-sensitive and must match the output field names below. Invalid names fail before querying the API and include the valid field list in the error.
 
 Both flags can be combined: watchlist filters merge on top of preset filters, and explicit CLI flags override both.
 
@@ -31,9 +33,10 @@ volumeleaders-agent trade list --tickers AAPL --start-date 2025-04-16 --end-date
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --preset "Megacaps" --start-date 2025-04-01 --end-date 2025-04-24 --trade-rank 10
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
+volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars,DollarsMultiplier,DarkPool,CumulativeDistribution
 ```
 
-Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `Price`, `Bid`, `Ask`, `Dollars`, `DollarsMultiplier`, `Volume`, `AverageDailyVolume`, `PercentDailyVolume`, `TradeCount`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `DarkPool`, `Sweep`, `LatePrint`, `SignaturePrint`, `OpeningTrade`, `ClosingTrade`, `PhantomPrint`, `InsideBar`, `DoubleInsideBar`, `NewPosition`, `Cancelled`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `TotalDollars`, `TotalDollarsRank`, `TotalVolume`, `ClosePrice`, `RSIHour`, `RSIDay`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FrequencyLast1CY`, `LastComparibleTradeDate`, `IPODate`, `TotalRows`
+Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`
 
 ## trade clusters
 


### PR DESCRIPTION
## Summary
- Add `trade list --fields` to filter JSON output to requested trade fields.
- Validate field names before querying the API and report the valid field list on errors.
- Update trade skill docs and tests for filtered output and invalid field handling.

## Validation
- `go test -v ./internal/commands -run 'Test(ParseJSONFieldList|TradeListFields)'`
- `make test`
- `make lint`
- `make build`
- Five-agent post-implementation review passed
- CodeRabbit reported one minor finding, fixed in `f887641`; rerun was blocked by service rate limit

Closes #13