### PR TITLE
feat: add csv and tsv output formats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ make install    # Install to $GOPATH/bin
 
 ## Conventions
 
-- All commands output compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr via `slog`.
+- All commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Errors go to stderr via `slog`.
 - Dates use `YYYY-MM-DD` format on the CLI, converted internally as needed.
 - Boolean/toggle filters use integers: `-1` = all/unfiltered, `0` = exclude, `1` = include/only.
 - Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results.

--- a/internal/commands/alert.go
+++ b/internal/commands/alert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -17,18 +18,19 @@ func NewAlertCommand() *cli.Command {
 		Name:  "alert",
 		Usage: "Alert configuration commands",
 		Commands: []*cli.Command{
-		{
-			Name:      "configs",
-			Usage:     "List saved alert configurations",
-			UsageText: "volumeleaders-agent alert configs",
-				Action: func(ctx context.Context, _ *cli.Command) error {
-					return runAlertConfigs(ctx)
+			{
+				Name:      "configs",
+				Usage:     "List saved alert configurations",
+				UsageText: "volumeleaders-agent alert configs",
+				Flags:     outputFormatFlags(),
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return runAlertConfigs(ctx, cmd.String("format"))
 				},
 			},
-		{
-			Name:      "delete",
-			Usage:     "Delete an alert configuration",
-			UsageText: "volumeleaders-agent alert delete --key 42",
+			{
+				Name:      "delete",
+				Usage:     "Delete an alert configuration",
+				UsageText: "volumeleaders-agent alert delete --key 42",
 				Flags: []cli.Flag{
 					&cli.IntFlag{Name: "key", Required: true, Usage: "Alert config key to delete"},
 				},
@@ -100,14 +102,17 @@ volumeleaders-agent alert create --name "Dark pool sweeps" --sweep --dark-pool -
 }
 
 func newAlertEditCommand() *cli.Command {
-	flags := append([]cli.Flag{
-		&cli.IntFlag{Name: "key", Required: true, Usage: "Alert config key to edit"},
-	}, alertConfigFlags()...)
+	flags := slices.Concat(
+		[]cli.Flag{
+			&cli.IntFlag{Name: "key", Required: true, Usage: "Alert config key to edit"},
+		},
+		alertConfigFlags(),
+	)
 	return &cli.Command{
 		Name:      "edit",
 		Usage:     "Edit an existing alert configuration",
 		UsageText: "volumeleaders-agent alert edit --key 42 --name \"Updated alert\" --trade-rank-lte 3",
-		Flags: flags,
+		Flags:     flags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return runAlertCreateEdit(ctx, cmd, cmd.Int("key"))
 		},
@@ -160,7 +165,12 @@ func buildAlertConfigFields(cmd *cli.Command, key int) map[string]string {
 
 // --- Action handlers ---
 
-func runAlertConfigs(ctx context.Context) error {
+func runAlertConfigs(ctx context.Context, formatValue string) error {
+	format, err := parseOutputFormat(formatValue)
+	if err != nil {
+		return err
+	}
+
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
@@ -173,7 +183,7 @@ func runAlertConfigs(ctx context.Context) error {
 		return fmt.Errorf("query alert configs: %w", err)
 	}
 
-	return printJSON(ctx, configs)
+	return printDataTablesResult(ctx, configs, nil, format)
 }
 
 func runAlertDelete(ctx context.Context, key int) error {

--- a/internal/commands/alert_test.go
+++ b/internal/commands/alert_test.go
@@ -22,7 +22,7 @@ func TestRunAlertConfigs(t *testing.T) {
 
 	ctx := contextWithTestClient(server.URL)
 	captureStdout(t, func() {
-		if err := runAlertConfigs(ctx); err != nil {
+		if err := runAlertConfigs(ctx, "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -35,7 +35,7 @@ func TestRunAlertConfigsServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	err := runAlertConfigs(ctx)
+	err := runAlertConfigs(ctx, "json")
 	assertErrContains(t, err, "query alert configs")
 }
 

--- a/internal/commands/chart.go
+++ b/internal/commands/chart.go
@@ -15,7 +15,7 @@ import (
 // --- Option structs ---
 
 type priceDataOptions struct {
-	ticker                         string
+	ticker, format                 string
 	startDate, endDate             string
 	volumeProfile, levels          int
 	minVolume, maxVolume           int
@@ -32,8 +32,8 @@ type priceDataOptions struct {
 }
 
 type chartLevelsOptions struct {
-	ticker, startDate, endDate string
-	levels                     int
+	ticker, startDate, endDate, format string
+	levels                             int
 }
 
 // NewChartCommand returns the "chart" command group with all subcommands.
@@ -83,10 +83,12 @@ volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end
 				&cli.IntFlag{Name: "include-phantom", Value: 1, Usage: "Include phantom prints (0/1)"},
 				&cli.IntFlag{Name: "include-offsetting", Value: 1, Usage: "Include offsetting trades (0/1)"},
 			},
+			outputFormatFlags(),
 		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			opts := priceDataOptions{
 				ticker:            cmd.String("ticker"),
+				format:            cmd.String("format"),
 				startDate:         cmd.String("start-date"),
 				endDate:           cmd.String("end-date"),
 				volumeProfile:     cmd.Int("volume-profile"),
@@ -145,6 +147,7 @@ volumeleaders-agent chart levels --ticker TSLA --start-date 2025-01-01 --levels 
 				&cli.StringFlag{Name: "ticker", Required: true, Usage: "Ticker symbol"},
 				&cli.IntFlag{Name: "levels", Value: 5, Usage: "Number of trade levels"},
 			},
+			outputFormatFlags(),
 		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			opts := chartLevelsOptions{
@@ -152,6 +155,7 @@ volumeleaders-agent chart levels --ticker TSLA --start-date 2025-01-01 --levels 
 				startDate: cmd.String("start-date"),
 				endDate:   cmd.String("end-date"),
 				levels:    cmd.Int("levels"),
+				format:    cmd.String("format"),
 			}
 			return runChartLevels(ctx, opts)
 		},
@@ -175,6 +179,11 @@ func newCompanyCommand() *cli.Command {
 // --- Action handlers ---
 
 func runPriceData(ctx context.Context, opts *priceDataOptions) error {
+	format, err := parseOutputFormat(opts.format)
+	if err != nil {
+		return err
+	}
+
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
@@ -224,7 +233,7 @@ func runPriceData(ctx context.Context, opts *priceDataOptions) error {
 		}
 	}
 
-	return printJSON(ctx, bars)
+	return printDataTablesResult(ctx, bars, nil, format)
 }
 
 func runChartSnapshot(ctx context.Context, ticker, dateKey string) error {
@@ -261,6 +270,7 @@ func runChartLevels(ctx context.Context, opts chartLevelsOptions) error {
 				"Levels":    intStr(opts.levels),
 			},
 		},
+		opts.format,
 		"query chart levels")
 }
 

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -30,6 +31,14 @@ type dataTableOptions struct {
 	fields                  []string
 }
 
+type outputFormat string
+
+const (
+	outputFormatJSON outputFormat = "json"
+	outputFormatCSV  outputFormat = "csv"
+	outputFormatTSV  outputFormat = "tsv"
+)
+
 // paginationPageSize is the number of records fetched per page when the user
 // requests all results (--length -1).
 const paginationPageSize = 1000
@@ -39,14 +48,19 @@ const paginationPageSize = 1000
 // prints the result as JSON. The label is used in error messages.
 // When opts.length is negative, results are fetched in pages of
 // paginationPageSize until all records have been retrieved.
-func runDataTablesCommand[T any](ctx context.Context, path string, columns []string, opts dataTableOptions, label string) error {
+func runDataTablesCommand[T any](ctx context.Context, path string, columns []string, opts dataTableOptions, formatValue, label string) error {
+	format, err := parseOutputFormat(formatValue)
+	if err != nil {
+		return err
+	}
+
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
 	}
 
 	if opts.length < 0 {
-		return runPaginatedCommand[T](ctx, vlClient, path, columns, opts, label)
+		return runPaginatedCommand[T](ctx, vlClient, path, columns, opts, format, label)
 	}
 
 	request := newDataTablesRequest(columns, opts)
@@ -55,14 +69,14 @@ func runDataTablesCommand[T any](ctx context.Context, path string, columns []str
 		slog.Error("failed to "+label, "error", err)
 		return fmt.Errorf("%s: %w", label, err)
 	}
-	return printDataTablesResult(ctx, result, opts.fields)
+	return printDataTablesResult(ctx, result, opts.fields, format)
 }
 
 // runPaginatedCommand fetches all records by paginating through the DataTables
 // endpoint in pages of paginationPageSize. It accumulates results across pages
 // and stops when all filtered records have been retrieved or the server returns
 // an empty page.
-func runPaginatedCommand[T any](ctx context.Context, vlClient *client.Client, path string, columns []string, opts dataTableOptions, label string) error {
+func runPaginatedCommand[T any](ctx context.Context, vlClient *client.Client, path string, columns []string, opts dataTableOptions, format outputFormat, label string) error {
 	opts.length = paginationPageSize
 	all := make([]T, 0)
 
@@ -94,19 +108,34 @@ func runPaginatedCommand[T any](ctx context.Context, vlClient *client.Client, pa
 		opts.start += len(page)
 	}
 
-	return printDataTablesResult(ctx, all, opts.fields)
+	return printDataTablesResult(ctx, all, opts.fields, format)
 }
 
-func printDataTablesResult[T any](ctx context.Context, result []T, fields []string) error {
-	if len(fields) == 0 {
+func printDataTablesResult[T any](ctx context.Context, result []T, fields []string, format outputFormat) error {
+	if format == outputFormatJSON && len(fields) == 0 {
 		return printJSON(ctx, result)
 	}
 
-	selected, err := selectJSONFields(result, fields)
+	selectedFields := fields
+	if len(selectedFields) == 0 {
+		selectedFields = jsonFieldNamesInOrder[T]()
+	}
+
+	selected, err := selectJSONFields(result, selectedFields)
 	if err != nil {
 		return err
 	}
-	return printJSON(ctx, selected)
+
+	switch format {
+	case outputFormatJSON:
+		return printJSON(ctx, selected)
+	case outputFormatCSV:
+		return printDelimited(selected, selectedFields, ',')
+	case outputFormatTSV:
+		return printDelimited(selected, selectedFields, '\t')
+	default:
+		return fmt.Errorf("unsupported output format %q", format)
+	}
 }
 
 func selectJSONFields[T any](items []T, fields []string) ([]map[string]json.RawMessage, error) {
@@ -162,6 +191,12 @@ func parseJSONFieldList[T any](value string) ([]string, error) {
 }
 
 func jsonFieldNames[T any]() []string {
+	fields := jsonFieldNamesInOrder[T]()
+	slices.Sort(fields)
+	return fields
+}
+
+func jsonFieldNamesInOrder[T any]() []string {
 	var zero T
 	typeOf := reflect.TypeOf(zero)
 	for typeOf.Kind() == reflect.Pointer {
@@ -179,8 +214,91 @@ func jsonFieldNames[T any]() []string {
 			fields = append(fields, name)
 		}
 	}
-	slices.Sort(fields)
 	return fields
+}
+
+func parseOutputFormat(value string) (outputFormat, error) {
+	format := outputFormat(strings.ToLower(strings.TrimSpace(value)))
+	if format == "" {
+		return outputFormatJSON, nil
+	}
+
+	switch format {
+	case outputFormatJSON, outputFormatCSV, outputFormatTSV:
+		return format, nil
+	default:
+		return "", fmt.Errorf("invalid format %q; valid formats: json,csv,tsv", value)
+	}
+}
+
+func printDelimited(rows []map[string]json.RawMessage, fields []string, comma rune) error {
+	writer := csv.NewWriter(os.Stdout)
+	writer.Comma = comma
+
+	if err := writer.Write(fields); err != nil {
+		return fmt.Errorf("write delimited header: %w", err)
+	}
+	for _, row := range rows {
+		record, err := delimitedRecord(row, fields)
+		if err != nil {
+			return err
+		}
+		if err := writer.Write(record); err != nil {
+			return fmt.Errorf("write delimited row: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("flush delimited output: %w", err)
+	}
+	return nil
+}
+
+func delimitedRecord(row map[string]json.RawMessage, fields []string) ([]string, error) {
+	record := make([]string, 0, len(fields))
+	for _, field := range fields {
+		value, err := delimitedValue(row[field])
+		if err != nil {
+			return nil, fmt.Errorf("format field %q: %w", field, err)
+		}
+		record = append(record, value)
+	}
+	return record, nil
+}
+
+func delimitedValue(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	if isJSONNumber(raw) {
+		return string(raw), nil
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text, nil
+	}
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", fmt.Errorf("decode JSON value: %w", err)
+	}
+	switch typed := value.(type) {
+	case bool:
+		return strconv.FormatBool(typed), nil
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64), nil
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return "", fmt.Errorf("marshal complex JSON value: %w", err)
+		}
+		return string(data), nil
+	}
+}
+
+func isJSONNumber(raw json.RawMessage) bool {
+	return raw[0] == '-' || raw[0] >= '0' && raw[0] <= '9'
 }
 
 // newCommandClient centralizes authenticated client creation so command
@@ -255,6 +373,13 @@ func paginationFlags(length, orderCol int, orderDir string) []cli.Flag {
 		&cli.IntFlag{Name: "length", Value: length, Usage: "Number of results"},
 		&cli.IntFlag{Name: "order-col", Value: orderCol, Usage: "Order column index"},
 		&cli.StringFlag{Name: "order-dir", Value: orderDir, Usage: "Order direction"},
+	}
+}
+
+// outputFormatFlags returns the standard tabular output format flag.
+func outputFormatFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{Name: "format", Value: string(outputFormatJSON), Usage: "Output format: json, csv, or tsv"},
 	}
 }
 

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
+	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -331,6 +332,106 @@ func TestPaginationFlags(t *testing.T) {
 	assertFlagName(t, flags[1], "length")
 	assertFlagName(t, flags[2], "order-col")
 	assertFlagName(t, flags[3], "order-dir")
+}
+
+func TestOutputFormatFlags(t *testing.T) {
+	t.Parallel()
+
+	flags := outputFormatFlags()
+	if len(flags) != 1 {
+		t.Fatalf("expected 1 flag, got %d", len(flags))
+	}
+	assertFlagName(t, flags[0], "format")
+}
+
+func TestParseOutputFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    outputFormat
+		expectError bool
+	}{
+		{name: "empty defaults to json", input: "", expected: outputFormatJSON},
+		{name: "json", input: "json", expected: outputFormatJSON},
+		{name: "csv", input: "csv", expected: outputFormatCSV},
+		{name: "tsv with whitespace and case", input: " TSV ", expected: outputFormatTSV},
+		{name: "invalid", input: "table", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseOutputFormat(tt.input)
+			if tt.expectError {
+				assertErrContains(t, err, "valid formats: json,csv,tsv")
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("parseOutputFormat(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPrintDataTablesResultDelimited(t *testing.T) {
+	// Not parallel: captures os.Stdout.
+	industry := "Software, Infrastructure"
+	rows := []models.Trade{
+		{
+			Ticker:   "AAPL",
+			Name:     "Apple, Inc.",
+			Industry: &industry,
+			DarkPool: true,
+			Dollars:  123.45,
+			TradeID:  9007199254740993,
+		},
+		{
+			Ticker:   "MSFT",
+			Name:     "Microsoft Corp",
+			DarkPool: false,
+			Dollars:  0,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		format   outputFormat
+		fields   []string
+		expected string
+	}{
+		{
+			name:     "csv quotes strings and leaves nil empty",
+			format:   outputFormatCSV,
+			fields:   []string{"Ticker", "Name", "Industry", "DarkPool", "Dollars", "TradeID"},
+			expected: "Ticker,Name,Industry,DarkPool,Dollars,TradeID\nAAPL,\"Apple, Inc.\",\"Software, Infrastructure\",true,123.45,9007199254740993\nMSFT,Microsoft Corp,,false,0,0\n",
+		},
+		{
+			name:     "tsv uses tabs",
+			format:   outputFormatTSV,
+			fields:   []string{"Ticker", "DarkPool"},
+			expected: "Ticker\tDarkPool\nAAPL\ttrue\nMSFT\tfalse\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := captureStdout(t, func() {
+				err := printDataTablesResult(context.Background(), rows, tt.fields, tt.format)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if output != tt.expected {
+				t.Errorf("delimited output:\nexpected: %q\ngot:      %q", tt.expected, output)
+			}
+		})
+	}
 }
 
 func TestRequireStringFlag(t *testing.T) {

--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
@@ -41,9 +42,9 @@ func newEarningsCommand() *cli.Command {
 		Name:      "earnings",
 		Usage:     "Query earnings calendar within a date range",
 		UsageText: "volumeleaders-agent market earnings --start-date 2025-01-20 --end-date 2025-01-24",
-		Flags: dateRangeFlags(),
+		Flags:     slices.Concat(dateRangeFlags(), outputFormatFlags()),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return runEarnings(ctx, cmd.String("start-date"), cmd.String("end-date"))
+			return runEarnings(ctx, cmd.String("start-date"), cmd.String("end-date"), cmd.String("format"))
 		},
 	}
 }
@@ -80,7 +81,7 @@ func runSnapshots(ctx context.Context) error {
 	return printJSON(ctx, snapshots)
 }
 
-func runEarnings(ctx context.Context, startDate, endDate string) error {
+func runEarnings(ctx context.Context, startDate, endDate, format string) error {
 	return runDataTablesCommand[models.Earnings](ctx, "/Earnings/GetEarnings", datatables.EarningsColumns,
 		dataTableOptions{
 			start:    0,
@@ -92,6 +93,7 @@ func runEarnings(ctx context.Context, startDate, endDate string) error {
 				"EndDate":   endDate,
 			},
 		},
+		format,
 		"query earnings")
 }
 

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -55,7 +55,7 @@ func TestRunEarnings(t *testing.T) {
 
 	ctx := contextWithTestClient(server.URL)
 	captureStdout(t, func() {
-		if err := runEarnings(ctx, "2025-01-20", "2025-01-24"); err != nil {
+		if err := runEarnings(ctx, "2025-01-20", "2025-01-24", "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -68,7 +68,7 @@ func TestRunEarningsServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	err := runEarnings(ctx, "2025-01-20", "2025-01-24")
+	err := runEarnings(ctx, "2025-01-20", "2025-01-24", "json")
 	assertErrContains(t, err, "query earnings")
 }
 

--- a/internal/commands/presets.go
+++ b/internal/commands/presets.go
@@ -497,11 +497,17 @@ func newTradePresetsCommand() *cli.Command {
 		Name:      "presets",
 		Usage:     "List available trade filter presets",
 		UsageText: "volumeleaders-agent trade presets",
+		Flags:     outputFormatFlags(),
 		Action:    runTradePresets,
 	}
 }
 
-func runTradePresets(ctx context.Context, _ *cli.Command) error {
+func runTradePresets(ctx context.Context, cmd *cli.Command) error {
+	format, err := parseOutputFormat(cmd.String("format"))
+	if err != nil {
+		return err
+	}
+
 	presets := make([]models.PresetInfo, len(tradePresets))
 	for i, p := range tradePresets {
 		presets[i] = models.PresetInfo{
@@ -510,5 +516,5 @@ func runTradePresets(ctx context.Context, _ *cli.Command) error {
 			Filters: p.filters,
 		}
 	}
-	return printJSON(ctx, presets)
+	return printDataTablesResult(ctx, presets, nil, format)
 }

--- a/internal/commands/run_helpers_test.go
+++ b/internal/commands/run_helpers_test.go
@@ -42,6 +42,7 @@ func TestRunDataTablesCommand(t *testing.T) {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
 			dataTableOptions{start: 0, length: 100, orderCol: 1, orderDir: "desc"},
+			"",
 			"test query")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -64,6 +65,7 @@ func TestRunDataTablesCommandPrettyJSON(t *testing.T) {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
 			dataTableOptions{start: 0, length: 100, orderCol: 1, orderDir: "desc"},
+			"",
 			"test query")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -85,8 +87,29 @@ func TestRunDataTablesCommandServerError(t *testing.T) {
 	err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 		datatables.TradeColumns,
 		dataTableOptions{start: 0, length: 100, orderCol: 1, orderDir: "desc"},
+		"",
 		"test query")
 	assertErrContains(t, err, "test query")
+}
+
+func TestRunDataTablesCommandInvalidFormatDoesNotQueryAPI(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
+		datatables.TradeColumns,
+		dataTableOptions{start: 0, length: 100, orderCol: 1, orderDir: "desc"},
+		"table",
+		"test query")
+	assertErrContains(t, err, "valid formats: json,csv,tsv")
+	if requestCount != 0 {
+		t.Errorf("expected invalid format to fail before API query, got %d requests", requestCount)
+	}
 }
 
 func TestPaginatedCommandSinglePage(t *testing.T) {
@@ -102,6 +125,7 @@ func TestPaginatedCommandSinglePage(t *testing.T) {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
 			dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+			"",
 			"test paginated")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -146,6 +170,7 @@ func TestPaginatedCommandMultiPage(t *testing.T) {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
 			dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+			"",
 			"test paginated multi")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -176,6 +201,7 @@ func TestPaginatedCommandEmptyResults(t *testing.T) {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
 			dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+			"",
 			"test paginated empty")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -199,6 +225,7 @@ func TestPaginatedCommandServerError(t *testing.T) {
 	err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 		datatables.TradeColumns,
 		dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},
+		"",
 		"test paginated error")
 	assertErrContains(t, err, "test paginated error")
 }

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -137,6 +137,29 @@ func TestTradeListFieldsRejectsInvalidField(t *testing.T) {
 	assertErrContains(t, err, "Ticker")
 }
 
+func TestTradeListInvalidFormatWithWatchlistDoesNotQueryAPI(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		fmt.Fprint(w, dataTablesJSON(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "list",
+		"--start-date", "2025-01-01",
+		"--end-date", "2025-01-31",
+		"--watchlist", "Core",
+		"--format", "table",
+	})
+	assertErrContains(t, err, "valid formats: json,csv,tsv")
+	if requestCount != 0 {
+		t.Fatalf("expected invalid format to fail before watchlist/API query, got %d requests", requestCount)
+	}
+}
+
 func TestTradeListPresetIncludesDefaults(t *testing.T) {
 	// Regression test for https://github.com/major/volumeleaders-agent/issues/8
 	// Presets must include CLI flag defaults for params the API requires

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -94,6 +94,7 @@ volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-
 				&cli.StringFlag{Name: "watchlist", Usage: "Apply filters from a saved watchlist by name"},
 				&cli.StringFlag{Name: "fields", Usage: "Comma-separated trade fields to include in output"},
 			},
+			outputFormatFlags(),
 			paginationFlags(100, 1, "desc"),
 		),
 		Action: runTradeList,
@@ -119,6 +120,7 @@ volumeleaders-agent trade clusters --min-dollars 50000000 --vcd 1`,
 				&cli.IntFlag{Name: "trade-cluster-rank", Value: -1, Usage: "Trade cluster rank filter"},
 				&cli.StringFlag{Name: "sector", Usage: "Sector/Industry filter"},
 			},
+			outputFormatFlags(),
 			paginationFlags(1000, 1, "desc"),
 		),
 		Action: runTradeClusters,
@@ -143,6 +145,7 @@ volumeleaders-agent trade cluster-bombs --vcd 1 --min-volume 100000`,
 				&cli.IntFlag{Name: "trade-cluster-bomb-rank", Value: -1, Usage: "Trade cluster bomb rank filter"},
 				&cli.StringFlag{Name: "sector", Usage: "Sector/Industry filter"},
 			},
+			outputFormatFlags(),
 			paginationFlags(100, 1, "desc"),
 		),
 		Action: runTradeClusterBombs,
@@ -154,9 +157,13 @@ func newTradeAlertsCommand() *cli.Command {
 		Name:      "alerts",
 		Usage:     "Query trade alerts for a date",
 		UsageText: "volumeleaders-agent trade alerts --date 2025-01-15",
-		Flags: append([]cli.Flag{
-			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-		}, paginationFlags(100, 1, "desc")...),
+		Flags: slices.Concat(
+			[]cli.Flag{
+				&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
+			},
+			outputFormatFlags(),
+			paginationFlags(100, 1, "desc"),
+		),
 		Action: runTradeAlerts,
 	}
 }
@@ -166,9 +173,13 @@ func newTradeClusterAlertsCommand() *cli.Command {
 		Name:      "cluster-alerts",
 		Usage:     "Query trade cluster alerts for a date",
 		UsageText: "volumeleaders-agent trade cluster-alerts --date 2025-01-15",
-		Flags: append([]cli.Flag{
-			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-		}, paginationFlags(100, 1, "desc")...),
+		Flags: slices.Concat(
+			[]cli.Flag{
+				&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
+			},
+			outputFormatFlags(),
+			paginationFlags(100, 1, "desc"),
+		),
 		Action: runTradeClusterAlerts,
 	}
 }
@@ -191,6 +202,7 @@ volumeleaders-agent trade levels --ticker MSFT --trade-level-count 20 --min-doll
 				&cli.IntFlag{Name: "trade-level-rank", Value: -1, Usage: "Trade level rank filter"},
 				&cli.IntFlag{Name: "trade-level-count", Value: 10, Usage: "Number of price levels to return"},
 			},
+			outputFormatFlags(),
 		),
 		Action: runTradeLevels,
 	}
@@ -213,6 +225,7 @@ volumeleaders-agent trade level-touches --tickers NVDA,AMD --trade-level-rank 5`
 				&cli.IntFlag{Name: "relative-size", Value: 0, Usage: "Relative size threshold"},
 				&cli.IntFlag{Name: "trade-level-rank", Value: 10, Usage: "Trade level rank filter"},
 			},
+			outputFormatFlags(),
 			paginationFlags(100, 0, "desc"),
 		),
 		Action: runTradeLevelTouches,
@@ -227,6 +240,9 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	fields, err := parseJSONFieldList[models.Trade](cmd.String("fields"))
 	if err != nil {
 		return fmt.Errorf("parsing fields flag: %w", err)
+	}
+	if _, err := parseOutputFormat(cmd.String("format")); err != nil {
+		return err
 	}
 
 	// Build the full filter map from CLI flags (includes defaults for unset
@@ -295,7 +311,15 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	filters["EndDate"] = cmd.String("end-date")
 
 	return runDataTablesCommand[models.Trade](ctx, "/Trades/GetTrades", datatables.TradeColumns,
-		dataTableOptions{start: cmd.Int("start"), length: cmd.Int("length"), orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"), filters: filters, fields: fields},
+		dataTableOptions{
+			start:    cmd.Int("start"),
+			length:   cmd.Int("length"),
+			orderCol: cmd.Int("order-col"),
+			orderDir: cmd.String("order-dir"),
+			filters:  filters,
+			fields:   fields,
+		},
+		cmd.String("format"),
 		"query trades")
 }
 
@@ -320,7 +344,7 @@ func runTradeClusters(ctx context.Context, cmd *cli.Command) error {
 				"TradeClusterRank": intStr(cmd.Int("trade-cluster-rank")),
 				"SectorIndustry":   cmd.String("sector"),
 			},
-		}, "query trade clusters")
+		}, cmd.String("format"), "query trade clusters")
 }
 
 func runTradeClusterBombs(ctx context.Context, cmd *cli.Command) error {
@@ -342,7 +366,7 @@ func runTradeClusterBombs(ctx context.Context, cmd *cli.Command) error {
 				"TradeClusterBombRank": intStr(cmd.Int("trade-cluster-bomb-rank")),
 				"SectorIndustry":       cmd.String("sector"),
 			},
-		}, "query trade cluster bombs")
+		}, cmd.String("format"), "query trade cluster bombs")
 }
 
 func runTradeAlerts(ctx context.Context, cmd *cli.Command) error {
@@ -351,7 +375,7 @@ func runTradeAlerts(ctx context.Context, cmd *cli.Command) error {
 			start: cmd.Int("start"), length: cmd.Int("length"),
 			orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"),
 			filters: map[string]string{"Date": cmd.String("date")},
-		}, "query trade alerts")
+		}, cmd.String("format"), "query trade alerts")
 }
 
 func runTradeClusterAlerts(ctx context.Context, cmd *cli.Command) error {
@@ -360,7 +384,7 @@ func runTradeClusterAlerts(ctx context.Context, cmd *cli.Command) error {
 			start: cmd.Int("start"), length: cmd.Int("length"),
 			orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"),
 			filters: map[string]string{"Date": cmd.String("date")},
-		}, "query trade cluster alerts")
+		}, cmd.String("format"), "query trade cluster alerts")
 }
 
 func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
@@ -380,7 +404,14 @@ func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
 		tradeLevelCount: cmd.Int("trade-level-count"),
 	}
 	return runDataTablesCommand[models.TradeLevel](ctx, "/TradeLevels/GetTradeLevels", datatables.TradeLevelColumns,
-		dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc", filters: buildTradeLevelFilters(opts)},
+		dataTableOptions{
+			start:    0,
+			length:   -1,
+			orderCol: 1,
+			orderDir: "desc",
+			filters:  buildTradeLevelFilters(opts),
+		},
+		cmd.String("format"),
 		"query trade levels")
 }
 
@@ -403,7 +434,7 @@ func runTradeLevelTouches(ctx context.Context, cmd *cli.Command) error {
 				"RelativeSize":   intStr(cmd.Int("relative-size")),
 				"TradeLevelRank": intStr(cmd.Int("trade-level-rank")),
 			},
-		}, "query trade level touches")
+		}, cmd.String("format"), "query trade level touches")
 }
 
 // --- Filter builders ---

--- a/internal/commands/volume.go
+++ b/internal/commands/volume.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"slices"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
@@ -9,27 +10,32 @@ import (
 )
 
 type volumeOptions struct {
-	date, tickers, orderDir string
-	start, length, orderCol int
+	date, tickers, orderDir, format string
+	start, length, orderCol         int
 }
 
 // volumeFlags returns the shared flag set used by all volume subcommands.
 func volumeFlags() []cli.Flag {
-	return append([]cli.Flag{
-		&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-		&cli.StringFlag{Name: "tickers", Usage: "Comma-separated ticker symbols"},
-	}, paginationFlags(100, 1, "asc")...)
+	return slices.Concat(
+		[]cli.Flag{
+			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
+			&cli.StringFlag{Name: "tickers", Usage: "Comma-separated ticker symbols"},
+		},
+		outputFormatFlags(),
+		paginationFlags(100, 1, "asc"),
+	)
 }
 
 // parseVolumeOptions extracts volumeOptions from the parsed CLI flags.
-func parseVolumeOptions(cmd *cli.Command) volumeOptions {
-	return volumeOptions{
+func parseVolumeOptions(cmd *cli.Command) *volumeOptions {
+	return &volumeOptions{
 		date:     cmd.String("date"),
 		tickers:  cmd.String("tickers"),
 		start:    cmd.Int("start"),
 		length:   cmd.Int("length"),
 		orderCol: cmd.Int("order-col"),
 		orderDir: cmd.String("order-dir"),
+		format:   cmd.String("format"),
 	}
 }
 
@@ -39,33 +45,33 @@ func NewVolumeCommand() *cli.Command {
 		Name:  "volume",
 		Usage: "Volume leaderboard commands",
 		Commands: []*cli.Command{
-		{
-			Name:      "institutional",
-			Usage:     "Query institutional volume leaderboard",
-			UsageText: "volumeleaders-agent volume institutional --date 2025-01-15 --tickers AAPL,MSFT",
-				Flags: volumeFlags(),
+			{
+				Name:      "institutional",
+				Usage:     "Query institutional volume leaderboard",
+				UsageText: "volumeleaders-agent volume institutional --date 2025-01-15 --tickers AAPL,MSFT",
+				Flags:     volumeFlags(),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					return runVolume(ctx, parseVolumeOptions(cmd),
 						"/InstitutionalVolume/GetInstitutionalVolume",
 						datatables.InstitutionalVolumeColumns)
 				},
 			},
-		{
-			Name:      "ah-institutional",
-			Usage:     "Query after-hours institutional volume leaderboard",
-			UsageText: "volumeleaders-agent volume ah-institutional --date 2025-01-15",
-				Flags: volumeFlags(),
+			{
+				Name:      "ah-institutional",
+				Usage:     "Query after-hours institutional volume leaderboard",
+				UsageText: "volumeleaders-agent volume ah-institutional --date 2025-01-15",
+				Flags:     volumeFlags(),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					return runVolume(ctx, parseVolumeOptions(cmd),
 						"/AHInstitutionalVolume/GetAHInstitutionalVolume",
 						datatables.InstitutionalVolumeColumns)
 				},
 			},
-		{
-			Name:      "total",
-			Usage:     "Query total volume leaderboard",
-			UsageText: "volumeleaders-agent volume total --date 2025-01-15 --length 20",
-				Flags: volumeFlags(),
+			{
+				Name:      "total",
+				Usage:     "Query total volume leaderboard",
+				UsageText: "volumeleaders-agent volume total --date 2025-01-15 --length 20",
+				Flags:     volumeFlags(),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					return runVolume(ctx, parseVolumeOptions(cmd),
 						"/TotalVolume/GetTotalVolume",
@@ -77,7 +83,7 @@ func NewVolumeCommand() *cli.Command {
 }
 
 // runVolume is the shared handler for all volume subcommands.
-func runVolume(ctx context.Context, opts volumeOptions, path string, columns []string) error {
+func runVolume(ctx context.Context, opts *volumeOptions, path string, columns []string) error {
 	return runDataTablesCommand[models.Trade](ctx, path, columns,
 		dataTableOptions{
 			start:    opts.start,
@@ -89,5 +95,6 @@ func runVolume(ctx context.Context, opts volumeOptions, path string, columns []s
 				"Tickers": opts.tickers,
 			},
 		},
+		opts.format,
 		"query volume data")
 }

--- a/internal/commands/volume_test.go
+++ b/internal/commands/volume_test.go
@@ -21,7 +21,7 @@ func TestRunVolume(t *testing.T) {
 
 	ctx := contextWithTestClient(server.URL)
 	captureStdout(t, func() {
-		opts := volumeOptions{
+		opts := &volumeOptions{
 			date:     "2025-01-15",
 			tickers:  "AAPL",
 			start:    0,
@@ -42,7 +42,7 @@ func TestRunVolumeServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	opts := volumeOptions{date: "2025-01-15", start: 0, length: 100, orderCol: 1, orderDir: "asc"}
+	opts := &volumeOptions{date: "2025-01-15", start: 0, length: 100, orderCol: 1, orderDir: "asc"}
 	err := runVolume(ctx, opts, "/InstitutionalVolume/GetInstitutionalVolume", datatables.InstitutionalVolumeColumns)
 	assertErrContains(t, err, "query volume data")
 }

--- a/internal/commands/watchlist.go
+++ b/internal/commands/watchlist.go
@@ -18,29 +18,30 @@ func NewWatchlistCommand() *cli.Command {
 		Name:  "watchlist",
 		Usage: "Watch list commands",
 		Commands: []*cli.Command{
-		{
-			Name:      "configs",
-			Usage:     "List saved watch list configurations",
-			UsageText: "volumeleaders-agent watchlist configs",
-				Action: func(ctx context.Context, _ *cli.Command) error {
-					return runWatchlistConfigs(ctx)
-				},
-			},
-		{
-			Name:      "tickers",
-			Usage:     "Query tickers for a selected watch list",
-			UsageText: "volumeleaders-agent watchlist tickers --watchlist-key 1",
-				Flags: []cli.Flag{
-					&cli.IntFlag{Name: "watchlist-key", Value: -1, Usage: "Watch list key (-1 for all)"},
-				},
+			{
+				Name:      "configs",
+				Usage:     "List saved watch list configurations",
+				UsageText: "volumeleaders-agent watchlist configs",
+				Flags:     outputFormatFlags(),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runWatchlistTickers(ctx, cmd.Int("watchlist-key"))
+					return runWatchlistConfigs(ctx, cmd.String("format"))
 				},
 			},
-		{
-			Name:      "delete",
-			Usage:     "Delete a watch list configuration",
-			UsageText: "volumeleaders-agent watchlist delete --key 1",
+			{
+				Name:      "tickers",
+				Usage:     "Query tickers for a selected watch list",
+				UsageText: "volumeleaders-agent watchlist tickers --watchlist-key 1",
+				Flags: append([]cli.Flag{
+					&cli.IntFlag{Name: "watchlist-key", Value: -1, Usage: "Watch list key (-1 for all)"},
+				}, outputFormatFlags()...),
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return runWatchlistTickers(ctx, cmd.Int("watchlist-key"), cmd.String("format"))
+				},
+			},
+			{
+				Name:      "delete",
+				Usage:     "Delete a watch list configuration",
+				UsageText: "volumeleaders-agent watchlist delete --key 1",
 				Flags: []cli.Flag{
 					&cli.IntFlag{Name: "key", Required: true, Usage: "Watch list key to delete"},
 				},
@@ -48,10 +49,10 @@ func NewWatchlistCommand() *cli.Command {
 					return runWatchlistDelete(ctx, cmd.Int("key"))
 				},
 			},
-		{
-			Name:      "add-ticker",
-			Usage:     "Add a ticker to an existing watch list",
-			UsageText: "volumeleaders-agent watchlist add-ticker --watchlist-key 1 --ticker NVDA",
+			{
+				Name:      "add-ticker",
+				Usage:     "Add a ticker to an existing watch list",
+				UsageText: "volumeleaders-agent watchlist add-ticker --watchlist-key 1 --ticker NVDA",
 				Flags: []cli.Flag{
 					&cli.IntFlag{Name: "watchlist-key", Required: true, Usage: "Watch list key"},
 					&cli.StringFlag{Name: "ticker", Required: true, Usage: "Ticker symbol to add"},
@@ -128,7 +129,7 @@ func newWatchlistEditCommand() *cli.Command {
 		Name:      "edit",
 		Usage:     "Edit an existing watch list configuration",
 		UsageText: "volumeleaders-agent watchlist edit --key 1 --name \"Updated watchlist\" --tickers AAPL,MSFT",
-		Flags: flags,
+		Flags:     flags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return runWatchlistCreateEdit(ctx, cmd, cmd.Int("key"))
 		},
@@ -176,7 +177,12 @@ func buildWatchlistConfigFields(cmd *cli.Command, key int) map[string]string {
 
 // --- Action handlers ---
 
-func runWatchlistConfigs(ctx context.Context) error {
+func runWatchlistConfigs(ctx context.Context, formatValue string) error {
+	format, err := parseOutputFormat(formatValue)
+	if err != nil {
+		return err
+	}
+
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
@@ -189,10 +195,15 @@ func runWatchlistConfigs(ctx context.Context) error {
 		return fmt.Errorf("query watchlist configs: %w", err)
 	}
 
-	return printJSON(ctx, configs)
+	return printDataTablesResult(ctx, configs, nil, format)
 }
 
-func runWatchlistTickers(ctx context.Context, watchlistKey int) error {
+func runWatchlistTickers(ctx context.Context, watchlistKey int, formatValue string) error {
+	format, err := parseOutputFormat(formatValue)
+	if err != nil {
+		return err
+	}
+
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
@@ -213,7 +224,7 @@ func runWatchlistTickers(ctx context.Context, watchlistKey int) error {
 		return fmt.Errorf("query watchlist tickers: %w", err)
 	}
 
-	return printJSON(ctx, tickers)
+	return printDataTablesResult(ctx, tickers, nil, format)
 }
 
 func runWatchlistDelete(ctx context.Context, key int) error {

--- a/internal/commands/watchlist_test.go
+++ b/internal/commands/watchlist_test.go
@@ -21,7 +21,7 @@ func TestRunWatchlistConfigs(t *testing.T) {
 
 	ctx := contextWithTestClient(server.URL)
 	captureStdout(t, func() {
-		if err := runWatchlistConfigs(ctx); err != nil {
+		if err := runWatchlistConfigs(ctx, "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -34,7 +34,7 @@ func TestRunWatchlistConfigsServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	err := runWatchlistConfigs(ctx)
+	err := runWatchlistConfigs(ctx, "json")
 	assertErrContains(t, err, "query watchlist configs")
 }
 
@@ -49,7 +49,7 @@ func TestRunWatchlistTickers(t *testing.T) {
 
 	ctx := contextWithTestClient(server.URL)
 	captureStdout(t, func() {
-		if err := runWatchlistTickers(ctx, 1); err != nil {
+		if err := runWatchlistTickers(ctx, 1, "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -232,7 +232,7 @@ func TestRunWatchlistTickersServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(server.URL)
-	err := runWatchlistTickers(ctx, 1)
+	err := runWatchlistTickers(ctx, 1, "json")
 	assertErrContains(t, err, "query watchlist tickers")
 }
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -4,7 +4,7 @@ CLI for querying institutional trade data from VolumeLeaders. Binary: `volumelea
 
 Auth: extracts browser cookies automatically. User must be logged into volumeleaders.com. Auth errors mean the user needs to log in via their browser.
 
-Output: compact JSON to stdout. Add `--pretty` before the command group for indented output. Errors go to stderr.
+Output: compact JSON to stdout by default. List-style commands support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null/missing values as empty cells. Add `--pretty` before the command group for indented JSON output. Errors go to stderr.
 
 ## Command Chooser
 
@@ -49,6 +49,8 @@ Chain commands for deeper analysis:
 
 **Pagination**: `--start` (offset, default 0), `--length` (count, default varies, `-1` = all), `--order-col` (sort column index), `--order-dir` (`asc` or `desc`).
 
+**Output formats**: list-style object outputs accept `--format json|csv|tsv` (default `json`). CSV/TSV use output field names as headers. `--pretty` only affects JSON.
+
 **Ticker flags**: `--tickers` takes comma-separated list (multi-ticker commands). `--ticker` takes a single symbol (single-ticker commands). All trade subcommands also accept `--ticker`, `--tickers`, `--symbol`, and `--symbols` as aliases, so any form works on any command.
 
 ## Shared Flag Defaults
@@ -90,7 +92,7 @@ These defaults apply across trade commands unless overridden (overrides noted pe
 | `DollarsMultiplier` | Trade dollar value relative to average block size (higher = bigger than usual) |
 | `TradeRank` | VL proprietary significance ranking (lower = more significant) |
 | `TradeRankSnapshot` | TradeRank at time of trade (vs current recalculated rank) |
-| `RelativeSize` | Trade size vs average daily volume (higher = more unusual). Only on levels/price-data, not on trade list |
+| `RelativeSize` | Trade size vs average daily volume (higher = more unusual). Present on trade list, levels, and price-data outputs |
 | `PercentDailyVolume` | Trade volume as % of average daily volume. On trade list output |
 | `VCD` | Volume Confirmation Distribution score |
 | `FrequencyLast30TD` | Count of similar-magnitude trades in last 30 trading days |

--- a/skills/alert.md
+++ b/skills/alert.md
@@ -4,13 +4,18 @@ Manage saved alert configurations. Alerts trigger when trades/clusters match thr
 
 ## alert configs
 
-List all saved alert configurations. No flags.
+List all saved alert configurations.
+
+Optional: `--format json|csv|tsv`
 
 ```bash
 volumeleaders-agent alert configs
+volumeleaders-agent alert configs --format csv
 ```
 
 Output fields: `AlertConfigKey` (use as `--key` for edit/delete), `Name`, `Tickers`, plus threshold fields. Threshold naming pattern: `{Category}{Metric}{LTE|GTE}` where LTE = max rank (lower rank = more significant) and GTE = minimum value (higher = bigger trade).
+
+Output format: `alert configs` defaults to JSON and supports CSV/TSV. Create/edit/delete responses remain JSON-only.
 
 ## alert delete
 

--- a/skills/chart.md
+++ b/skills/chart.md
@@ -34,9 +34,11 @@ Optional flags:
 | **`--include-closing`** | 1 | **Not `--closing`** |
 | **`--include-phantom`** | 1 | **Not `--phantom`** |
 | **`--include-offsetting`** | 1 | **Not `--offsetting`** |
+| `--format` | json | `json`, `csv`, or `tsv` |
 
 ```bash
 volumeleaders-agent chart price-data --ticker AAPL --start-date 2025-04-23 --end-date 2025-04-23
+volumeleaders-agent chart price-data --ticker AAPL --start-date 2025-04-23 --end-date 2025-04-23 --format tsv
 ```
 
 Output fields (PriceBar model): `DateKey`, `TimeKey`, `Date`, `FullDateTime`, `FullTimeString24`, `OpenPrice`, `ClosePrice`, `HighPrice`, `LowPrice`, `Volume`, `Dollars`, `Trades`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `TradeLevelRank`, `DollarsMultiplier`, `RelativeSize`, `DarkPoolTrade` (note: NOT `DarkPool`), `LatePrint`, `OpeningTrade`, `ClosingTrade`, `SignaturePrint`, `PhantomPrint`, `Sweep`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FrequencyLast1CY`
@@ -60,13 +62,15 @@ Note: `lastQuote` and `lastTrade` use single-letter JSON keys, not descriptive n
 Institutional price levels for charting. Simpler interface than `trade levels` with fewer filter options.
 
 Required: `--ticker`, `--start-date`, `--end-date`
-Optional: `--levels` (default 5)
+Optional: `--levels` (default 5), `--format json|csv|tsv`
 
 ```bash
 volumeleaders-agent chart levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-04-23 --levels 10
 ```
 
 Output fields: same TradeLevel model as `trade levels`.
+
+Output format: `chart price-data` and `chart levels` default to JSON and support CSV/TSV. `chart snapshot` and `chart company` remain JSON-only single-object outputs.
 
 ## chart company
 

--- a/skills/market.md
+++ b/skills/market.md
@@ -17,12 +17,16 @@ Output: JSON object mapping ticker to price data.
 Earnings calendar with institutional activity counts. Shows how much institutional positioning preceded each earnings event.
 
 Required: `--start-date`, `--end-date`
+Optional: `--format json|csv|tsv`
 
 ```bash
 volumeleaders-agent market earnings --start-date 2025-04-21 --end-date 2025-04-25
+volumeleaders-agent market earnings --start-date 2025-04-21 --end-date 2025-04-25 --format csv
 ```
 
 Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `EarningsDate`, `AfterMarketClose` (bool), `TradeCount`, `TradeClusterCount`, `TradeClusterBombCount`
+
+Output format: `market earnings` defaults to JSON and supports CSV/TSV. `market snapshots` and `market exhaustion` remain JSON-only.
 
 ## market exhaustion
 

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -4,12 +4,13 @@ Institutional trade discovery. 9 subcommands. See SKILL.md for shared flag defau
 
 ## trade presets
 
-List all built-in trade filter presets. No authentication required. Output is a JSON array of objects with `Name`, `Group`, and `Filters` fields.
+List all built-in trade filter presets. No authentication required. Output is a JSON array by default, with `--format csv|tsv` available for tabular output. Fields: `Name`, `Group`, `Filters`.
 
 Groups: "Common" (general-purpose filters), "Disproportionately Large" (>=5x avg size, sector/ticker-based).
 
 ```bash
 volumeleaders-agent trade presets
+volumeleaders-agent trade presets --format csv
 volumeleaders-agent trade presets --pretty | jq '.[].Name'
 ```
 
@@ -39,13 +40,15 @@ Output fields: `Preset`, `Group`, `Type`, `Tickers` (trimmed, deduplicated, omit
 Query individual institutional block trades. The primary trade discovery command.
 
 Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
+Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, `--format json|csv|tsv`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
 
 **`--preset NAME`**: Apply a built-in filter preset by name (case-insensitive). The preset sets baseline filters; any explicitly-provided CLI flags override the preset values. Use `trade presets` to list available names.
 
 **`--watchlist NAME`**: Apply filters from a saved user watchlist by name (case-insensitive). Fetches the watchlist config at runtime and converts its settings to trade filters. Use `watchlist configs` to list available names.
 
-**`--fields FIELD1,FIELD2`**: Return only the listed trade fields in each JSON object. Field names are case-sensitive and must match the output field names below. Invalid names fail before querying the API and include the valid field list in the error.
+**`--fields FIELD1,FIELD2`**: Return only the listed trade fields in each JSON object, or use the listed fields as CSV/TSV columns. Field names are case-sensitive and must match the output field names below. Invalid names fail before querying the API and include the valid field list in the error.
+
+**`--format json|csv|tsv`**: Select output format for list results. JSON is the default. CSV/TSV include a header row, render booleans as `true`/`false`, and render null/missing values as empty cells.
 
 Both flags can be combined: watchlist filters merge on top of preset filters, and explicit CLI flags override both.
 
@@ -55,6 +58,7 @@ volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 -
 volumeleaders-agent trade list --preset "Megacaps" --start-date 2025-04-01 --end-date 2025-04-24 --trade-rank 10
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars,DollarsMultiplier,DarkPool,CumulativeDistribution
+volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars --format csv
 ```
 
 Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RelativeSize`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`
@@ -64,7 +68,7 @@ Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstit
 Aggregated clusters where multiple institutional trades converge at similar price levels. Clusters signal stronger conviction than individual trades.
 
 Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank` (-1), pagination (`--length 1000 --order-col 1 --order-dir desc`)
+Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank` (-1), `--format json|csv|tsv`, pagination (`--length 1000 --order-col 1 --order-dir desc`)
 Non-standard defaults: `--min-dollars 10000000`, `--length 1000`
 
 ```bash
@@ -78,7 +82,7 @@ Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `Price`, `Dollars
 Sudden, aggressive institutional positioning bursts. Many trades clustered tightly in time and price.
 
 Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, volume/dollar ranges (no price range), `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-bomb-rank` (-1), pagination (`--length 1000 --order-col 1 --order-dir desc`)
+Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, volume/dollar ranges (no price range), `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-bomb-rank` (-1), `--format json|csv|tsv`, pagination (`--length 1000 --order-col 1 --order-dir desc`)
 Non-standard defaults: `--min-dollars 0`, `--security-type 0`, `--relative-size 0`
 
 ```bash
@@ -92,7 +96,7 @@ Output fields: same as clusters but `TradeClusterBombRank` instead of `TradeClus
 System-generated notifications about notable individual trades for a single date.
 
 Required: `--date`
-Optional: pagination
+Optional: `--format json|csv|tsv`, pagination
 
 ```bash
 volumeleaders-agent trade alerts --date 2025-04-23
@@ -105,7 +109,7 @@ Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `AlertType`, `Pri
 System-generated notifications about notable trade clusters for a single date.
 
 Required: `--date`
-Optional: pagination
+Optional: `--format json|csv|tsv`, pagination
 
 ```bash
 volumeleaders-agent trade cluster-alerts --date 2025-04-23
@@ -118,7 +122,7 @@ Output fields: same as trade clusters.
 Significant institutional price levels for a single ticker. These levels often act as support/resistance.
 
 Required: `--ticker` (single; aliases: `--tickers`, `--symbol`, `--symbols`), `--start-date`, `--end-date`
-Optional: volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (-1), `--trade-level-count` (10)
+Optional: volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (-1), `--trade-level-count` (10), `--format json|csv|tsv`
 Non-standard defaults: `--relative-size 0`. No pagination flags.
 
 ```bash
@@ -132,7 +136,7 @@ Output fields: `Ticker`, `Name`, `Price`, `Dollars`, `Volume`, `Trades`, `Relati
 Events where price revisits significant institutional price levels. Signals support/resistance tests or institutional re-engagement.
 
 Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (10), pagination (`--length 100 --order-col 0 --order-dir desc`)
+Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (10), `--format json|csv|tsv`, pagination (`--length 100 --order-col 0 --order-dir desc`)
 Non-standard defaults: `--relative-size 0`, `--order-col 0`, `--trade-level-rank 10`
 
 ```bash

--- a/skills/volume.md
+++ b/skills/volume.md
@@ -3,7 +3,9 @@
 Volume leaderboards ranking stocks by trading activity. All three subcommands share the same flags and return Trade model objects.
 
 Required: `--date` (YYYY-MM-DD)
-Optional: `--tickers`, pagination (`--length 100 --order-col 1 --order-dir asc`)
+Optional: `--tickers`, `--format json|csv|tsv`, pagination (`--length 100 --order-col 1 --order-dir asc`)
+
+Output format: JSON by default. CSV/TSV include a header row, render booleans as `true`/`false`, and render null/missing values as empty cells.
 
 Note: default sort direction is `asc` (ascending), unlike trade commands which default to `desc`.
 
@@ -13,6 +15,7 @@ Stocks ranked by institutional dollar volume for a date. The primary "what are i
 
 ```bash
 volumeleaders-agent volume institutional --date 2025-04-23
+volumeleaders-agent volume institutional --date 2025-04-23 --format csv
 ```
 
 ## volume ah-institutional

--- a/skills/watchlist.md
+++ b/skills/watchlist.md
@@ -4,25 +4,33 @@ Manage saved watchlist configurations.
 
 ## watchlist configs
 
-List all saved watchlist configurations. No flags.
+List all saved watchlist configurations.
+
+Optional: `--format json|csv|tsv`
 
 ```bash
 volumeleaders-agent watchlist configs
+volumeleaders-agent watchlist configs --format csv
 ```
 
 Output fields: `SearchTemplateKey` (use as `--key` or `--watchlist-key` for other commands), `Name`, `Tickers`, plus filter settings (volume/price/dollar ranges, RSI conditions, trade type booleans, `SecurityTypeKey`, `MinVCD`, `SectorIndustry`).
+
+Output format: `watchlist configs` defaults to JSON and supports CSV/TSV. Mutation responses remain JSON-only.
 
 ## watchlist tickers
 
 Get tickers and summary data from a watchlist.
 
-Optional: `--watchlist-key` (default -1 = all watchlists). Get key from `watchlist configs` `SearchTemplateKey`.
+Optional: `--watchlist-key` (default -1 = all watchlists), `--format json|csv|tsv`. Get key from `watchlist configs` `SearchTemplateKey`.
 
 ```bash
 volumeleaders-agent watchlist tickers --watchlist-key 12345
+volumeleaders-agent watchlist tickers --watchlist-key 12345 --format tsv
 ```
 
 Output fields: `Ticker`, `Price`, `NearestTop10TradeDate`, `NearestTop10TradeClusterDate`, `NearestTop10TradeLevel`
+
+Output format: `watchlist tickers` defaults to JSON and supports CSV/TSV.
 
 ## watchlist delete
 


### PR DESCRIPTION
## Summary
- Add `--format json|csv|tsv` to list-style commands, keeping JSON as the default.
- Route CSV/TSV through shared output helpers with headers, empty null cells, boolean text, and exact numeric tokens.
- Update command skill docs and add regression coverage for format parsing, delimited output, fields, and invalid-format behavior.

Closes #17

## Testing
- `go test ./internal/commands -run 'Test(ParseOutputFormat|PrintDataTablesResultDelimited|RunDataTablesCommandInvalidFormatDoesNotQueryAPI|RunDataTablesCommand|PaginatedCommand|RunEarnings|RunAlertConfigs|RunWatchlistConfigs|RunWatchlistTickers|ChartPriceData|RunPriceData|RunChartLevels|RunVolume|NewApp)' -count=1`
- `go test ./internal/commands -run 'Test(PrintDataTablesResultDelimited|TradeListInvalidFormatWithWatchlistDoesNotQueryAPI|ParseOutputFormat|RunDataTablesCommandInvalidFormatDoesNotQueryAPI|TradeListFieldsFiltersOutput)' -count=1`
- `make test && make lint && make build`