### PR TITLE
fix: improve auth session diagnostics

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/browserutils/kooky"
@@ -17,6 +18,10 @@ import (
 
 // UserAgent mimics Chrome 147 on Windows for authenticated requests.
 const UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+
+const volumeLeadersDomain = "volumeleaders.com"
+
+var requiredCookieNames = []string{"ASP.NET_SessionId", ".ASPXAUTH"}
 
 var xsrfTokenPattern = regexp.MustCompile(`<input\s+name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"`)
 
@@ -27,23 +32,14 @@ var xsrfTokenPattern = regexp.MustCompile(`<input\s+name="__RequestVerificationT
 // those errors as long as the required auth cookies were found in at least
 // one browser.
 func ExtractCookies(ctx context.Context) (map[string]string, error) {
-	found := make(map[string]string, 3)
-
 	// ReadCookies returns cookies it could find plus errors from browsers
 	// it could not read. Errors from missing browsers are expected.
-	cookies, _ := kooky.ReadCookies(ctx, kooky.Valid, kooky.DomainHasSuffix("volumeleaders.com"))
-	for _, cookie := range cookies {
-		switch cookie.Name {
-		case "ASP.NET_SessionId", ".ASPXAUTH", "__RequestVerificationToken":
-			found[cookie.Name] = cookie.Value
-		}
-	}
+	validCookies, _ := kooky.ReadCookies(ctx, kooky.Valid, kooky.DomainHasSuffix(volumeLeadersDomain))
+	found := authCookies(validCookies)
 
 	if found["ASP.NET_SessionId"] == "" || found[".ASPXAUTH"] == "" {
-		return nil, fmt.Errorf(
-			"required cookies (ASP.NET_SessionId, .ASPXAUTH) not found in any browser; " +
-				"log in to volumeleaders.com and try again",
-		)
+		allCookies, _ := kooky.ReadCookies(ctx, kooky.DomainHasSuffix(volumeLeadersDomain))
+		return nil, fmt.Errorf("required browser cookies unavailable: %s", cookieDiagnostic(found, allCookies, validCookies))
 	}
 	return found, nil
 }
@@ -66,7 +62,7 @@ func FetchXSRFToken(ctx context.Context, httpClient *http.Client, cookies map[st
 	defer resp.Body.Close()
 
 	if strings.Contains(resp.Request.URL.Path, "/Login") {
-		return "", fmt.Errorf("session expired")
+		return "", fmt.Errorf("session expired: requested host www.%s redirected to %s", volumeLeadersDomain, safeRedirectPath(resp))
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("fetch XSRF token page: status %d", resp.StatusCode)
@@ -93,6 +89,84 @@ func FetchXSRFToken(ctx context.Context, httpClient *http.Client, cookies map[st
 		return "", fmt.Errorf("XSRF token not found in HTML")
 	}
 	return string(matches[1]), nil
+}
+
+func authCookies(cookies kooky.Cookies) map[string]string {
+	found := make(map[string]string, 3)
+	for _, cookie := range cookies {
+		switch cookie.Name {
+		case "ASP.NET_SessionId", ".ASPXAUTH", "__RequestVerificationToken":
+			found[cookie.Name] = cookie.Value
+		}
+	}
+	return found
+}
+
+func cookieDiagnostic(found map[string]string, allCookies, validCookies kooky.Cookies) string {
+	missing := missingRequiredCookies(found)
+	rejected := rejectedRequiredCookies(found, allCookies)
+	parts := []string{
+		fmt.Sprintf("searched browser cookie stores for domain suffix %q", volumeLeadersDomain),
+		"required cookies: ASP.NET_SessionId, .ASPXAUTH",
+		fmt.Sprintf("valid VolumeLeaders cookies found: %d", len(validCookies)),
+		fmt.Sprintf("browser stores with VolumeLeaders cookies: %d", browserStoreCount(allCookies)),
+		fmt.Sprintf("missing valid cookies: %s", strings.Join(missing, ", ")),
+		"only cookie storage is inspected; local storage, session storage, and IndexedDB are not inspected",
+	}
+	if len(rejected) > 0 {
+		parts = append(parts, fmt.Sprintf("matching required cookies found but not usable as valid cookies: %s", strings.Join(rejected, ", ")))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func missingRequiredCookies(found map[string]string) []string {
+	missing := make([]string, 0, len(requiredCookieNames))
+	for _, name := range requiredCookieNames {
+		if found[name] == "" {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func rejectedRequiredCookies(found map[string]string, allCookies kooky.Cookies) []string {
+	rejected := make([]string, 0, len(requiredCookieNames))
+	for _, name := range requiredCookieNames {
+		if found[name] != "" || !containsCookieName(allCookies, name) {
+			continue
+		}
+		rejected = append(rejected, name)
+	}
+	return rejected
+}
+
+func containsCookieName(cookies kooky.Cookies, name string) bool {
+	return slices.ContainsFunc(cookies, func(cookie *kooky.Cookie) bool {
+		return cookie.Name == name
+	})
+}
+
+func browserStoreCount(cookies kooky.Cookies) int {
+	stores := make(map[string]struct{})
+	for _, cookie := range cookies {
+		if cookie.Browser == nil {
+			stores["unknown"] = struct{}{}
+			continue
+		}
+		stores[cookie.Browser.Browser()+":"+cookie.Browser.Profile()] = struct{}{}
+	}
+	return len(stores)
+}
+
+func safeRedirectPath(resp *http.Response) string {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return "unknown redirect target"
+	}
+	path := resp.Request.URL.EscapedPath()
+	if path == "" {
+		return "/"
+	}
+	return path
 }
 
 func setBrowserHeaders(req *http.Request) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/browserutils/kooky"
 )
 
 func TestXSRFTokenPattern(t *testing.T) {
@@ -89,7 +91,7 @@ func TestFetchXSRFToken(t *testing.T) {
 				}
 				fmt.Fprint(w, "login")
 			},
-			wantErr: "session expired",
+			wantErr: "session expired: requested host www.volumeleaders.com redirected to /Login",
 		},
 		{
 			name: "non 200 status",
@@ -150,6 +152,85 @@ func TestFetchXSRFToken(t *testing.T) {
 	}
 }
 
+func TestCookieDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		found        map[string]string
+		allCookies   kooky.Cookies
+		validCookies kooky.Cookies
+		wantParts    []string
+		forbidParts  []string
+	}{
+		{
+			name:  "missing all required cookies",
+			found: map[string]string{},
+			wantParts: []string{
+				`searched browser cookie stores for domain suffix "volumeleaders.com"`,
+				"required cookies: ASP.NET_SessionId, .ASPXAUTH",
+				"valid VolumeLeaders cookies found: 0",
+				"browser stores with VolumeLeaders cookies: 0",
+				"missing valid cookies: ASP.NET_SessionId, .ASPXAUTH",
+				"only cookie storage is inspected; local storage, session storage, and IndexedDB are not inspected",
+			},
+		},
+		{
+			name: "reports required cookies not usable as valid cookies",
+			found: map[string]string{
+				"ASP.NET_SessionId": "valid-session-cookie",
+			},
+			allCookies: kooky.Cookies{
+				cookieWithBrowser("ASP.NET_SessionId", "valid-session-cookie", "Firefox", "default-release"),
+				cookieWithBrowser(".ASPXAUTH", "expired-auth-cookie", "Firefox", "default-release"),
+			},
+			validCookies: kooky.Cookies{
+				cookieWithBrowser("ASP.NET_SessionId", "valid-session-cookie", "Firefox", "default-release"),
+			},
+			wantParts: []string{
+				"valid VolumeLeaders cookies found: 1",
+				"browser stores with VolumeLeaders cookies: 1",
+				"missing valid cookies: .ASPXAUTH",
+				"matching required cookies found but not usable as valid cookies: .ASPXAUTH",
+			},
+			forbidParts: []string{
+				"valid-session-cookie",
+				"expired-auth-cookie",
+				"default-release",
+				"/home/",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostic := cookieDiagnostic(tt.found, tt.allCookies, tt.validCookies)
+			for _, want := range tt.wantParts {
+				if !strings.Contains(diagnostic, want) {
+					t.Errorf("expected diagnostic to contain %q, got %q", want, diagnostic)
+				}
+			}
+			for _, forbidden := range tt.forbidParts {
+				if strings.Contains(diagnostic, forbidden) {
+					t.Errorf("expected diagnostic not to contain %q, got %q", forbidden, diagnostic)
+				}
+			}
+		})
+	}
+}
+
+func TestSafeRedirectPath(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://www.volumeleaders.com/Login?returnUrl=%2FAccount", http.NoBody)
+	got := safeRedirectPath(&http.Response{Request: req})
+	if got != "/Login" {
+		t.Fatalf("expected sanitized redirect path, got %q", got)
+	}
+}
+
 func TestFetchXSRFToken_CanceledContext(t *testing.T) {
 	t.Parallel()
 
@@ -196,15 +277,15 @@ func assertBrowserHeaders(t *testing.T, r *http.Request) {
 	t.Helper()
 
 	checks := map[string]string{
-		"User-Agent":        UserAgent,
-		"Sec-Ch-Ua":         `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
-		"Sec-Ch-Ua-Mobile":  "?0",
+		"User-Agent":         UserAgent,
+		"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
+		"Sec-Ch-Ua-Mobile":   "?0",
 		"Sec-Ch-Ua-Platform": `"Windows"`,
-		"Sec-Fetch-Dest":    "empty",
-		"Sec-Fetch-Mode":    "cors",
-		"Sec-Fetch-Site":    "same-origin",
-		"Accept-Language":   "en-US,en;q=0.9",
-		"Accept-Encoding":   "gzip, deflate, br",
+		"Sec-Fetch-Dest":     "empty",
+		"Sec-Fetch-Mode":     "cors",
+		"Sec-Fetch-Site":     "same-origin",
+		"Accept-Language":    "en-US,en;q=0.9",
+		"Accept-Encoding":    "gzip, deflate, br",
 	}
 	for key, expected := range checks {
 		if got := r.Header.Get(key); got != expected {
@@ -229,5 +310,30 @@ func assertRequestCookies(t *testing.T, r *http.Request) {
 		if cookie.Value != expected {
 			t.Errorf("cookie %s: expected %q, got %q", name, expected, cookie.Value)
 		}
+	}
+}
+
+type testBrowserInfo struct {
+	browser string
+	profile string
+}
+
+func (b testBrowserInfo) Browser() string { return b.browser }
+
+func (b testBrowserInfo) Profile() string { return b.profile }
+
+func (b testBrowserInfo) IsDefaultProfile() bool { return true }
+
+func (b testBrowserInfo) FilePath() string {
+	return "/home/example/.mozilla/firefox/profile/cookies.sqlite"
+}
+
+func cookieWithBrowser(name, value, browser, profile string) *kooky.Cookie {
+	return &kooky.Cookie{
+		Cookie: http.Cookie{
+			Name:  name,
+			Value: value,
+		},
+		Browser: testBrowserInfo{browser: browser, profile: profile},
 	}
 }


### PR DESCRIPTION
## Summary
- Adds safer diagnostics when required VolumeLeaders browser auth cookies are missing, including searched domain, missing cookie names, valid cookie counts, and whether matching required cookies were present but unusable.
- Reports sanitized login redirect paths during XSRF token fetch without exposing cookie values, token values, profile paths, redirect queries, or account data.

Fixes #25

## Verification
- go test ./internal/auth
- go test ./...
- make lint
- make build
- lsp diagnostics: internal/auth/auth.go, internal/auth/auth_test.go
- coderabbit review --agent --base main -c .coderabbit.yaml, 0 findings