### PR TITLE
ci: replace govulncheck action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,4 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        with:
-          repo-checkout: false
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
## Summary
- Replaces the abandoned `golang/govulncheck-action` CI dependency with the official govulncheck CLI via `go run`.
- Keeps the existing checkout and setup-go workflow steps so the scan still uses the repository Go version from `go.mod`.

Fixes #1

## Verification
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...
- make lint
- lsp diagnostics: .github/workflows/ci.yml

## Notes
- Local CodeRabbit review was attempted, but the CLI returned an hourly rate-limit error before producing findings.