### PR TITLE
Add trade list summary output

### DIFF
--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -135,6 +137,242 @@ func TestTradeListFieldsRejectsInvalidField(t *testing.T) {
 	})
 	assertErrContains(t, err, "invalid field \"NotAField\"")
 	assertErrContains(t, err, "Ticker")
+}
+
+func TestTradeListSummaryDefaultsToTickerGrouping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":100,"DollarsMultiplier":2,"CumulativeDistribution":0.8,"DarkPool":1,"Sweep":0},
+			{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":300,"DollarsMultiplier":4,"CumulativeDistribution":1,"DarkPool":0,"Sweep":1},
+			{"Date":"/Date(1745280000000)/","Ticker":"QQQ","Dollars":200,"DollarsMultiplier":6,"CumulativeDistribution":0.5,"DarkPool":1,"Sweep":1}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-22",
+			"--summary",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal summary output: %v", err)
+	}
+	if got.TotalTrades != 3 {
+		t.Fatalf("total trades = %d, want 3", got.TotalTrades)
+	}
+	if got.TotalDollars != 600 {
+		t.Fatalf("total dollars = %v, want 600", got.TotalDollars)
+	}
+	if got.DateRange.Start != "2025-04-21" || got.DateRange.End != "2025-04-22" {
+		t.Fatalf("date range = %#v, want 2025-04-21 to 2025-04-22", got.DateRange)
+	}
+	if got.ByDay != nil || got.ByTickerDay != nil {
+		t.Fatalf("unexpected non-ticker groups: byDay=%#v byTickerDay=%#v", got.ByDay, got.ByTickerDay)
+	}
+
+	spy := got.ByTicker["SPY"]
+	if spy.Trades != 2 || spy.Dollars != 400 {
+		t.Fatalf("SPY summary = %#v, want 2 trades and 400 dollars", spy)
+	}
+	if spy.AvgDollarsMultiplier != 3 {
+		t.Fatalf("SPY avg dollars multiplier = %v, want 3", spy.AvgDollarsMultiplier)
+	}
+	if spy.PctDarkPool != 50 || spy.PctSweep != 50 {
+		t.Fatalf("SPY dark/sweep pct = %v/%v, want 50/50", spy.PctDarkPool, spy.PctSweep)
+	}
+	if spy.AvgCumulativeDistribution != 0.9 {
+		t.Fatalf("SPY avg cumulative distribution = %v, want 0.9", spy.AvgCumulativeDistribution)
+	}
+}
+
+func TestTradeListSummaryGroupsByTickerDay(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":100,"DollarsMultiplier":2,"CumulativeDistribution":0.8,"DarkPool":1,"Sweep":0},
+			{"Date":"/Date(1745280000000)/","Ticker":"SPY","Dollars":300,"DollarsMultiplier":4,"CumulativeDistribution":1,"DarkPool":0,"Sweep":1}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-22",
+			"--summary",
+			"--group-by", "ticker,day",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal summary output: %v", err)
+	}
+	if got.ByTicker != nil || got.ByDay != nil {
+		t.Fatalf("unexpected non-cross-tab groups: byTicker=%#v byDay=%#v", got.ByTicker, got.ByDay)
+	}
+	if got.ByTickerDay["SPY|2025-04-21"].Dollars != 100 {
+		t.Fatalf("SPY first day dollars = %v, want 100", got.ByTickerDay["SPY|2025-04-21"].Dollars)
+	}
+	if got.ByTickerDay["SPY|2025-04-22"].Dollars != 300 {
+		t.Fatalf("SPY second day dollars = %v, want 300", got.ByTickerDay["SPY|2025-04-22"].Dollars)
+	}
+}
+
+func TestTradeListSummaryGroupsByDay(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":100,"DollarsMultiplier":2,"CumulativeDistribution":0.8,"DarkPool":1,"Sweep":0},
+			{"Date":"/Date(1745280000000)/","Ticker":"QQQ","Dollars":300,"DollarsMultiplier":4,"CumulativeDistribution":1,"DarkPool":0,"Sweep":1}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-22",
+			"--summary",
+			"--group-by", "day",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal summary output: %v", err)
+	}
+	if got.ByTicker != nil || got.ByTickerDay != nil {
+		t.Fatalf("unexpected non-day groups: byTicker=%#v byTickerDay=%#v", got.ByTicker, got.ByTickerDay)
+	}
+	if got.ByDay["2025-04-21"].Dollars != 100 {
+		t.Fatalf("first day dollars = %v, want 100", got.ByDay["2025-04-21"].Dollars)
+	}
+	if got.ByDay["2025-04-22"].Dollars != 300 {
+		t.Fatalf("second day dollars = %v, want 300", got.ByDay["2025-04-22"].Dollars)
+	}
+}
+
+func TestTradeListSummaryAllResultsUsesPagination(t *testing.T) {
+	totalRecords := paginationPageSize + 1
+	var requestCount int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		body, _ := io.ReadAll(r.Body)
+		params, _ := url.ParseQuery(string(body))
+
+		if params.Get("start") == "0" {
+			items := make([]string, paginationPageSize)
+			for i := range items {
+				items[i] = `{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":1}`
+			}
+			fmt.Fprint(w, dataTablesJSONPage("["+strings.Join(items, ",")+"]", totalRecords))
+			return
+		}
+
+		fmt.Fprint(w, dataTablesJSONPage(`[{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":2}]`, totalRecords))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+			"--summary",
+			"--length", "-1",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal summary output: %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+	if got.TotalTrades != totalRecords {
+		t.Fatalf("total trades = %d, want %d", got.TotalTrades, totalRecords)
+	}
+	wantDollars := float64(paginationPageSize + 2)
+	if got.TotalDollars != wantDollars {
+		t.Fatalf("total dollars = %v, want %v", got.TotalDollars, wantDollars)
+	}
+}
+
+func TestTradeListSummaryAllResultsRejectsMalformedPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSONPage(`{}`, 1))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "list",
+		"--start-date", "2025-04-21",
+		"--end-date", "2025-04-21",
+		"--summary",
+		"--length", "-1",
+	})
+	assertErrContains(t, err, "query trades: decode response")
+}
+
+func TestTradeListSummaryRejectsInvalidGroupBy(t *testing.T) {
+	ctx := contextWithTestClient("http://127.0.0.1")
+	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "list",
+		"--start-date", "2025-01-01",
+		"--end-date", "2025-01-31",
+		"--summary",
+		"--group-by", "sector",
+	})
+	assertErrContains(t, err, "invalid group-by \"sector\"")
+}
+
+func TestTradeListSummaryRejectsFields(t *testing.T) {
+	ctx := contextWithTestClient("http://127.0.0.1")
+	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "list",
+		"--start-date", "2025-01-01",
+		"--end-date", "2025-01-31",
+		"--summary",
+		"--fields", "Ticker,Dollars",
+	})
+	assertErrContains(t, err, "--fields cannot be used with --summary")
 }
 
 func TestTradeListPresetIncludesDefaults(t *testing.T) {

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -2,9 +2,13 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
+	"strings"
 
+	"github.com/major/volumeleaders-agent/internal/client"
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
@@ -92,6 +96,8 @@ volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-
 				&cli.StringFlag{Name: "preset", Usage: "Apply a built-in filter preset (see: trade presets)"},
 				&cli.StringFlag{Name: "watchlist", Usage: "Apply filters from a saved watchlist by name"},
 				&cli.StringFlag{Name: "fields", Usage: "Comma-separated trade fields to include in output"},
+				&cli.BoolFlag{Name: "summary", Usage: "Return aggregate metrics instead of individual trades"},
+				&cli.StringFlag{Name: "group-by", Value: "ticker", Usage: "Summary grouping: ticker, day, or ticker,day"},
 			},
 			paginationFlags(100, 1, "desc"),
 		),
@@ -293,9 +299,199 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	filters["StartDate"] = cmd.String("start-date")
 	filters["EndDate"] = cmd.String("end-date")
 
-	return runDataTablesCommand[models.Trade](ctx, "/Trades/GetTrades", datatables.TradeColumns,
-		dataTableOptions{start: cmd.Int("start"), length: cmd.Int("length"), orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"), filters: filters, fields: fields},
-		"query trades")
+	optsDataTable := dataTableOptions{
+		start:    cmd.Int("start"),
+		length:   cmd.Int("length"),
+		orderCol: cmd.Int("order-col"),
+		orderDir: cmd.String("order-dir"),
+		filters:  filters,
+		fields:   fields,
+	}
+
+	if cmd.Bool("summary") {
+		if len(fields) > 0 {
+			return fmt.Errorf("--fields cannot be used with --summary")
+		}
+		return runTradeSummary(ctx, optsDataTable, cmd.String("group-by"), cmd.String("start-date"), cmd.String("end-date"))
+	}
+
+	return runDataTablesCommand[models.Trade](ctx, "/Trades/GetTrades", datatables.TradeColumns, optsDataTable, "query trades")
+}
+
+func runTradeSummary(ctx context.Context, opts dataTableOptions, groupBy, startDate, endDate string) error {
+	group, err := parseTradeSummaryGroup(groupBy)
+	if err != nil {
+		return err
+	}
+
+	trades, err := fetchTradeList(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	summary := summarizeTrades(trades, group, startDate, endDate)
+	return printJSON(ctx, summary)
+}
+
+func fetchTradeList(ctx context.Context, opts dataTableOptions) ([]models.Trade, error) {
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.length < 0 {
+		return fetchAllTradePages(ctx, vlClient, opts)
+	}
+
+	request := newDataTablesRequest(datatables.TradeColumns, opts)
+	var result []models.Trade
+	if err := vlClient.PostDataTables(ctx, "/Trades/GetTrades", request.Encode(), &result); err != nil {
+		slog.Error("failed to query trades", "error", err)
+		return nil, fmt.Errorf("query trades: %w", err)
+	}
+	return result, nil
+}
+
+func fetchAllTradePages(ctx context.Context, vlClient *client.Client, opts dataTableOptions) ([]models.Trade, error) {
+	opts.length = paginationPageSize
+	all := make([]models.Trade, 0)
+	for {
+		request := newDataTablesRequest(datatables.TradeColumns, opts)
+		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
+		if err != nil {
+			slog.Error("failed to query trades", "error", err)
+			return nil, fmt.Errorf("query trades: %w", err)
+		}
+
+		var page []models.Trade
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
+			slog.Error("failed to decode trades", "error", err)
+			return nil, fmt.Errorf("query trades: decode response: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+
+		all = append(all, page...)
+		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
+			break
+		}
+		if len(page) < paginationPageSize {
+			break
+		}
+
+		opts.start += len(page)
+	}
+	return all, nil
+}
+
+type tradeSummaryGroup string
+
+const (
+	tradeSummaryGroupTicker    tradeSummaryGroup = "ticker"
+	tradeSummaryGroupDay       tradeSummaryGroup = "day"
+	tradeSummaryGroupTickerDay tradeSummaryGroup = "ticker,day"
+)
+
+func parseTradeSummaryGroup(value string) (tradeSummaryGroup, error) {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), " ", ""))
+	switch tradeSummaryGroup(normalized) {
+	case tradeSummaryGroupTicker, tradeSummaryGroupDay, tradeSummaryGroupTickerDay:
+		return tradeSummaryGroup(normalized), nil
+	default:
+		return "", fmt.Errorf("invalid group-by %q; valid values: ticker, day, ticker,day", value)
+	}
+}
+
+type tradeGroupAccumulator struct {
+	trades                 int
+	dollars                float64
+	dollarsMultiplier      float64
+	darkPool, sweep        int
+	cumulativeDistribution float64
+}
+
+func summarizeTrades(trades []models.Trade, group tradeSummaryGroup, startDate, endDate string) models.TradeSummary {
+	summary := models.TradeSummary{
+		DateRange: models.TradeSummaryDateRange{Start: startDate, End: endDate},
+	}
+
+	for i := range trades {
+		trade := &trades[i]
+		summary.TotalTrades++
+		summary.TotalDollars += trade.Dollars
+	}
+
+	switch group {
+	case tradeSummaryGroupTicker:
+		summary.ByTicker = summarizeTradeGroups(trades, tradeTickerKey)
+	case tradeSummaryGroupDay:
+		summary.ByDay = summarizeTradeGroups(trades, tradeDayKey)
+	case tradeSummaryGroupTickerDay:
+		summary.ByTickerDay = summarizeTradeGroups(trades, tradeTickerDayKey)
+	}
+
+	return summary
+}
+
+func summarizeTradeGroups(trades []models.Trade, keyFunc func(*models.Trade) string) map[string]models.TradeGroupSummary {
+	groups := make(map[string]tradeGroupAccumulator)
+	for i := range trades {
+		trade := &trades[i]
+		key := keyFunc(trade)
+		acc := groups[key]
+		acc.trades++
+		acc.dollars += trade.Dollars
+		acc.dollarsMultiplier += trade.DollarsMultiplier
+		acc.cumulativeDistribution += trade.CumulativeDistribution
+		if bool(trade.DarkPool) {
+			acc.darkPool++
+		}
+		if bool(trade.Sweep) {
+			acc.sweep++
+		}
+		groups[key] = acc
+	}
+
+	summaries := make(map[string]models.TradeGroupSummary, len(groups))
+	for key, acc := range groups {
+		summaries[key] = acc.summary()
+	}
+	return summaries
+}
+
+func (acc tradeGroupAccumulator) summary() models.TradeGroupSummary {
+	if acc.trades == 0 {
+		return models.TradeGroupSummary{}
+	}
+
+	count := float64(acc.trades)
+	return models.TradeGroupSummary{
+		Trades:                    acc.trades,
+		Dollars:                   acc.dollars,
+		AvgDollarsMultiplier:      acc.dollarsMultiplier / count,
+		PctDarkPool:               float64(acc.darkPool) / count * 100,
+		PctSweep:                  float64(acc.sweep) / count * 100,
+		AvgCumulativeDistribution: acc.cumulativeDistribution / count,
+	}
+}
+
+func tradeTickerKey(trade *models.Trade) string {
+	if trade.Ticker == "" {
+		return "unknown"
+	}
+	return trade.Ticker
+}
+
+func tradeDayKey(trade *models.Trade) string {
+	if !trade.Date.Valid {
+		return "unknown"
+	}
+	return trade.Date.Format("2006-01-02")
+}
+
+func tradeTickerDayKey(trade *models.Trade) string {
+	return tradeTickerKey(trade) + "|" + tradeDayKey(trade)
 }
 
 func runTradeClusters(ctx context.Context, cmd *cli.Command) error {

--- a/internal/models/trade.go
+++ b/internal/models/trade.go
@@ -173,6 +173,32 @@ type Trade struct {
 	ExternalFeed                  FlexBool   `json:"ExternalFeed"`
 }
 
+// TradeSummary represents aggregate trade metrics for a trade list query.
+type TradeSummary struct {
+	TotalTrades  int                          `json:"totalTrades"`
+	TotalDollars float64                      `json:"totalDollars"`
+	DateRange    TradeSummaryDateRange        `json:"dateRange"`
+	ByTicker     map[string]TradeGroupSummary `json:"byTicker,omitempty"`
+	ByDay        map[string]TradeGroupSummary `json:"byDay,omitempty"`
+	ByTickerDay  map[string]TradeGroupSummary `json:"byTickerDay,omitempty"`
+}
+
+// TradeSummaryDateRange records the CLI date range used for a summary query.
+type TradeSummaryDateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// TradeGroupSummary represents aggregate metrics for one summary group.
+type TradeGroupSummary struct {
+	Trades                    int     `json:"trades"`
+	Dollars                   float64 `json:"dollars"`
+	AvgDollarsMultiplier      float64 `json:"avgDollarsMultiplier"`
+	PctDarkPool               float64 `json:"pctDarkPool"`
+	PctSweep                  float64 `json:"pctSweep"`
+	AvgCumulativeDistribution float64 `json:"avgCumulativeDistribution"`
+}
+
 // DataTablesResponse represents the server-side DataTables JSON envelope.
 type DataTablesResponse struct {
 	Draw            int             `json:"draw"`

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -18,7 +18,7 @@ volumeleaders-agent trade presets --pretty | jq '.[].Name'
 Query individual institutional block trades. The primary trade discovery command.
 
 Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
+Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, `--summary`, `--group-by`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
 
 **`--preset NAME`**: Apply a built-in filter preset by name (case-insensitive). The preset sets baseline filters; any explicitly-provided CLI flags override the preset values. Use `trade presets` to list available names.
 
@@ -26,7 +26,11 @@ Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`
 
 **`--fields FIELD1,FIELD2`**: Return only the listed trade fields in each JSON object. Field names are case-sensitive and must match the output field names below. Invalid names fail before querying the API and include the valid field list in the error.
 
-Both flags can be combined: watchlist filters merge on top of preset filters, and explicit CLI flags override both.
+**`--summary`**: Return aggregate metrics instead of individual trade rows. The summary includes `totalTrades`, `totalDollars`, `dateRange`, and one grouped section. Metrics per group are `trades`, `dollars`, `avgDollarsMultiplier`, `pctDarkPool`, `pctSweep`, and `avgCumulativeDistribution`. Summaries respect pagination, use `--length -1` to aggregate all matching rows. `--fields` cannot be used with `--summary`.
+
+**`--group-by VALUE`**: Select the summary grouping. Valid values are `ticker` (default, outputs `byTicker`), `day` (outputs `byDay`), and `ticker,day` (outputs `byTickerDay` keys in `TICKER|YYYY-MM-DD` format). Only applies with `--summary`.
+
+Preset and watchlist filters can be combined: watchlist filters merge on top of preset filters, and explicit CLI flags override both.
 
 ```bash
 volumeleaders-agent trade list --tickers AAPL --start-date 2025-04-16 --end-date 2025-04-23 --dark-pools 1 --min-dollars 1000000
@@ -34,6 +38,7 @@ volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 -
 volumeleaders-agent trade list --preset "Megacaps" --start-date 2025-04-01 --end-date 2025-04-24 --trade-rank 10
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars,DollarsMultiplier,DarkPool,CumulativeDistribution
+volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --summary --group-by ticker,day
 ```
 
 Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`


### PR DESCRIPTION
Adds `trade list --summary` for aggregate trade output so agent workflows can consume compact totals instead of raw trade rows.

- Supports `--group-by ticker`, `day`, and `ticker,day`
- Adds summary models and pagination-aware aggregation with `--length -1`
- Documents the new flags in `skills/trade.md`

Closes #12

Verification:
- `go test ./...`
- `make lint`
- `make build`