### PR TITLE
Add leveraged ETF sentiment command

### DIFF
--- a/internal/commands/app_test.go
+++ b/internal/commands/app_test.go
@@ -50,7 +50,7 @@ func TestNewAppSubcommandCounts(t *testing.T) {
 	app := NewApp("0.0.0")
 
 	expected := map[string]int{
-		"trade":     9,
+		"trade":     10,
 		"volume":    3,
 		"chart":     4,
 		"market":    3,

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -23,6 +24,12 @@ func TestTradeRunFunctions(t *testing.T) {
 			name: "list",
 			cmd:  newTradeListCommand,
 			args: []string{"app", "list", "--start-date", "2025-01-01", "--end-date", "2025-01-31"},
+			path: "/Trades/GetTrades",
+		},
+		{
+			name: "sentiment",
+			cmd:  newTradeSentimentCommand,
+			args: []string{"app", "sentiment", "--start-date", "2025-01-01", "--end-date", "2025-01-31"},
 			path: "/Trades/GetTrades",
 		},
 		{
@@ -81,6 +88,189 @@ func TestTradeRunFunctions(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestTradeSentimentAggregatesLeveragedFlow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"SH","Sector":"X Bear","Dollars":886000000},
+			{"Date":"/Date(1745193600000)/","Ticker":"TQQQ","Sector":"X Bull","Dollars":68000000},
+			{"Date":"/Date(1745280000000)/","Ticker":"SQQQ","Industry":"X Bear","Dollars":51000000},
+			{"Date":"/Date(1745280000000)/","Ticker":"SOXL","Industry":"X Bull","Dollars":102000000},
+			{"Date":"/Date(1745280000000)/","Ticker":"AAPL","Sector":"Technology","Dollars":999999999}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeSentimentCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "sentiment",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-22",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSentiment
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal sentiment output: %v", err)
+	}
+	if got.DateRange.Start != "2025-04-21" || got.DateRange.End != "2025-04-22" {
+		t.Fatalf("unexpected date range: %#v", got.DateRange)
+	}
+	if len(got.Daily) != 2 {
+		t.Fatalf("expected two daily rows, got %d", len(got.Daily))
+	}
+
+	monday := got.Daily[0]
+	if monday.Date != "2025-04-21" {
+		t.Fatalf("expected first day 2025-04-21, got %s", monday.Date)
+	}
+	if monday.Bear.Trades != 1 || monday.Bear.Dollars != 886000000 {
+		t.Fatalf("unexpected Monday bear summary: %#v", monday.Bear)
+	}
+	if monday.Bull.Trades != 1 || monday.Bull.Dollars != 68000000 {
+		t.Fatalf("unexpected Monday bull summary: %#v", monday.Bull)
+	}
+	if monday.Ratio == nil || *monday.Ratio < 0.076 || *monday.Ratio > 0.077 {
+		t.Fatalf("unexpected Monday ratio: %v", monday.Ratio)
+	}
+	if monday.Signal != models.TradeSentimentExtremeBear {
+		t.Fatalf("expected Monday extreme bear signal, got %s", monday.Signal)
+	}
+	if strings.Join(monday.Bear.TopTickers, ",") != "SH" {
+		t.Fatalf("unexpected Monday bear top tickers: %#v", monday.Bear.TopTickers)
+	}
+	if strings.Join(monday.Bull.TopTickers, ",") != "TQQQ" {
+		t.Fatalf("unexpected Monday bull top tickers: %#v", monday.Bull.TopTickers)
+	}
+
+	tuesday := got.Daily[1]
+	if tuesday.Ratio == nil || *tuesday.Ratio != 2.0 {
+		t.Fatalf("unexpected Tuesday ratio: %v", tuesday.Ratio)
+	}
+	if tuesday.Signal != models.TradeSentimentNeutral {
+		t.Fatalf("expected Tuesday neutral signal at 2.0 boundary, got %s", tuesday.Signal)
+	}
+	if got.Totals.Bear.Trades != 2 || got.Totals.Bull.Trades != 2 {
+		t.Fatalf("unexpected totals: %#v", got.Totals)
+	}
+}
+
+func TestTradeSentimentUsesCombinedLeverageFilter(t *testing.T) {
+	var body string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		fmt.Fprint(w, dataTablesJSON(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeSentimentCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "sentiment",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-25",
+			"--min-dollars", "7000000",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"SectorIndustry=X+B", "VCD=97", "MinDollars=7000000", "length=1000"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected request body to contain %q, got %s", want, body)
+		}
+	}
+}
+
+func TestTradeSentimentRejectsMalformedPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`{"not":"a trade array"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	root := &cli.Command{Commands: []*cli.Command{newTradeSentimentCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "sentiment",
+		"--start-date", "2025-04-21",
+		"--end-date", "2025-04-25",
+	})
+	assertErrContains(t, err, "query trade sentiment: decode response")
+}
+
+func TestTradeSentimentTickerFallbackClassifiesCWEBAsBull(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"CWEB","Sector":"ETF","Industry":"China","Name":"ProShares Ultra China ETF","Dollars":25000000},
+			{"Date":"/Date(1745193600000)/","Ticker":"SH","Sector":"ETF","Industry":"Index","Name":"Short S&P 500 ETF","Dollars":5000000}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeSentimentCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "sentiment",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSentiment
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal sentiment output: %v", err)
+	}
+	if got.Totals.Bull.Trades != 1 || got.Totals.Bull.Dollars != 25000000 {
+		t.Fatalf("expected CWEB to be classified as bull, got %#v", got.Totals.Bull)
+	}
+	if strings.Join(got.Totals.Bull.TopTickers, ",") != "CWEB" {
+		t.Fatalf("unexpected bull top tickers: %#v", got.Totals.Bull.TopTickers)
+	}
+}
+
+func TestTradeSentimentNoBearFlowUsesNullRatioAndExtremeBull(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"TQQQ","Sector":"X Bull","Dollars":75000000}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeSentimentCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "sentiment",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSentiment
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal sentiment output: %v", err)
+	}
+	if got.Totals.Ratio != nil {
+		t.Fatalf("expected nil total ratio with no bear flow, got %v", got.Totals.Ratio)
+	}
+	if got.Totals.Signal != models.TradeSentimentExtremeBull {
+		t.Fatalf("expected extreme bull signal, got %s", got.Totals.Signal)
 	}
 }
 

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -2,9 +2,14 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
+	"sort"
+	"strings"
 
+	"github.com/major/volumeleaders-agent/internal/client"
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
@@ -40,6 +45,7 @@ func NewTradeCommand() *cli.Command {
 		Usage: "Trade-related commands",
 		Commands: []*cli.Command{
 			newTradeListCommand(),
+			newTradeSentimentCommand(),
 			newTradePresetsCommand(),
 			newTradePresetTickersCommand(),
 			newTradeClustersCommand(),
@@ -49,6 +55,43 @@ func NewTradeCommand() *cli.Command {
 			newTradeLevelsCommand(),
 			newTradeLevelTouchesCommand(),
 		},
+	}
+}
+
+func newTradeSentimentCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "sentiment",
+		Usage: "Summarize leveraged ETF bull/bear flow by day",
+		UsageText: `volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25
+volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --min-dollars 5000000`,
+		Flags: slices.Concat(
+			dateRangeFlags(),
+			volumeRangeFlags(),
+			priceRangeFlags(),
+			dollarRangeFlags(5000000),
+			[]cli.Flag{
+				&cli.IntFlag{Name: "conditions", Value: -1, Usage: "Trade conditions filter"},
+				&cli.IntFlag{Name: "vcd", Value: 97, Usage: "VCD filter"},
+				&cli.IntFlag{Name: "security-type", Value: -1, Usage: "Security type key"},
+				&cli.IntFlag{Name: "relative-size", Value: 5, Usage: "Relative size threshold"},
+				&cli.IntFlag{Name: "dark-pools", Value: -1, Usage: "Dark pool filter"},
+				&cli.IntFlag{Name: "sweeps", Value: -1, Usage: "Sweep filter"},
+				&cli.IntFlag{Name: "late-prints", Value: -1, Usage: "Late print filter"},
+				&cli.IntFlag{Name: "sig-prints", Value: -1, Usage: "Signature print filter"},
+				&cli.IntFlag{Name: "even-shared", Value: -1, Usage: "Even shared filter"},
+				&cli.IntFlag{Name: "trade-rank", Value: -1, Usage: "Trade rank filter"},
+				&cli.IntFlag{Name: "rank-snapshot", Value: -1, Usage: "Trade rank snapshot filter"},
+				&cli.IntFlag{Name: "market-cap", Value: 0, Usage: "Market cap filter"},
+				&cli.IntFlag{Name: "premarket", Value: 1, Usage: "Include premarket"},
+				&cli.IntFlag{Name: "rth", Value: 1, Usage: "Include regular trading hours"},
+				&cli.IntFlag{Name: "ah", Value: 1, Usage: "Include after hours"},
+				&cli.IntFlag{Name: "opening", Value: 1, Usage: "Include opening trades"},
+				&cli.IntFlag{Name: "closing", Value: 1, Usage: "Include closing trades"},
+				&cli.IntFlag{Name: "phantom", Value: 1, Usage: "Include phantom prints"},
+				&cli.IntFlag{Name: "offsetting", Value: 1, Usage: "Include offsetting trades"},
+			},
+		),
+		Action: runTradeSentiment,
 	}
 }
 
@@ -323,6 +366,52 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		"query trades")
 }
 
+func runTradeSentiment(ctx context.Context, cmd *cli.Command) error {
+	opts := &tradesOptions{
+		startDate:    cmd.String("start-date"),
+		endDate:      cmd.String("end-date"),
+		minVolume:    cmd.Int("min-volume"),
+		maxVolume:    cmd.Int("max-volume"),
+		minPrice:     cmd.Float("min-price"),
+		maxPrice:     cmd.Float("max-price"),
+		minDollars:   cmd.Float("min-dollars"),
+		maxDollars:   cmd.Float("max-dollars"),
+		conditions:   cmd.Int("conditions"),
+		vcd:          cmd.Int("vcd"),
+		securityType: cmd.Int("security-type"),
+		relativeSize: cmd.Int("relative-size"),
+		darkPools:    cmd.Int("dark-pools"),
+		sweeps:       cmd.Int("sweeps"),
+		latePrints:   cmd.Int("late-prints"),
+		sigPrints:    cmd.Int("sig-prints"),
+		evenShared:   cmd.Int("even-shared"),
+		tradeRank:    cmd.Int("trade-rank"),
+		rankSnapshot: cmd.Int("rank-snapshot"),
+		marketCap:    cmd.Int("market-cap"),
+		premarket:    cmd.Int("premarket"),
+		rth:          cmd.Int("rth"),
+		ah:           cmd.Int("ah"),
+		opening:      cmd.Int("opening"),
+		closing:      cmd.Int("closing"),
+		phantom:      cmd.Int("phantom"),
+		offsetting:   cmd.Int("offsetting"),
+		sector:       "X B",
+	}
+	filters := buildTradeFilters(opts)
+	trades, err := fetchAllTradeSentimentTrades(ctx, dataTableOptions{
+		start:    0,
+		length:   -1,
+		orderCol: 1,
+		orderDir: "desc",
+		filters:  filters,
+	})
+	if err != nil {
+		return err
+	}
+
+	return printJSON(ctx, summarizeTradeSentiment(trades, cmd.String("start-date"), cmd.String("end-date")))
+}
+
 func runTradeClusters(ctx context.Context, cmd *cli.Command) error {
 	return runDataTablesCommand[models.TradeCluster](ctx, "/TradeClusters/GetTradeClusters", datatables.TradeClusterColumns,
 		dataTableOptions{
@@ -435,6 +524,245 @@ func runTradeLevelTouches(ctx context.Context, cmd *cli.Command) error {
 				"TradeLevelRank": intStr(cmd.Int("trade-level-rank")),
 			},
 		}, cmd.String("format"), "query trade level touches")
+}
+
+func fetchAllTradeSentimentTrades(ctx context.Context, opts dataTableOptions) ([]models.Trade, error) {
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchAllTradeSentimentPages(ctx, vlClient, opts)
+}
+
+func fetchAllTradeSentimentPages(ctx context.Context, vlClient *client.Client, opts dataTableOptions) ([]models.Trade, error) {
+	opts.length = paginationPageSize
+	all := make([]models.Trade, 0)
+
+	for {
+		request := newDataTablesRequest(datatables.TradeColumns, opts)
+		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
+		if err != nil {
+			slog.Error("failed to query trade sentiment", "error", err)
+			return nil, fmt.Errorf("query trade sentiment: %w", err)
+		}
+
+		var page []models.Trade
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
+			slog.Error("failed to decode trade sentiment response", "error", err)
+			return nil, fmt.Errorf("query trade sentiment: decode response: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+
+		all = append(all, page...)
+		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
+			break
+		}
+		if len(page) < paginationPageSize {
+			break
+		}
+
+		opts.start += len(page)
+	}
+
+	return all, nil
+}
+
+type tradeSentimentAccumulator struct {
+	trades        int
+	dollars       float64
+	tickerDollars map[string]float64
+}
+
+type tradeSentimentDayAccumulator struct {
+	bear tradeSentimentAccumulator
+	bull tradeSentimentAccumulator
+}
+
+func summarizeTradeSentiment(trades []models.Trade, startDate, endDate string) models.TradeSentiment {
+	byDay := make(map[string]*tradeSentimentDayAccumulator)
+	var totals tradeSentimentDayAccumulator
+
+	for i := range trades {
+		trade := &trades[i]
+		if !trade.Date.Valid {
+			continue
+		}
+
+		side := classifyTradeSentimentSide(trade)
+		if side == "" {
+			continue
+		}
+
+		day := trade.Date.Format("2006-01-02")
+		acc, ok := byDay[day]
+		if !ok {
+			acc = &tradeSentimentDayAccumulator{}
+			byDay[day] = acc
+		}
+
+		acc.add(side, trade)
+		totals.add(side, trade)
+	}
+
+	days := make([]string, 0, len(byDay))
+	for day := range byDay {
+		days = append(days, day)
+	}
+	sort.Strings(days)
+
+	daily := make([]models.TradeSentimentDay, 0, len(days))
+	for _, day := range days {
+		daily = append(daily, byDay[day].summary(day))
+	}
+
+	return models.TradeSentiment{
+		DateRange: models.TradeSentimentDateRange{Start: startDate, End: endDate},
+		Daily:     daily,
+		Totals:    totals.summaryTotals(),
+	}
+}
+
+func (a *tradeSentimentDayAccumulator) add(side string, trade *models.Trade) {
+	switch side {
+	case "bear":
+		a.bear.add(trade)
+	case "bull":
+		a.bull.add(trade)
+	}
+}
+
+func (a *tradeSentimentAccumulator) add(trade *models.Trade) {
+	if a.tickerDollars == nil {
+		a.tickerDollars = make(map[string]float64)
+	}
+	a.trades++
+	a.dollars += trade.Dollars
+	a.tickerDollars[trade.Ticker] += trade.Dollars
+}
+
+func (a tradeSentimentDayAccumulator) summary(day string) models.TradeSentimentDay {
+	ratio := tradeSentimentRatio(a.bull.dollars, a.bear.dollars)
+	return models.TradeSentimentDay{
+		Date:   day,
+		Bear:   a.bear.summary(),
+		Bull:   a.bull.summary(),
+		Ratio:  ratio,
+		Signal: tradeSentimentSignal(ratio, a.bull.dollars, a.bear.dollars),
+	}
+}
+
+func (a tradeSentimentDayAccumulator) summaryTotals() models.TradeSentimentTotals {
+	ratio := tradeSentimentRatio(a.bull.dollars, a.bear.dollars)
+	return models.TradeSentimentTotals{
+		Bear:   a.bear.summary(),
+		Bull:   a.bull.summary(),
+		Ratio:  ratio,
+		Signal: tradeSentimentSignal(ratio, a.bull.dollars, a.bear.dollars),
+	}
+}
+
+func (a tradeSentimentAccumulator) summary() models.TradeSentimentSide {
+	return models.TradeSentimentSide{
+		Trades:     a.trades,
+		Dollars:    a.dollars,
+		TopTickers: topTradeSentimentTickers(a.tickerDollars, 3),
+	}
+}
+
+func tradeSentimentRatio(bullDollars, bearDollars float64) *float64 {
+	if bearDollars == 0 {
+		return nil
+	}
+	ratio := bullDollars / bearDollars
+	return &ratio
+}
+
+func tradeSentimentSignal(ratio *float64, bullDollars, bearDollars float64) models.TradeSentimentSignal {
+	if ratio == nil {
+		switch {
+		case bullDollars > 0:
+			return models.TradeSentimentExtremeBull
+		case bearDollars > 0:
+			return models.TradeSentimentExtremeBear
+		default:
+			return models.TradeSentimentNeutral
+		}
+	}
+
+	switch {
+	case *ratio < 0.2:
+		return models.TradeSentimentExtremeBear
+	case *ratio < 0.5:
+		return models.TradeSentimentModerateBear
+	case *ratio <= 2.0:
+		return models.TradeSentimentNeutral
+	case *ratio <= 5.0:
+		return models.TradeSentimentModerateBull
+	default:
+		return models.TradeSentimentExtremeBull
+	}
+}
+
+type tradeSentimentTickerTotal struct {
+	ticker  string
+	dollars float64
+}
+
+func topTradeSentimentTickers(tickerDollars map[string]float64, limit int) []string {
+	if len(tickerDollars) == 0 {
+		return []string{}
+	}
+
+	totals := make([]tradeSentimentTickerTotal, 0, len(tickerDollars))
+	for ticker, dollars := range tickerDollars {
+		totals = append(totals, tradeSentimentTickerTotal{ticker: ticker, dollars: dollars})
+	}
+	sort.Slice(totals, func(i, j int) bool {
+		if totals[i].dollars == totals[j].dollars {
+			return totals[i].ticker < totals[j].ticker
+		}
+		return totals[i].dollars > totals[j].dollars
+	})
+
+	if len(totals) < limit {
+		limit = len(totals)
+	}
+	tickers := make([]string, 0, limit)
+	for _, total := range totals[:limit] {
+		tickers = append(tickers, total.ticker)
+	}
+	return tickers
+}
+
+func classifyTradeSentimentSide(trade *models.Trade) string {
+	fields := []string{trade.Sector, trade.Name}
+	if trade.Industry != nil {
+		fields = append(fields, *trade.Industry)
+	}
+	for _, field := range fields {
+		field = strings.ToLower(field)
+		switch {
+		case strings.Contains(field, "bear"):
+			return "bear"
+		case strings.Contains(field, "bull"):
+			return "bull"
+		}
+	}
+
+	return leveragedETFDirection(trade.Ticker)
+}
+
+func leveragedETFDirection(ticker string) string {
+	switch strings.ToUpper(strings.TrimSpace(ticker)) {
+	case "AAPD", "AMDD", "BERZ", "BITI", "BNKD", "BZQ", "DUST", "EDZ", "ERY", "FAZ", "HIBS", "KOLD", "LABD", "MEXZ", "MYY", "NVDD", "QID", "REK", "REW", "RXD", "SARK", "SCO", "SDD", "SDOW", "SDS", "SEF", "SH", "SMDD", "SOXS", "SPDN", "SPXU", "SPXS", "SQQQ", "SRS", "SSG", "SVIX", "TSDD", "TSLQ", "TSLS", "TZA", "UVIX", "WEBS", "YANG", "YCS", "ZSL":
+		return "bear"
+	case "AAPU", "AMDL", "BITU", "BOIL", "BRZU", "CURE", "CWEB", "DFEN", "DIG", "DPST", "DRN", "EDC", "ERX", "FAS", "FNGU", "GUSH", "HIBL", "LABU", "MIDU", "NAIL", "NVDL", "QLD", "ROM", "SOXL", "SPXL", "SSO", "TECL", "TMF", "TNA", "TQQQ", "TSLL", "TURB", "UDOW", "UMDD", "UPRO", "URTY", "USD", "UWM", "WEBL", "YINN":
+		return "bull"
+	default:
+		return ""
+	}
 }
 
 // --- Filter builders ---

--- a/internal/models/trade.go
+++ b/internal/models/trade.go
@@ -174,6 +174,54 @@ type Trade struct {
 	ExternalFeed                  FlexBool   `json:"ExternalFeed"`
 }
 
+// TradeSentiment summarizes bull/bear leveraged ETF flow over a date range.
+type TradeSentiment struct {
+	DateRange TradeSentimentDateRange `json:"dateRange"`
+	Daily     []TradeSentimentDay     `json:"daily"`
+	Totals    TradeSentimentTotals    `json:"totals"`
+}
+
+// TradeSentimentDateRange is the CLI date range used for sentiment analysis.
+type TradeSentimentDateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// TradeSentimentDay summarizes leveraged ETF flow for one trading day.
+type TradeSentimentDay struct {
+	Date   string               `json:"date"`
+	Bear   TradeSentimentSide   `json:"bear"`
+	Bull   TradeSentimentSide   `json:"bull"`
+	Ratio  *float64             `json:"ratio"`
+	Signal TradeSentimentSignal `json:"signal"`
+}
+
+// TradeSentimentSide summarizes one side of leveraged ETF sentiment.
+type TradeSentimentSide struct {
+	Trades     int      `json:"trades"`
+	Dollars    float64  `json:"dollars"`
+	TopTickers []string `json:"topTickers"`
+}
+
+// TradeSentimentTotals summarizes leveraged ETF flow for the whole date range.
+type TradeSentimentTotals struct {
+	Bear   TradeSentimentSide   `json:"bear"`
+	Bull   TradeSentimentSide   `json:"bull"`
+	Ratio  *float64             `json:"ratio"`
+	Signal TradeSentimentSignal `json:"signal"`
+}
+
+// TradeSentimentSignal labels the bull/bear flow ratio for quick interpretation.
+type TradeSentimentSignal string
+
+const (
+	TradeSentimentExtremeBear  TradeSentimentSignal = "extreme_bear"
+	TradeSentimentModerateBear TradeSentimentSignal = "moderate_bear"
+	TradeSentimentNeutral      TradeSentimentSignal = "neutral"
+	TradeSentimentModerateBull TradeSentimentSignal = "moderate_bull"
+	TradeSentimentExtremeBull  TradeSentimentSignal = "extreme_bull"
+)
+
 // DataTablesResponse represents the server-side DataTables JSON envelope.
 type DataTablesResponse struct {
 	Draw            int             `json:"draw"`

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -11,6 +11,7 @@ Output: compact JSON to stdout by default. List-style commands support `--format
 | I want to... | Command |
 |---|---|
 | Find large institutional trades in specific stocks | `trade list --tickers X --start-date D --end-date D` |
+| Compare leveraged ETF bull/bear flow | `trade sentiment --start-date D --end-date D` |
 | See where institutions are clustering trades | `trade clusters --start-date D --end-date D` |
 | Detect sudden aggressive institutional bursts | `trade cluster-bombs --start-date D --end-date D` |
 | Check system-flagged individual trade alerts | `trade alerts --date D` |
@@ -51,7 +52,7 @@ Chain commands for deeper analysis:
 
 **Output formats**: list-style object outputs accept `--format json|csv|tsv` (default `json`). CSV/TSV use output field names as headers. `--pretty` only affects JSON.
 
-**Ticker flags**: `--tickers` takes comma-separated list (multi-ticker commands). `--ticker` takes a single symbol (single-ticker commands). All trade subcommands also accept `--ticker`, `--tickers`, `--symbol`, and `--symbols` as aliases, so any form works on any command.
+**Ticker flags**: `--tickers` takes comma-separated list (multi-ticker commands). `--ticker` takes a single symbol (single-ticker commands). Ticker-based trade subcommands accept `--ticker`, `--tickers`, `--symbol`, and `--symbols` aliases, so any form works there. `trade sentiment` intentionally does not accept ticker flags because it always analyzes the leveraged ETF universe.
 
 ## Shared Flag Defaults
 
@@ -83,6 +84,8 @@ These defaults apply across trade commands unless overridden (overrides noted pe
 | `--offsetting` | 1 | Session toggle |
 
 **Chart commands use different flag names** for some of these. See chart.md for the exact mapping.
+
+**Trade sentiment overrides**: `trade sentiment` defaults to `--min-dollars 5000000` and `--vcd 97` because leveraged ETF sentiment is meant to highlight unusually large, high-confirmation flow.
 
 ## Key Metrics Glossary
 

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -1,6 +1,6 @@
 # trade
 
-Institutional trade discovery. 9 subcommands. See SKILL.md for shared flag defaults and metrics glossary.
+Institutional trade discovery. 10 subcommands. See SKILL.md for shared flag defaults and metrics glossary.
 
 ## trade presets
 
@@ -62,6 +62,20 @@ volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2025-04-21 --end
 ```
 
 Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RelativeSize`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`
+
+## trade sentiment
+
+Summarize leveraged ETF institutional flow into daily bull/bear ratios. The command queries the combined leveraged ETF sector filter (`SectorIndustry=X B`) once, classifies bull and bear rows locally, aggregates dollars by day, and returns compact JSON for sentiment analysis.
+
+Required: `--start-date`, `--end-date`
+Optional: volume/price/dollar ranges, trade filters, trade type toggles, session toggles
+Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`, `--relative-size 5`
+
+```bash
+volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --min-dollars 5000000
+```
+
+Output fields: `dateRange` (`start`, `end`), `daily` array, and `totals`. Each daily row includes `date`, `bear`, `bull`, `ratio`, and `signal`. `bear`, `bull`, and total side objects include `trades`, `dollars`, and `topTickers`. `ratio` is bull dollars divided by bear dollars; it is `null` when there is no bear flow. Signals use thresholds: `<0.2` `extreme_bear`, `<0.5` `moderate_bear`, `0.5-2.0` `neutral`, `>2.0-5.0` `moderate_bull`, `>5.0` `extreme_bull`.
 
 ## trade clusters
 


### PR DESCRIPTION
Closes #15.

## Summary
- Add `trade sentiment` for leveraged ETF bull/bear flow ratios by day.
- Aggregate bear/bull dollars, top tickers, ratio, and signal totals in compact JSON.
- Document the new command and shared skill chooser behavior.

## Verification
- `go test ./...`
- `make lint`
- `make build`