### PR TITLE
feat: add smart date defaults for trade list and trade levels

### DIFF
--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/major/volumeleaders-agent/internal/client"
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -336,6 +337,43 @@ func dateRangeFlags() []cli.Flag {
 		&cli.StringFlag{Name: "start-date", Required: true, Usage: "Start date YYYY-MM-DD"},
 		&cli.StringFlag{Name: "end-date", Required: true, Usage: "End date YYYY-MM-DD"},
 	}
+}
+
+// optionalDateRangeFlags returns --start-date and --end-date flags without
+// Required, for commands that supply sensible defaults when dates are omitted.
+func optionalDateRangeFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{Name: "start-date", Usage: "Start date YYYY-MM-DD (default: auto)"},
+		&cli.StringFlag{Name: "end-date", Usage: "End date YYYY-MM-DD (default: today)"},
+	}
+}
+
+// timeNow is the clock function used by defaultDates.
+// Tests replace it to control the current time.
+var timeNow = time.Now
+
+// defaultDates returns start and end dates for a query, applying defaults when
+// the user did not explicitly set them. lookbackDays controls how far back the
+// start date goes; pass 0 for a today-only default.
+func defaultDates(cmd *cli.Command, lookbackDays int) (startDate, endDate string) {
+	now := timeNow()
+	today := now.Format("2006-01-02")
+
+	endDate = cmd.String("end-date")
+	if !cmd.IsSet("end-date") {
+		endDate = today
+	}
+
+	startDate = cmd.String("start-date")
+	if !cmd.IsSet("start-date") {
+		if lookbackDays > 0 {
+			startDate = now.AddDate(0, 0, -lookbackDays).Format("2006-01-02")
+		} else {
+			startDate = today
+		}
+	}
+
+	return startDate, endDate
 }
 
 // volumeRangeFlags returns --min-volume and --max-volume flags with

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
@@ -286,6 +288,103 @@ func TestDateRangeFlags(t *testing.T) {
 	assertFlagName(t, flags[1], "end-date")
 	assertStringFlagRequired(t, flags[0], true)
 	assertStringFlagRequired(t, flags[1], true)
+}
+
+func TestOptionalDateRangeFlags(t *testing.T) {
+	t.Parallel()
+
+	flags := optionalDateRangeFlags()
+	if len(flags) != 2 {
+		t.Fatalf("expected 2 flags, got %d", len(flags))
+	}
+	assertFlagName(t, flags[0], "start-date")
+	assertFlagName(t, flags[1], "end-date")
+	assertStringFlagRequired(t, flags[0], false)
+	assertStringFlagRequired(t, flags[1], false)
+}
+
+func TestDefaultDates(t *testing.T) {
+	t.Parallel()
+
+	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	origTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	t.Cleanup(func() { timeNow = origTimeNow })
+
+	tests := []struct {
+		name         string
+		args         []string
+		lookbackDays int
+		wantStart    string
+		wantEnd      string
+	}{
+		{
+			name:         "both dates explicit",
+			args:         []string{"app", "sub", "--start-date", "2025-01-01", "--end-date", "2025-03-01"},
+			lookbackDays: 90,
+			wantStart:    "2025-01-01",
+			wantEnd:      "2025-03-01",
+		},
+		{
+			name:         "90-day lookback default",
+			args:         []string{"app", "sub"},
+			lookbackDays: 90,
+			wantStart:    "2025-03-17",
+			wantEnd:      "2025-06-15",
+		},
+		{
+			name:         "today-only default",
+			args:         []string{"app", "sub"},
+			lookbackDays: 0,
+			wantStart:    "2025-06-15",
+			wantEnd:      "2025-06-15",
+		},
+		{
+			name:         "365-day lookback default",
+			args:         []string{"app", "sub"},
+			lookbackDays: 365,
+			wantStart:    "2024-06-15",
+			wantEnd:      "2025-06-15",
+		},
+		{
+			name:         "only start-date explicit",
+			args:         []string{"app", "sub", "--start-date", "2025-01-01"},
+			lookbackDays: 90,
+			wantStart:    "2025-01-01",
+			wantEnd:      "2025-06-15",
+		},
+		{
+			name:         "only end-date explicit",
+			args:         []string{"app", "sub", "--end-date", "2025-03-01"},
+			lookbackDays: 90,
+			wantStart:    "2025-03-17",
+			wantEnd:      "2025-03-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotStart, gotEnd string
+			sub := &cli.Command{
+				Name: "sub",
+				Flags: slices.Concat(optionalDateRangeFlags()),
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					gotStart, gotEnd = defaultDates(cmd, tt.lookbackDays)
+					return nil
+				},
+			}
+			root := &cli.Command{Commands: []*cli.Command{sub}}
+			if err := root.Run(context.Background(), tt.args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotStart != tt.wantStart {
+				t.Errorf("start date = %q, want %q", gotStart, tt.wantStart)
+			}
+			if gotEnd != tt.wantEnd {
+				t.Errorf("end date = %q, want %q", gotEnd, tt.wantEnd)
+			}
+		})
+	}
 }
 
 func TestVolumeRangeFlags(t *testing.T) {

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
@@ -88,6 +89,122 @@ func TestTradeRunFunctions(t *testing.T) {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			})
+		})
+	}
+}
+
+func TestTradeListDefaultDates(t *testing.T) {
+	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	origTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	t.Cleanup(func() { timeNow = origTimeNow })
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantStart string
+		wantEnd   string
+	}{
+		{
+			name:      "with tickers defaults to 90-day lookback",
+			args:      []string{"app", "list", "--tickers", "AAPL"},
+			wantStart: "2025-03-17",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:      "without tickers defaults to today only",
+			args:      []string{"app", "list"},
+			wantStart: "2025-06-15",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:      "explicit dates override defaults",
+			args:      []string{"app", "list", "--tickers", "AAPL", "--start-date", "2025-01-01", "--end-date", "2025-02-01"},
+			wantStart: "2025-01-01",
+			wantEnd:   "2025-02-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotStart, gotEnd string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				form, _ := url.ParseQuery(string(body))
+				gotStart = form.Get("StartDate")
+				gotEnd = form.Get("EndDate")
+				fmt.Fprint(w, dataTablesJSON(`[{}]`))
+			}))
+			t.Cleanup(server.Close)
+
+			ctx := contextWithTestClient(t, server.URL)
+			captureStdout(t, func() {
+				root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+				if err := root.Run(ctx, tt.args); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if gotStart != tt.wantStart {
+				t.Errorf("StartDate = %q, want %q", gotStart, tt.wantStart)
+			}
+			if gotEnd != tt.wantEnd {
+				t.Errorf("EndDate = %q, want %q", gotEnd, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestTradeLevelsDefaultDates(t *testing.T) {
+	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	origTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	t.Cleanup(func() { timeNow = origTimeNow })
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantStart string
+		wantEnd   string
+	}{
+		{
+			name:      "defaults to 1-year lookback",
+			args:      []string{"app", "levels", "--ticker", "AAPL"},
+			wantStart: "2024-06-15",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:      "explicit dates override defaults",
+			args:      []string{"app", "levels", "--ticker", "AAPL", "--start-date", "2025-01-01", "--end-date", "2025-02-01"},
+			wantStart: "2025-01-01",
+			wantEnd:   "2025-02-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotStart, gotEnd string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				form, _ := url.ParseQuery(string(body))
+				gotStart = form.Get("MinDate")
+				gotEnd = form.Get("MaxDate")
+				fmt.Fprint(w, dataTablesJSON(`[{}]`))
+			}))
+			t.Cleanup(server.Close)
+
+			ctx := contextWithTestClient(t, server.URL)
+			captureStdout(t, func() {
+				root := &cli.Command{Commands: []*cli.Command{newTradeLevelsCommand()}}
+				if err := root.Run(ctx, tt.args); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if gotStart != tt.wantStart {
+				t.Errorf("MinDate = %q, want %q", gotStart, tt.wantStart)
+			}
+			if gotEnd != tt.wantEnd {
+				t.Errorf("MaxDate = %q, want %q", gotEnd, tt.wantEnd)
+			}
 		})
 	}
 }

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -102,13 +102,15 @@ func newTradeListCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "list",
 		Usage: "Query institutional trades",
-		UsageText: `volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2025-01-01 --end-date 2025-01-31
+		UsageText: `volumeleaders-agent trade list --tickers AAPL,MSFT
 volumeleaders-agent trade list --tickers NVDA --dark-pools 1 --min-dollars 1000000
 volumeleaders-agent trade list --sector Technology --relative-size 10 --length 50
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
-volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24`,
+volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
+
+Dates are optional. With --tickers: defaults to 90-day lookback. Without: defaults to today only.`,
 		Flags: slices.Concat(
-			dateRangeFlags(),
+			optionalDateRangeFlags(),
 			volumeRangeFlags(),
 			priceRangeFlags(),
 			dollarRangeFlags(500000),
@@ -234,10 +236,12 @@ func newTradeLevelsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "levels",
 		Usage: "Query significant price levels for a ticker",
-		UsageText: `volumeleaders-agent trade levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-01-31
-volumeleaders-agent trade levels --ticker MSFT --trade-level-count 20 --min-dollars 1000000`,
+		UsageText: `volumeleaders-agent trade levels --ticker AAPL
+volumeleaders-agent trade levels --ticker MSFT --trade-level-count 20 --min-dollars 1000000
+
+Dates are optional. Defaults to 1-year lookback ending today.`,
 		Flags: slices.Concat(
-			dateRangeFlags(),
+			optionalDateRangeFlags(),
 			volumeRangeFlags(),
 			priceRangeFlags(),
 			dollarRangeFlags(500000),
@@ -291,12 +295,20 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	// Apply sensible date defaults: 90-day lookback when tickers are scoped,
+	// today-only for broad (untickered) scans.
+	lookbackDays := 0
+	if cmd.String("tickers") != "" {
+		lookbackDays = 90
+	}
+	startDate, endDate := defaultDates(cmd, lookbackDays)
+
 	// Build the full filter map from CLI flags (includes defaults for unset
 	// flags). Every key the API requires is present after this call.
 	opts := &tradesOptions{
 		tickers:      cmd.String("tickers"),
-		startDate:    cmd.String("start-date"),
-		endDate:      cmd.String("end-date"),
+		startDate:    startDate,
+		endDate:      endDate,
 		minVolume:    cmd.Int("min-volume"),
 		maxVolume:    cmd.Int("max-volume"),
 		minPrice:     cmd.Float("min-price"),
@@ -348,9 +360,9 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		applyExplicitFlags(cmd, filters)
 	}
 
-	// Dates always come from CLI (required flags).
-	filters["StartDate"] = cmd.String("start-date")
-	filters["EndDate"] = cmd.String("end-date")
+	// Dates always come from CLI or computed defaults (never from presets).
+	filters["StartDate"] = startDate
+	filters["EndDate"] = endDate
 
 	optsDataTable := dataTableOptions{
 		start:    cmd.Int("start"),
@@ -692,10 +704,11 @@ func runTradeClusterAlerts(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
+	startDate, endDate := defaultDates(cmd, 365)
 	opts := &tradeLevelOptions{
 		ticker:          cmd.String("ticker"),
-		startDate:       cmd.String("start-date"),
-		endDate:         cmd.String("end-date"),
+		startDate:       startDate,
+		endDate:         endDate,
 		minVolume:       cmd.Int("min-volume"),
 		maxVolume:       cmd.Int("max-volume"),
 		minPrice:        cmd.Float("min-price"),

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -39,8 +39,10 @@ Output fields: `Preset`, `Group`, `Type`, `Tickers` (trimmed, deduplicated, omit
 
 Query individual institutional block trades. The primary trade discovery command.
 
-Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, `--format json|csv|tsv`, `--summary`, `--group-by`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
+Required: none (dates have smart defaults)
+Optional: `--start-date`, `--end-date`, `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, `--format json|csv|tsv`, `--summary`, `--group-by`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
+
+**Date defaults**: When `--start-date` or `--end-date` are omitted, smart defaults apply. With `--tickers`: 90-day lookback from today. Without `--tickers` (broad scan): today only. Explicit `--start-date` and `--end-date` override these defaults. Dates are never inherited from presets or watchlists.
 
 **`--preset NAME`**: Apply a built-in filter preset by name (case-insensitive). The preset sets baseline filters; any explicitly-provided CLI flags override the preset values. Use `trade presets` to list available names.
 
@@ -57,8 +59,12 @@ Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`
 Preset and watchlist filters can be combined: watchlist filters merge on top of preset filters, and explicit CLI flags override both.
 
 ```bash
+# With tickers: defaults to 90-day lookback
+volumeleaders-agent trade list --tickers AAPL --dark-pools 1 --min-dollars 1000000
+# Without tickers (broad scan): defaults to today only
+volumeleaders-agent trade list --preset "Top-100 Rank"
+# Explicit dates override defaults
 volumeleaders-agent trade list --tickers AAPL --start-date 2025-04-16 --end-date 2025-04-23 --dark-pools 1 --min-dollars 1000000
-volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --preset "Megacaps" --start-date 2025-04-01 --end-date 2025-04-24 --trade-rank 10
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars,DollarsMultiplier,DarkPool,CumulativeDistribution
@@ -140,11 +146,16 @@ Output fields: same as trade clusters.
 
 Significant institutional price levels for a single ticker. These levels often act as support/resistance.
 
-Required: `--ticker` (single; aliases: `--tickers`, `--symbol`, `--symbols`), `--start-date`, `--end-date`
-Optional: volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (-1), `--trade-level-count` (10), `--format json|csv|tsv`
+Required: `--ticker` (single; aliases: `--tickers`, `--symbol`, `--symbols`)
+Optional: `--start-date`, `--end-date`, volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (-1), `--trade-level-count` (10), `--format json|csv|tsv`
 Non-standard defaults: `--relative-size 0`. No pagination flags.
 
+**Date defaults**: When dates are omitted, defaults to a 1-year lookback from today. Explicit `--start-date` and `--end-date` override these defaults.
+
 ```bash
+# Defaults to 1-year lookback
+volumeleaders-agent trade levels --ticker AAPL
+# Explicit dates override defaults
 volumeleaders-agent trade levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-04-23
 ```
 


### PR DESCRIPTION
## Summary

- `trade list` and `trade levels` no longer require explicit `--start-date`/`--end-date` flags
- Smart defaults when dates are omitted:
  - `trade list` with `--tickers`: 90-day lookback, end=today
  - `trade list` without tickers (broad scan): today only
  - `trade levels` (always has `--ticker`): 1-year lookback, end=today
- All other trade subcommands retain required date flags
- Explicit `--start-date`/`--end-date` still override defaults; dates are never inherited from presets or watchlists

## Changes

- **helpers.go**: Added `optionalDateRangeFlags()` (no `Required`) and `defaultDates()` helper that computes defaults via `cmd.IsSet()` checks, with injectable `timeNow` for testing
- **trade.go**: `trade list` and `trade levels` switched to optional date flags, `runTradeList()` picks lookback (0 or 90 days) based on tickers presence, `runTradeLevels()` uses 365-day lookback
- **helpers_test.go**: Tests for `optionalDateRangeFlags` and `defaultDates` (6 table-driven cases with frozen time)
- **run_trade_test.go**: Integration tests for `trade list` (3 cases) and `trade levels` (2 cases) verifying correct API date params
- **skills/trade.md**: Updated docs for new default behavior

Closes #29