### PR TITLE
chore(go): upgrade to go 1.26

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gocritic
     - gosec
     - misspell
+    - modernize
     - nolintlint
     - revive
     - unconvert

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make lint
 
 ## Development
 
-**Requirements:** Go 1.24 or later.
+**Requirements:** Go 1.26 or later.
 
 Linting uses [golangci-lint](https://golangci-lint.run/) with the config in `.golangci.yml`. Run `make lint` before submitting.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/major/volumeleaders-agent
 
-go 1.24.0
+go 1.26.0
+
+toolchain go1.26.2
 
 require (
 	github.com/browserutils/kooky v0.2.9

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -49,8 +49,8 @@ func ExtractCookies(ctx context.Context) (map[string]string, error) {
 }
 
 // FetchXSRFToken retrieves the hidden request verification token from ExecutiveSummary.
-func FetchXSRFToken(httpClient *http.Client, cookies map[string]string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, "https://www.volumeleaders.com/ExecutiveSummary", http.NoBody)
+func FetchXSRFToken(ctx context.Context, httpClient *http.Client, cookies map[string]string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.volumeleaders.com/ExecutiveSummary", http.NoBody)
 	if err != nil {
 		return "", fmt.Errorf("create XSRF token request: %w", err)
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"compress/gzip"
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -125,7 +127,7 @@ func TestFetchXSRFToken(t *testing.T) {
 			client := server.Client()
 			client.Transport = rewriteHostTransport{base: client.Transport, target: server.URL}
 
-			token, err := FetchXSRFToken(client, map[string]string{
+			token, err := FetchXSRFToken(t.Context(), client, map[string]string{
 				"ASP.NET_SessionId": "session-cookie",
 				".ASPXAUTH":         "auth-cookie",
 			})
@@ -145,6 +147,32 @@ func TestFetchXSRFToken(t *testing.T) {
 				t.Errorf("expected token %q, got %q", tt.wantToken, token)
 			}
 		})
+	}
+}
+
+func TestFetchXSRFToken_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `<input name="__RequestVerificationToken" type="hidden" value="token-123" />`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := server.Client()
+	client.Transport = rewriteHostTransport{base: client.Transport, target: server.URL}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	_, err := FetchXSRFToken(ctx, client, map[string]string{
+		"ASP.NET_SessionId": "session-cookie",
+		".ASPXAUTH":         "auth-cookie",
+	})
+	if err == nil {
+		t.Fatal("expected error from canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -50,7 +50,7 @@ func New(ctx context.Context) (*Client, error) {
 	}
 
 	httpClient := &http.Client{Timeout: 60 * time.Second}
-	xsrfToken, err := auth.FetchXSRFToken(httpClient, cookies)
+	xsrfToken, err := auth.FetchXSRFToken(ctx, httpClient, cookies)
 	if err != nil {
 		return nil, fmt.Errorf("fetch XSRF token: %w", err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -98,7 +97,7 @@ func TestPostDataTables(t *testing.T) {
 
 			client := newTestClient(server.URL)
 			var got []string
-			err := client.PostDataTables(context.Background(), "/datatable", "draw=1", &got)
+			err := client.PostDataTables(t.Context(), "/datatable", "draw=1", &got)
 			assertErrorContains(t, err, tt.wantErr)
 			if tt.wantErr != "" {
 				return
@@ -135,7 +134,7 @@ func TestPostJSON(t *testing.T) {
 		var got struct {
 			OK bool `json:"ok"`
 		}
-		if err := client.PostJSON(context.Background(), "/json", map[string]string{"symbol": "AAPL"}, &got); err != nil {
+		if err := client.PostJSON(t.Context(), "/json", map[string]string{"symbol": "AAPL"}, &got); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if !got.OK {
@@ -147,7 +146,7 @@ func TestPostJSON(t *testing.T) {
 		t.Parallel()
 
 		client := newTestClient("http://example.test")
-		err := client.PostJSON(context.Background(), "/json", map[string]any{"bad": make(chan int)}, &struct{}{})
+		err := client.PostJSON(t.Context(), "/json", map[string]any{"bad": make(chan int)}, &struct{}{})
 		assertErrorContains(t, err, "marshal JSON request")
 	})
 
@@ -160,7 +159,7 @@ func TestPostJSON(t *testing.T) {
 		t.Cleanup(server.Close)
 
 		client := newTestClient(server.URL)
-		err := client.PostJSON(context.Background(), "/json", map[string]string{"ok": "true"}, &struct{}{})
+		err := client.PostJSON(t.Context(), "/json", map[string]string{"ok": "true"}, &struct{}{})
 		assertErrorContains(t, err, "status 500")
 	})
 }
@@ -215,7 +214,7 @@ func TestPostForm(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			client := newTestClient(server.URL)
-			err := client.PostForm(context.Background(), "/form", url.Values{"ticker": {"AAPL"}}, tt.result)
+			err := client.PostForm(t.Context(), "/form", url.Values{"ticker": {"AAPL"}}, tt.result)
 			assertErrorContains(t, err, tt.wantErr)
 			if tt.wantName != "" {
 				got := tt.result.(*struct{ Name string `json:"name"` })
@@ -263,7 +262,7 @@ func TestPostMultipart(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			client := newTestClient(server.URL)
-			err := client.PostMultipart(context.Background(), "/multipart", map[string]string{"ticker": "AAPL"})
+			err := client.PostMultipart(t.Context(), "/multipart", map[string]string{"ticker": "AAPL"})
 			assertErrorContains(t, err, tt.wantErr)
 		})
 	}
@@ -417,7 +416,7 @@ func TestPostDataTablesDataDecodeError(t *testing.T) {
 
 	c := newTestClient(server.URL)
 	var got []string
-	err := c.PostDataTables(context.Background(), "/test", "draw=1", &got)
+	err := c.PostDataTables(t.Context(), "/test", "draw=1", &got)
 	assertErrorContains(t, err, "decode DataTables data")
 }
 
@@ -431,7 +430,7 @@ func TestPostJSONDecodeError(t *testing.T) {
 
 	c := newTestClient(server.URL)
 	var got struct{ Name string }
-	err := c.PostJSON(context.Background(), "/test", struct{}{}, &got)
+	err := c.PostJSON(t.Context(), "/test", struct{}{}, &got)
 	assertErrorContains(t, err, "decode JSON response")
 }
 
@@ -445,7 +444,7 @@ func TestPostFormDecodeError(t *testing.T) {
 
 	c := newTestClient(server.URL)
 	var got struct{ Name string }
-	err := c.PostForm(context.Background(), "/test", url.Values{"key": {"val"}}, &got)
+	err := c.PostForm(t.Context(), "/test", url.Values{"key": {"val"}}, &got)
 	assertErrorContains(t, err, "decode form response")
 }
 
@@ -456,7 +455,7 @@ func TestDoRequestConnectionError(t *testing.T) {
 	server.Close()
 
 	c := newTestClient(server.URL)
-	err := c.PostJSON(context.Background(), "/test", struct{}{}, &struct{}{})
+	err := c.PostJSON(t.Context(), "/test", struct{}{}, &struct{}{})
 	assertErrorContains(t, err, "post JSON request")
 }
 
@@ -478,7 +477,7 @@ func TestPostMultipartConnectionError(t *testing.T) {
 	server.Close()
 
 	c := newTestClient(server.URL)
-	err := c.PostMultipart(context.Background(), "/test", map[string]string{"key": "val"})
+	err := c.PostMultipart(t.Context(), "/test", map[string]string{"key": "val"})
 	assertErrorContains(t, err, "post multipart request")
 }
 

--- a/internal/commands/alert.go
+++ b/internal/commands/alert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -100,9 +101,9 @@ volumeleaders-agent alert create --name "Dark pool sweeps" --sweep --dark-pool -
 }
 
 func newAlertEditCommand() *cli.Command {
-	flags := append([]cli.Flag{
+	flags := slices.Concat([]cli.Flag{
 		&cli.IntFlag{Name: "key", Required: true, Usage: "Alert config key to edit"},
-	}, alertConfigFlags()...)
+	}, alertConfigFlags())
 	return &cli.Command{
 		Name:      "edit",
 		Usage:     "Edit an existing alert configuration",

--- a/internal/commands/alert_test.go
+++ b/internal/commands/alert_test.go
@@ -20,7 +20,7 @@ func TestRunAlertConfigs(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runAlertConfigs(ctx); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -34,7 +34,7 @@ func TestRunAlertConfigsServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runAlertConfigs(ctx)
 	assertErrContains(t, err, "query alert configs")
 }
@@ -48,7 +48,7 @@ func TestRunAlertDelete(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runAlertDelete(ctx, 42); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -62,7 +62,7 @@ func TestRunAlertDeleteServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runAlertDelete(ctx, 42)
 	assertErrContains(t, err, "delete alert config")
 }
@@ -76,7 +76,7 @@ func TestRunAlertCreate(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
 		if err := root.Run(ctx, []string{"app", "alert", "create", "--name", "Test Alert"}); err != nil {
@@ -97,7 +97,7 @@ func TestRunAlertEdit(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
 		if err := root.Run(ctx, []string{"app", "alert", "edit", "--key", "42"}); err != nil {
@@ -119,7 +119,7 @@ func TestRunAlertCreateWithTickers(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
 		if err := root.Run(ctx, []string{"app", "alert", "create", "--name", "Ticker Alert", "--tickers", "AAPL,MSFT"}); err != nil {
@@ -137,7 +137,7 @@ func TestAlertConfigsCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
 		if err := root.Run(ctx, []string{"app", "alert", "configs"}); err != nil {
@@ -152,7 +152,7 @@ func TestAlertDeleteCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}
 		if err := root.Run(ctx, []string{"app", "alert", "delete", "--key", "42"}); err != nil {
@@ -167,7 +167,7 @@ func TestRunAlertCreateEditServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 
 	t.Run("create", func(t *testing.T) {
 		root := &cli.Command{Commands: []*cli.Command{NewAlertCommand()}}

--- a/internal/commands/chart_test.go
+++ b/internal/commands/chart_test.go
@@ -20,7 +20,7 @@ func TestRunPriceData(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		opts := &priceDataOptions{
 			ticker:    "AAPL",
@@ -39,7 +39,7 @@ func TestRunPriceDataEmptyResponse(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		opts := &priceDataOptions{ticker: "AAPL", startDate: "2025-01-15", endDate: "2025-01-15"}
 		if err := runPriceData(ctx, opts); err != nil {
@@ -57,7 +57,7 @@ func TestRunPriceDataServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	opts := &priceDataOptions{ticker: "AAPL", startDate: "2025-01-15", endDate: "2025-01-15"}
 	err := runPriceData(ctx, opts)
 	assertErrContains(t, err, "query price data")
@@ -72,7 +72,7 @@ func TestRunChartSnapshot(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runChartSnapshot(ctx, "AAPL", "2025-01-15"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -86,7 +86,7 @@ func TestRunChartSnapshotServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runChartSnapshot(ctx, "INVALID", "2025-01-15")
 	assertErrContains(t, err, "query chart snapshot")
 }
@@ -100,7 +100,7 @@ func TestRunChartLevels(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		opts := chartLevelsOptions{
 			ticker:    "AAPL",
@@ -123,7 +123,7 @@ func TestRunCompany(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runCompany(ctx, "AAPL"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -137,7 +137,7 @@ func TestRunCompanyServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runCompany(ctx, "INVALID")
 	assertErrContains(t, err, "query company")
 }
@@ -148,7 +148,7 @@ func TestRunPriceDataDecodeError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runPriceData(ctx, &priceDataOptions{ticker: "AAPL", startDate: "2025-01-15", endDate: "2025-01-15"})
 	assertErrContains(t, err, "decode price bars")
 }
@@ -159,7 +159,7 @@ func TestChartPriceDataCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
 		if err := root.Run(ctx, []string{"app", "chart", "price-data", "--ticker", "AAPL", "--start-date", "2025-01-15", "--end-date", "2025-01-15"}); err != nil {
@@ -174,7 +174,7 @@ func TestChartSnapshotCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
 		if err := root.Run(ctx, []string{"app", "chart", "snapshot", "--ticker", "AAPL", "--date-key", "2025-01-15"}); err != nil {
@@ -189,7 +189,7 @@ func TestChartLevelsCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
 		if err := root.Run(ctx, []string{"app", "chart", "levels", "--ticker", "AAPL", "--start-date", "2025-01-01", "--end-date", "2025-01-31"}); err != nil {
@@ -204,7 +204,7 @@ func TestChartCompanyCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
 		if err := root.Run(ctx, []string{"app", "chart", "company", "--ticker", "AAPL"}); err != nil {

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -169,8 +169,7 @@ func jsonFieldNames[T any]() []string {
 	}
 
 	fields := make([]string, 0, typeOf.NumField())
-	for i := range typeOf.NumField() {
-		field := typeOf.Field(i)
+	for field := range typeOf.Fields() {
 		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		switch name {
 		case "", "-":

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -238,7 +238,7 @@ func TestPrintJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.WithValue(context.Background(), prettyJSONKey, tt.pretty)
+			ctx := context.WithValue(t.Context(), prettyJSONKey, tt.pretty)
 
 			oldStdout := os.Stdout
 			r, w, _ := os.Pipe()
@@ -264,7 +264,7 @@ func TestPrintJSON(t *testing.T) {
 }
 
 func TestPrintJSONMarshalError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	err := printJSON(ctx, make(chan int))
 	if err == nil {
 		t.Fatal("expected marshal error")

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -19,7 +19,7 @@ func TestRunSnapshots(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		if err := runSnapshots(ctx); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -39,7 +39,7 @@ func TestRunSnapshotsServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runSnapshots(ctx)
 	assertErrContains(t, err, "query snapshots")
 }
@@ -53,7 +53,7 @@ func TestRunEarnings(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runEarnings(ctx, "2025-01-20", "2025-01-24"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -67,7 +67,7 @@ func TestRunEarningsServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runEarnings(ctx, "2025-01-20", "2025-01-24")
 	assertErrContains(t, err, "query earnings")
 }
@@ -81,7 +81,7 @@ func TestRunExhaustion(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runExhaustion(ctx, "2025-01-15"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestRunExhaustionServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runExhaustion(ctx, "2025-01-15")
 	assertErrContains(t, err, "query exhaustion scores")
 }
@@ -109,7 +109,7 @@ func TestMarketSnapshotsCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
 		if err := root.Run(ctx, []string{"app", "market", "snapshots"}); err != nil {
@@ -130,7 +130,7 @@ func TestMarketEarningsCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
 		if err := root.Run(ctx, []string{"app", "market", "earnings", "--start-date", "2025-01-20", "--end-date", "2025-01-24"}); err != nil {
@@ -148,7 +148,7 @@ func TestMarketExhaustionCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
 		if err := root.Run(ctx, []string{"app", "market", "exhaustion", "--date", "2025-01-15"}); err != nil {

--- a/internal/commands/presets.go
+++ b/internal/commands/presets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -55,9 +56,7 @@ func buildPresets() []tradePreset {
 			"RelativeSize":      "0",
 			"TradeCount":        "3",
 		}
-		for k, v := range extra {
-			f[k] = v
-		}
+		maps.Copy(f, extra)
 		return tradePreset{name: name, group: "Common", filters: f}
 	}
 
@@ -73,9 +72,7 @@ func buildPresets() []tradePreset {
 			"MinVolume":         "10000",
 			"TradeCount":        "3",
 		}
-		for k, v := range extra {
-			f[k] = v
-		}
+		maps.Copy(f, extra)
 		return tradePreset{name: name, group: "Disproportionately Large", filters: f}
 	}
 

--- a/internal/commands/run_helpers_test.go
+++ b/internal/commands/run_helpers_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestNewCommandClientWithTestClient(t *testing.T) {
 	t.Parallel()
-	ctx := contextWithTestClient("http://example.test")
+	ctx := contextWithTestClient(t, "http://example.test")
 	c, err := newCommandClient(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -37,7 +37,7 @@ func TestRunDataTablesCommand(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
@@ -58,7 +58,7 @@ func TestRunDataTablesCommandPrettyJSON(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	ctx = addPrettyJSON(ctx)
 	output := captureStdout(t, func() {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
@@ -81,7 +81,7 @@ func TestRunDataTablesCommandServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 		datatables.TradeColumns,
 		dataTableOptions{start: 0, length: 100, orderCol: 1, orderDir: "desc"},
@@ -97,7 +97,7 @@ func TestPaginatedCommandSinglePage(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
@@ -141,7 +141,7 @@ func TestPaginatedCommandMultiPage(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
@@ -171,7 +171,7 @@ func TestPaginatedCommandEmptyResults(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 			datatables.TradeColumns,
@@ -195,7 +195,7 @@ func TestPaginatedCommandServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runDataTablesCommand[models.Trade](ctx, "/Test/GetData",
 		datatables.TradeColumns,
 		dataTableOptions{start: 0, length: -1, orderCol: 1, orderDir: "desc"},

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -73,7 +73,7 @@ func TestTradeRunFunctions(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			ctx := contextWithTestClient(server.URL)
+			ctx := contextWithTestClient(t, server.URL)
 			captureStdout(t, func() {
 				root := &cli.Command{Commands: []*cli.Command{tt.cmd()}}
 				if err := root.Run(ctx, tt.args); err != nil {
@@ -93,7 +93,7 @@ func TestTradeListFieldsFiltersOutput(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
 		if err := root.Run(ctx, []string{
@@ -125,7 +125,7 @@ func TestTradeListFieldsFiltersOutput(t *testing.T) {
 }
 
 func TestTradeListFieldsRejectsInvalidField(t *testing.T) {
-	ctx := contextWithTestClient("http://127.0.0.1")
+	ctx := contextWithTestClient(t, "http://127.0.0.1")
 	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
 	err := root.Run(ctx, []string{
 		"app", "list",
@@ -162,7 +162,7 @@ func TestTradeListPresetIncludesDefaults(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
 		if err := root.Run(ctx, []string{
@@ -193,7 +193,7 @@ func TestTradeListPresetOverridesDefaults(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
 		if err := root.Run(ctx, []string{
@@ -225,7 +225,7 @@ func TestTradeListExplicitFlagOverridesPreset(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
 		if err := root.Run(ctx, []string{
@@ -255,7 +255,7 @@ func TestTradeRunFunctionServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
 	err := root.Run(ctx, []string{"app", "list", "--start-date", "2025-01-01", "--end-date", "2025-01-31"})
 	assertErrContains(t, err, "query trades")

--- a/internal/commands/testhelpers_test.go
+++ b/internal/commands/testhelpers_test.go
@@ -16,10 +16,11 @@ import (
 
 // contextWithTestClient returns a context carrying a test Client that targets
 // the given base URL. The returned context bypasses browser authentication.
-func contextWithTestClient(baseURL string) context.Context {
+func contextWithTestClient(t *testing.T, baseURL string) context.Context {
+	t.Helper()
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 	c := client.NewForTesting(httpClient, baseURL)
-	return context.WithValue(context.Background(), testClientKey, c)
+	return context.WithValue(t.Context(), testClientKey, c)
 }
 
 // captureStdout calls fn and returns everything written to os.Stdout during

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -270,9 +271,7 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 			if err != nil {
 				return err
 			}
-			for k, v := range preset.filters {
-				filters[k] = v
-			}
+			maps.Copy(filters, preset.filters)
 		}
 
 		if watchlistName != "" {
@@ -280,9 +279,7 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 			if err != nil {
 				return err
 			}
-			for k, v := range wlFilters {
-				filters[k] = v
-			}
+			maps.Copy(filters, wlFilters)
 		}
 
 		// User-explicit CLI flags take final precedence.

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -154,9 +154,9 @@ func newTradeAlertsCommand() *cli.Command {
 		Name:      "alerts",
 		Usage:     "Query trade alerts for a date",
 		UsageText: "volumeleaders-agent trade alerts --date 2025-01-15",
-		Flags: append([]cli.Flag{
+		Flags: slices.Concat([]cli.Flag{
 			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-		}, paginationFlags(100, 1, "desc")...),
+		}, paginationFlags(100, 1, "desc")),
 		Action: runTradeAlerts,
 	}
 }
@@ -166,9 +166,9 @@ func newTradeClusterAlertsCommand() *cli.Command {
 		Name:      "cluster-alerts",
 		Usage:     "Query trade cluster alerts for a date",
 		UsageText: "volumeleaders-agent trade cluster-alerts --date 2025-01-15",
-		Flags: append([]cli.Flag{
+		Flags: slices.Concat([]cli.Flag{
 			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-		}, paginationFlags(100, 1, "desc")...),
+		}, paginationFlags(100, 1, "desc")),
 		Action: runTradeClusterAlerts,
 	}
 }

--- a/internal/commands/trade_test.go
+++ b/internal/commands/trade_test.go
@@ -1,7 +1,8 @@
 package commands
 
 import (
-	"reflect"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -49,12 +50,12 @@ func TestParseJSONFieldList(t *testing.T) {
 				}
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("fields mismatch\nexpected: %#v\ngot:      %#v", tt.want, got)
-			}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.Equal(got, tt.want) {
+			t.Fatalf("fields mismatch\nexpected: %#v\ngot:      %#v", tt.want, got)
+		}
 		})
 	}
 }
@@ -125,7 +126,7 @@ func TestBuildTradeFiltersPreservesAPIKeys(t *testing.T) {
 		"IncludeOffsetting": "1",
 		"SectorIndustry":    "Technology",
 	}
-	if !reflect.DeepEqual(filters, expected) {
+	if !maps.Equal(filters, expected) {
 		t.Fatalf("filters mismatch\nexpected: %#v\ngot:      %#v", expected, filters)
 	}
 }
@@ -164,7 +165,7 @@ func TestBuildTradeLevelFiltersUseLevelDateKeys(t *testing.T) {
 		"TradeLevelRank":  "5",
 		"TradeLevelCount": "20",
 	}
-	if !reflect.DeepEqual(filters, expected) {
+	if !maps.Equal(filters, expected) {
 		t.Fatalf("filters mismatch\nexpected: %#v\ngot:      %#v", expected, filters)
 	}
 }

--- a/internal/commands/volume.go
+++ b/internal/commands/volume.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"slices"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
@@ -15,10 +16,10 @@ type volumeOptions struct {
 
 // volumeFlags returns the shared flag set used by all volume subcommands.
 func volumeFlags() []cli.Flag {
-	return append([]cli.Flag{
+	return slices.Concat([]cli.Flag{
 		&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
 		&cli.StringFlag{Name: "tickers", Usage: "Comma-separated ticker symbols"},
-	}, paginationFlags(100, 1, "asc")...)
+	}, paginationFlags(100, 1, "asc"))
 }
 
 // parseVolumeOptions extracts volumeOptions from the parsed CLI flags.

--- a/internal/commands/volume_test.go
+++ b/internal/commands/volume_test.go
@@ -19,7 +19,7 @@ func TestRunVolume(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		opts := volumeOptions{
 			date:     "2025-01-15",
@@ -41,7 +41,7 @@ func TestRunVolumeServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	opts := volumeOptions{date: "2025-01-15", start: 0, length: 100, orderCol: 1, orderDir: "asc"}
 	err := runVolume(ctx, opts, "/InstitutionalVolume/GetInstitutionalVolume", datatables.InstitutionalVolumeColumns)
 	assertErrContains(t, err, "query volume data")
@@ -67,7 +67,7 @@ func TestVolumeSubcommands(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			ctx := contextWithTestClient(server.URL)
+			ctx := contextWithTestClient(t, server.URL)
 			captureStdout(t, func() {
 				root := &cli.Command{Commands: []*cli.Command{NewVolumeCommand()}}
 				if err := root.Run(ctx, []string{"app", "volume", tt.name, "--date", "2025-01-15"}); err != nil {

--- a/internal/commands/watchlist.go
+++ b/internal/commands/watchlist.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"slices"
 	"strconv"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -121,9 +122,9 @@ volumeleaders-agent watchlist create --name "Large caps" --security-type 1 --min
 }
 
 func newWatchlistEditCommand() *cli.Command {
-	flags := append([]cli.Flag{
+	flags := slices.Concat([]cli.Flag{
 		&cli.IntFlag{Name: "key", Required: true, Usage: "Watch list key to edit"},
-	}, watchlistConfigFlags()...)
+	}, watchlistConfigFlags())
 	return &cli.Command{
 		Name:      "edit",
 		Usage:     "Edit an existing watch list configuration",

--- a/internal/commands/watchlist_test.go
+++ b/internal/commands/watchlist_test.go
@@ -19,7 +19,7 @@ func TestRunWatchlistConfigs(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runWatchlistConfigs(ctx); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -33,7 +33,7 @@ func TestRunWatchlistConfigsServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runWatchlistConfigs(ctx)
 	assertErrContains(t, err, "query watchlist configs")
 }
@@ -47,7 +47,7 @@ func TestRunWatchlistTickers(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runWatchlistTickers(ctx, 1); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -64,7 +64,7 @@ func TestRunWatchlistDelete(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runWatchlistDelete(ctx, 1); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -78,7 +78,7 @@ func TestRunWatchlistDeleteServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runWatchlistDelete(ctx, 1)
 	assertErrContains(t, err, "delete watchlist")
 }
@@ -92,7 +92,7 @@ func TestRunWatchlistAddTicker(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		if err := runWatchlistAddTicker(ctx, 1, "NVDA"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -106,7 +106,7 @@ func TestRunWatchlistAddTickerServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runWatchlistAddTicker(ctx, 1, "INVALID")
 	assertErrContains(t, err, "add ticker to watchlist")
 }
@@ -120,7 +120,7 @@ func TestRunWatchlistCreate(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
 		if err := root.Run(ctx, []string{"app", "watchlist", "create", "--name", "Test List"}); err != nil {
@@ -141,7 +141,7 @@ func TestRunWatchlistEdit(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
 		if err := root.Run(ctx, []string{"app", "watchlist", "edit", "--key", "1"}); err != nil {
@@ -162,7 +162,7 @@ func TestWatchlistConfigsCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
 		if err := root.Run(ctx, []string{"app", "watchlist", "configs"}); err != nil {
@@ -180,7 +180,7 @@ func TestWatchlistTickersCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
 		if err := root.Run(ctx, []string{"app", "watchlist", "tickers", "--watchlist-key", "1"}); err != nil {
@@ -198,7 +198,7 @@ func TestWatchlistDeleteCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
 		if err := root.Run(ctx, []string{"app", "watchlist", "delete", "--key", "1"}); err != nil {
@@ -216,7 +216,7 @@ func TestWatchlistAddTickerCLI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}
 		if err := root.Run(ctx, []string{"app", "watchlist", "add-ticker", "--watchlist-key", "1", "--ticker", "NVDA"}); err != nil {
@@ -231,7 +231,7 @@ func TestRunWatchlistTickersServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 	err := runWatchlistTickers(ctx, 1)
 	assertErrContains(t, err, "query watchlist tickers")
 }
@@ -242,7 +242,7 @@ func TestRunWatchlistCreateEditServerError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	ctx := contextWithTestClient(server.URL)
+	ctx := contextWithTestClient(t, server.URL)
 
 	t.Run("create", func(t *testing.T) {
 		root := &cli.Command{Commands: []*cli.Command{NewWatchlistCommand()}}

--- a/internal/datatables/datatables.go
+++ b/internal/datatables/datatables.go
@@ -3,6 +3,7 @@
 package datatables
 
 import (
+	"cmp"
 	"net/url"
 	"strconv"
 	"strings"
@@ -99,14 +100,8 @@ type pair struct {
 
 // Encode returns the URL-encoded form body in DataTables key order.
 func (r *Request) Encode() string {
-	draw := r.Draw
-	if draw == 0 {
-		draw = 1
-	}
-	orderDirection := r.OrderDirection
-	if orderDirection == "" {
-		orderDirection = "desc"
-	}
+	draw := cmp.Or(r.Draw, 1)
+	orderDirection := cmp.Or(r.OrderDirection, "desc")
 
 	pairs := []pair{{"draw", strconv.Itoa(draw)}, {"start", strconv.Itoa(r.Start)}, {"length", strconv.Itoa(r.Length)}, {"order[0][column]", strconv.Itoa(r.OrderColumnIndex)}, {"order[0][dir]", orderDirection}}
 	for index, column := range r.Columns {


### PR DESCRIPTION
## Summary
- Upgrade the project to Go 1.26 and refresh CI/tooling guidance around the new toolchain.
- Apply Go 1.26 modernization changes across context-aware tests, stdlib helpers, and lint configuration.
- Include the existing trade `--fields` work already present on this branch.

## Validation
- `make test`
- `go vet ./...`
- `make lint`
- `go mod verify`
- `make build`

## Notes
- Local CodeRabbit review skipped by request.
- Final verification approved code quality and manual QA, but flagged the pre-existing `--fields` commits as outside the original Go upgrade plan scope.