### PR TITLE
feat: add daily summary command and trade sentiment format flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ When modifying CLI commands, flags, models, or behavior:
 Command-to-skill mapping:
 
 - `internal/commands/trade.go`, `internal/commands/presets.go` -> `skills/trade.md`
+- `internal/commands/daily.go` -> `skills/daily.md`
 - `internal/commands/volume.go` -> `skills/volume.md`
 - `internal/commands/chart.go` -> `skills/chart.md`
 - `internal/commands/market.go` -> `skills/market.md`
@@ -25,7 +26,7 @@ Command-to-skill mapping:
 cmd/volumeleaders-agent/main.go    Entry point
 internal/auth/                     Browser cookie + XSRF token extraction
 internal/client/                   HTTP client (DataTables + JSON requests)
-internal/commands/                 CLI command definitions (6 groups, 21 subcommands)
+internal/commands/                 CLI command definitions (7 groups, 22 subcommands)
 internal/datatables/               DataTables protocol encoding + column definitions
 internal/models/                   Response type definitions
 skills/                            LLM skill files for agent integration

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All commands emit compact JSON to stdout by default. Use `--pretty` for indented
 | Group | Purpose | Docs |
 |---|---|---|
 | `trade` | Institutional trades, clusters, cluster bombs, price levels | [skills/trade.md](skills/trade.md) |
+| `daily` | Compact daily institutional activity summaries | [skills/daily.md](skills/daily.md) |
 | `volume` | Volume leaderboards (institutional, after-hours, total) | [skills/volume.md](skills/volume.md) |
 | `chart` | Price bars with trade overlays, snapshots, company metadata | [skills/chart.md](skills/chart.md) |
 | `market` | Market-wide snapshots, earnings calendar, exhaustion scores | [skills/market.md](skills/market.md) |

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -26,6 +26,7 @@ func NewApp(version string) *cli.Command {
 		},
 		Commands: []*cli.Command{
 			NewTradeCommand(),
+			NewDailyCommand(),
 			NewVolumeCommand(),
 			NewChartCommand(),
 			NewMarketCommand(),

--- a/internal/commands/app_test.go
+++ b/internal/commands/app_test.go
@@ -16,9 +16,9 @@ func TestNewAppStructure(t *testing.T) {
 		t.Errorf("expected version %q, got %q", "1.0.0-test", app.Version)
 	}
 
-	// Verify all 6 command groups are registered.
+	// Verify all 7 command groups are registered.
 	expected := map[string]bool{
-		"trade": false, "volume": false, "chart": false,
+		"trade": false, "daily": false, "volume": false, "chart": false,
 		"market": false, "alert": false, "watchlist": false,
 	}
 	for _, cmd := range app.Commands {
@@ -51,6 +51,7 @@ func TestNewAppSubcommandCounts(t *testing.T) {
 
 	expected := map[string]int{
 		"trade":     10,
+		"daily":     1,
 		"volume":    3,
 		"chart":     4,
 		"market":    3,

--- a/internal/commands/daily.go
+++ b/internal/commands/daily.go
@@ -1,0 +1,526 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sort"
+
+	"github.com/major/volumeleaders-agent/internal/client"
+	"github.com/major/volumeleaders-agent/internal/datatables"
+	"github.com/major/volumeleaders-agent/internal/models"
+	cli "github.com/urfave/cli/v3"
+)
+
+const maxDailySummaryPages = 100
+
+// NewDailyCommand returns the "daily" command group.
+func NewDailyCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "daily",
+		Usage: "Daily cross-endpoint summaries",
+		Commands: []*cli.Command{
+			newDailySummaryCommand(),
+		},
+	}
+}
+
+func newDailySummaryCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "summary",
+		Usage:     "Summarize institutional activity for one trading day",
+		UsageText: "volumeleaders-agent daily summary --date 2026-04-28 --limit 10",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
+			&cli.IntFlag{Name: "limit", Value: 10, Usage: "Maximum rows per summary section"},
+		},
+		Action: runDailySummary,
+	}
+}
+
+func runDailySummary(ctx context.Context, cmd *cli.Command) error {
+	limit := cmd.Int("limit")
+	if limit < 1 {
+		return fmt.Errorf("--limit must be greater than 0")
+	}
+
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	date := cmd.String("date")
+	institutional, err := fetchDailyInstitutionalVolume(ctx, vlClient, date)
+	if err != nil {
+		return err
+	}
+	clusters, err := fetchDailyClusters(ctx, vlClient, date)
+	if err != nil {
+		return err
+	}
+	clusterBombs, err := fetchDailyClusterBombs(ctx, vlClient, date)
+	if err != nil {
+		return err
+	}
+	levelTouches, err := fetchDailyLevelTouches(ctx, vlClient, date)
+	if err != nil {
+		return err
+	}
+	sentimentTrades, err := fetchDailySentimentTrades(ctx, vlClient, date)
+	if err != nil {
+		return err
+	}
+	exhaustion, err := fetchDailyExhaustion(ctx, vlClient, date)
+	if err != nil {
+		return err
+	}
+
+	summary := models.DailySummary{
+		Date:                          date,
+		TopInstitutionalVolumeTickers: summarizeDailyInstitutionalVolume(institutional, limit),
+		TopClustersByDollars:          summarizeDailyClustersByDollars(clusters, limit),
+		TopClustersByMultiplier:       summarizeDailyClustersByMultiplier(clusters, limit),
+		RepeatedClusterTickers:        summarizeRepeatedClusterTickers(clusters, limit),
+		SectorTotals:                  summarizeDailySectorTotals(institutional, clusters, clusterBombs, levelTouches, limit),
+		ClusterBombs:                  summarizeDailyClusterBombs(clusterBombs, limit),
+		LevelTouches:                  summarizeDailyLevelTouches(levelTouches, limit),
+		LeveragedETFSentiment:         summarizeDailyLeveragedETFSentiment(sentimentTrades, date),
+		MarketExhaustion:              exhaustion,
+	}
+	return printJSON(ctx, summary)
+}
+
+func fetchDailyInstitutionalVolume(ctx context.Context, vlClient *client.Client, date string) ([]models.Trade, error) {
+	return fetchDailyDataTables[models.Trade](ctx, vlClient, "/InstitutionalVolume/GetInstitutionalVolume", datatables.InstitutionalVolumeColumns, dataTableOptions{
+		orderCol: 6,
+		orderDir: "desc",
+		filters: map[string]string{
+			"Date":    date,
+			"Tickers": "",
+		},
+	}, "query daily institutional volume")
+}
+
+func fetchDailyClusters(ctx context.Context, vlClient *client.Client, date string) ([]models.TradeCluster, error) {
+	return fetchDailyDataTables[models.TradeCluster](ctx, vlClient, "/TradeClusters/GetTradeClusters", datatables.TradeClusterColumns, dataTableOptions{
+		orderCol: 9,
+		orderDir: "desc",
+		filters: map[string]string{
+			"Tickers":          "",
+			"StartDate":        date,
+			"EndDate":          date,
+			"MinVolume":        "0",
+			"MaxVolume":        "2000000000",
+			"MinPrice":         "0",
+			"MaxPrice":         "100000",
+			"MinDollars":       "10000000",
+			"MaxDollars":       "30000000000",
+			"VCD":              "0",
+			"SecurityTypeKey":  "-1",
+			"RelativeSize":     "5",
+			"TradeClusterRank": "-1",
+			"SectorIndustry":   "",
+		},
+	}, "query daily trade clusters")
+}
+
+func fetchDailyClusterBombs(ctx context.Context, vlClient *client.Client, date string) ([]models.TradeClusterBomb, error) {
+	return fetchDailyDataTables[models.TradeClusterBomb](ctx, vlClient, "/TradeClusterBombs/GetTradeClusterBombs", datatables.TradeClusterBombColumns, dataTableOptions{
+		orderCol: 7,
+		orderDir: "desc",
+		filters: map[string]string{
+			"Tickers":              "",
+			"StartDate":            date,
+			"EndDate":              date,
+			"MinVolume":            "0",
+			"MaxVolume":            "2000000000",
+			"MinDollars":           "0",
+			"MaxDollars":           "30000000000",
+			"VCD":                  "0",
+			"SecurityTypeKey":      "0",
+			"RelativeSize":         "0",
+			"TradeClusterBombRank": "-1",
+			"SectorIndustry":       "",
+		},
+	}, "query daily trade cluster bombs")
+}
+
+func fetchDailyLevelTouches(ctx context.Context, vlClient *client.Client, date string) ([]models.TradeLevelTouch, error) {
+	return fetchDailyDataTables[models.TradeLevelTouch](ctx, vlClient, "/TradeLevelTouches/GetTradeLevelTouches", datatables.TradeLevelTouchColumns, dataTableOptions{
+		orderCol: 8,
+		orderDir: "desc",
+		filters: map[string]string{
+			"Tickers":        "",
+			"StartDate":      date,
+			"EndDate":        date,
+			"MinVolume":      "0",
+			"MaxVolume":      "2000000000",
+			"MinPrice":       "0",
+			"MaxPrice":       "100000",
+			"MinDollars":     "500000",
+			"MaxDollars":     "30000000000",
+			"VCD":            "0",
+			"RelativeSize":   "0",
+			"TradeLevelRank": "10",
+		},
+	}, "query daily trade level touches")
+}
+
+func fetchDailySentimentTrades(ctx context.Context, vlClient *client.Client, date string) ([]models.Trade, error) {
+	opts := &tradesOptions{
+		startDate:    date,
+		endDate:      date,
+		minVolume:    0,
+		maxVolume:    2000000000,
+		minPrice:     0,
+		maxPrice:     100000,
+		minDollars:   5000000,
+		maxDollars:   30000000000,
+		conditions:   -1,
+		vcd:          97,
+		securityType: -1,
+		relativeSize: 5,
+		darkPools:    -1,
+		sweeps:       -1,
+		latePrints:   -1,
+		sigPrints:    -1,
+		evenShared:   -1,
+		tradeRank:    -1,
+		rankSnapshot: -1,
+		marketCap:    0,
+		premarket:    1,
+		rth:          1,
+		ah:           1,
+		opening:      1,
+		closing:      1,
+		phantom:      1,
+		offsetting:   1,
+		sector:       "X B",
+	}
+	return fetchAllTradeSentimentPages(ctx, vlClient, dataTableOptions{
+		orderCol: 1,
+		orderDir: "desc",
+		filters:  buildTradeFilters(opts),
+	})
+}
+
+func fetchDailyExhaustion(ctx context.Context, vlClient *client.Client, date string) (models.ExhaustionScore, error) {
+	var exhaustion models.ExhaustionScore
+	if err := vlClient.PostJSON(ctx, "/ExecutiveSummary/GetExhaustionScores", map[string]string{"Date": date}, &exhaustion); err != nil {
+		slog.Error("failed to query daily market exhaustion", "error", err)
+		return models.ExhaustionScore{}, fmt.Errorf("query daily market exhaustion: %w", err)
+	}
+	return exhaustion, nil
+}
+
+func fetchDailyDataTables[T any](ctx context.Context, vlClient *client.Client, path string, columns []string, opts dataTableOptions, label string) ([]T, error) {
+	opts.length = paginationPageSize
+	all := make([]T, 0)
+	for range maxDailySummaryPages {
+		request := newDataTablesRequest(columns, opts)
+		resp, err := vlClient.PostDataTablesPage(ctx, path, request.Encode())
+		if err != nil {
+			slog.Error("failed to "+label, "error", err)
+			return nil, fmt.Errorf("%s: %w", label, err)
+		}
+
+		var page []T
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
+			slog.Error("failed to decode "+label, "error", err)
+			return nil, fmt.Errorf("%s: decode response: %w", label, err)
+		}
+		if len(page) == 0 {
+			return all, nil
+		}
+
+		all = append(all, page...)
+		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
+			return all, nil
+		}
+		if len(page) < paginationPageSize {
+			return all, nil
+		}
+		opts.start += len(page)
+	}
+
+	return nil, fmt.Errorf("%s: pagination exceeded %d pages", label, maxDailySummaryPages)
+}
+
+func summarizeDailyInstitutionalVolume(trades []models.Trade, limit int) []models.DailyInstitutionalVolumeRow {
+	sorted := slices.Clone(trades)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].TotalInstitutionalDollars == sorted[j].TotalInstitutionalDollars {
+			return sorted[i].Ticker < sorted[j].Ticker
+		}
+		return sorted[i].TotalInstitutionalDollars > sorted[j].TotalInstitutionalDollars
+	})
+	rows := make([]models.DailyInstitutionalVolumeRow, 0, min(limit, len(sorted)))
+	for i := range min(limit, len(sorted)) {
+		trade := &sorted[i]
+		rows = append(rows, models.DailyInstitutionalVolumeRow{
+			Ticker:                       trade.Ticker,
+			Sector:                       trade.Sector,
+			Price:                        trade.Price,
+			Volume:                       trade.Volume,
+			TotalInstitutionalDollars:    trade.TotalInstitutionalDollars,
+			TotalInstitutionalDollarRank: trade.TotalInstitutionalDollarsRank,
+		})
+	}
+	return rows
+}
+
+func summarizeDailyClustersByDollars(clusters []models.TradeCluster, limit int) []models.DailyClusterRow {
+	sorted := slices.Clone(clusters)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Dollars == sorted[j].Dollars {
+			return sorted[i].Ticker < sorted[j].Ticker
+		}
+		return sorted[i].Dollars > sorted[j].Dollars
+	})
+	return dailyClusterRows(sorted, limit)
+}
+
+func summarizeDailyClustersByMultiplier(clusters []models.TradeCluster, limit int) []models.DailyClusterRow {
+	sorted := slices.Clone(clusters)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].DollarsMultiplier == sorted[j].DollarsMultiplier {
+			return sorted[i].Ticker < sorted[j].Ticker
+		}
+		return sorted[i].DollarsMultiplier > sorted[j].DollarsMultiplier
+	})
+	return dailyClusterRows(sorted, limit)
+}
+
+func dailyClusterRows(clusters []models.TradeCluster, limit int) []models.DailyClusterRow {
+	rows := make([]models.DailyClusterRow, 0, min(limit, len(clusters)))
+	for i := range min(limit, len(clusters)) {
+		cluster := &clusters[i]
+		rows = append(rows, models.DailyClusterRow{
+			Ticker:                 cluster.Ticker,
+			Sector:                 cluster.Sector,
+			Dollars:                cluster.Dollars,
+			DollarsMultiplier:      cluster.DollarsMultiplier,
+			Volume:                 cluster.Volume,
+			TradeCount:             cluster.TradeCount,
+			TradeClusterRank:       cluster.TradeClusterRank,
+			CumulativeDistribution: cluster.CumulativeDistribution,
+		})
+	}
+	return rows
+}
+
+type dailyRepeatedClusterAccumulator struct {
+	sector        string
+	clusters      int
+	dollars       float64
+	tradeCount    int
+	maxMultiplier float64
+}
+
+func summarizeRepeatedClusterTickers(clusters []models.TradeCluster, limit int) []models.DailyRepeatedClusterTicker {
+	byTicker := make(map[string]dailyRepeatedClusterAccumulator)
+	for i := range clusters {
+		cluster := &clusters[i]
+		acc := byTicker[cluster.Ticker]
+		acc.sector = cluster.Sector
+		acc.clusters++
+		acc.dollars += cluster.Dollars
+		acc.tradeCount += cluster.TradeCount
+		acc.maxMultiplier = max(acc.maxMultiplier, cluster.DollarsMultiplier)
+		byTicker[cluster.Ticker] = acc
+	}
+
+	rows := make([]models.DailyRepeatedClusterTicker, 0, len(byTicker))
+	for ticker, acc := range byTicker {
+		if acc.clusters < 2 {
+			continue
+		}
+		rows = append(rows, models.DailyRepeatedClusterTicker{
+			Ticker:        ticker,
+			Sector:        acc.sector,
+			Clusters:      acc.clusters,
+			Dollars:       acc.dollars,
+			TradeCount:    acc.tradeCount,
+			MaxMultiplier: acc.maxMultiplier,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Clusters == rows[j].Clusters {
+			if rows[i].Dollars == rows[j].Dollars {
+				return rows[i].Ticker < rows[j].Ticker
+			}
+			return rows[i].Dollars > rows[j].Dollars
+		}
+		return rows[i].Clusters > rows[j].Clusters
+	})
+	return rows[:min(limit, len(rows))]
+}
+
+type dailySectorAccumulator struct {
+	tickers    map[string]struct{}
+	trades     int
+	dollars    float64
+	volume     int
+	tradeCount int
+}
+
+func summarizeDailySectorTotals(trades []models.Trade, clusters []models.TradeCluster, bombs []models.TradeClusterBomb, touches []models.TradeLevelTouch, limit int) []models.DailySectorTotal {
+	bySector := make(map[string]dailySectorAccumulator)
+	for i := range trades {
+		trade := &trades[i]
+		acc := sectorAccumulator(bySector, trade.Sector)
+		acc.tickers[trade.Ticker] = struct{}{}
+		acc.trades++
+		acc.dollars += trade.TotalInstitutionalDollars
+		acc.volume += trade.Volume
+		bySector[sectorName(trade.Sector)] = acc
+	}
+	for i := range clusters {
+		cluster := &clusters[i]
+		acc := sectorAccumulator(bySector, cluster.Sector)
+		acc.tickers[cluster.Ticker] = struct{}{}
+		acc.dollars += cluster.Dollars
+		acc.volume += cluster.Volume
+		acc.tradeCount += cluster.TradeCount
+		bySector[sectorName(cluster.Sector)] = acc
+	}
+	for i := range bombs {
+		bomb := &bombs[i]
+		acc := sectorAccumulator(bySector, bomb.Sector)
+		acc.tickers[bomb.Ticker] = struct{}{}
+		acc.dollars += bomb.Dollars
+		acc.volume += bomb.Volume
+		acc.tradeCount += bomb.TradeCount
+		bySector[sectorName(bomb.Sector)] = acc
+	}
+	for i := range touches {
+		touch := &touches[i]
+		sector := ""
+		if touch.Sector != nil {
+			sector = *touch.Sector
+		}
+		acc := sectorAccumulator(bySector, sector)
+		acc.tickers[touch.Ticker] = struct{}{}
+		acc.dollars += touch.Dollars
+		acc.volume += touch.Volume
+		acc.tradeCount += touch.Trades
+		bySector[sectorName(sector)] = acc
+	}
+
+	rows := make([]models.DailySectorTotal, 0, len(bySector))
+	for sector, acc := range bySector {
+		rows = append(rows, models.DailySectorTotal{
+			Sector:     sector,
+			Tickers:    len(acc.tickers),
+			Trades:     acc.trades,
+			Dollars:    acc.dollars,
+			Volume:     acc.volume,
+			TradeCount: acc.tradeCount,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Dollars == rows[j].Dollars {
+			return rows[i].Sector < rows[j].Sector
+		}
+		return rows[i].Dollars > rows[j].Dollars
+	})
+	return rows[:min(limit, len(rows))]
+}
+
+func sectorAccumulator(items map[string]dailySectorAccumulator, sector string) dailySectorAccumulator {
+	acc := items[sectorName(sector)]
+	if acc.tickers == nil {
+		acc.tickers = make(map[string]struct{})
+	}
+	return acc
+}
+
+func sectorName(sector string) string {
+	if sector == "" {
+		return "unknown"
+	}
+	return sector
+}
+
+func summarizeDailyClusterBombs(bombs []models.TradeClusterBomb, limit int) []models.DailyClusterBombRow {
+	sorted := slices.Clone(bombs)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Dollars == sorted[j].Dollars {
+			return sorted[i].Ticker < sorted[j].Ticker
+		}
+		return sorted[i].Dollars > sorted[j].Dollars
+	})
+	rows := make([]models.DailyClusterBombRow, 0, min(limit, len(sorted)))
+	for i := range min(limit, len(sorted)) {
+		bomb := &sorted[i]
+		rows = append(rows, models.DailyClusterBombRow{
+			Ticker:                 bomb.Ticker,
+			Sector:                 bomb.Sector,
+			Dollars:                bomb.Dollars,
+			DollarsMultiplier:      bomb.DollarsMultiplier,
+			Volume:                 bomb.Volume,
+			TradeCount:             bomb.TradeCount,
+			TradeClusterBombRank:   bomb.TradeClusterBombRank,
+			CumulativeDistribution: bomb.CumulativeDistribution,
+		})
+	}
+	return rows
+}
+
+func summarizeDailyLevelTouches(touches []models.TradeLevelTouch, limit int) models.DailyLevelTouchSummary {
+	byRelativeSize := slices.Clone(touches)
+	sort.Slice(byRelativeSize, func(i, j int) bool {
+		if byRelativeSize[i].RelativeSize == byRelativeSize[j].RelativeSize {
+			return byRelativeSize[i].Ticker < byRelativeSize[j].Ticker
+		}
+		return byRelativeSize[i].RelativeSize > byRelativeSize[j].RelativeSize
+	})
+
+	byDollars := slices.Clone(touches)
+	sort.Slice(byDollars, func(i, j int) bool {
+		if byDollars[i].Dollars == byDollars[j].Dollars {
+			return byDollars[i].Ticker < byDollars[j].Ticker
+		}
+		return byDollars[i].Dollars > byDollars[j].Dollars
+	})
+
+	return models.DailyLevelTouchSummary{
+		ByRelativeSize: dailyLevelTouchRows(byRelativeSize, limit),
+		ByDollars:      dailyLevelTouchRows(byDollars, limit),
+	}
+}
+
+func dailyLevelTouchRows(touches []models.TradeLevelTouch, limit int) []models.DailyLevelTouchRow {
+	rows := make([]models.DailyLevelTouchRow, 0, min(limit, len(touches)))
+	for i := range min(limit, len(touches)) {
+		touch := &touches[i]
+		sector := ""
+		if touch.Sector != nil {
+			sector = *touch.Sector
+		}
+		rows = append(rows, models.DailyLevelTouchRow{
+			Ticker:            touch.Ticker,
+			Sector:            sector,
+			Price:             touch.Price,
+			Dollars:           touch.Dollars,
+			RelativeSize:      touch.RelativeSize,
+			Volume:            touch.Volume,
+			Trades:            touch.Trades,
+			TradeLevelRank:    touch.TradeLevelRank,
+			TradeLevelTouches: touch.TradeLevelTouches,
+		})
+	}
+	return rows
+}
+
+func summarizeDailyLeveragedETFSentiment(trades []models.Trade, date string) models.DailyLeveragedETFSentiment {
+	sentiment := summarizeTradeSentiment(trades, date, date)
+	return models.DailyLeveragedETFSentiment{
+		Bear:   sentiment.Totals.Bear,
+		Bull:   sentiment.Totals.Bull,
+		Ratio:  sentiment.Totals.Ratio,
+		Signal: sentiment.Totals.Signal,
+	}
+}

--- a/internal/commands/daily_test.go
+++ b/internal/commands/daily_test.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/major/volumeleaders-agent/internal/models"
+	cli "github.com/urfave/cli/v3"
+)
+
+func TestDailySummaryAggregatesInstitutionalActivity(t *testing.T) {
+	seen := make(map[string]bool)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen[r.URL.Path] = true
+		switch r.URL.Path {
+		case "/InstitutionalVolume/GetInstitutionalVolume":
+			fmt.Fprint(w, dataTablesJSON(`[
+				{"Ticker":"NVDA","Sector":"Technology","Price":900,"Volume":1000,"TotalInstitutionalDollars":500000000,"TotalInstitutionalDollarsRank":1},
+				{"Ticker":"SPY","Sector":"ETF","Price":500,"Volume":800,"TotalInstitutionalDollars":250000000,"TotalInstitutionalDollarsRank":2}
+			]`))
+		case "/TradeClusters/GetTradeClusters":
+			fmt.Fprint(w, dataTablesJSON(`[
+				{"Ticker":"NVDA","Sector":"Technology","Dollars":300000000,"DollarsMultiplier":6,"Volume":1000,"TradeCount":3,"TradeClusterRank":1,"CumulativeDistribution":0.99},
+				{"Ticker":"NVDA","Sector":"Technology","Dollars":150000000,"DollarsMultiplier":8,"Volume":500,"TradeCount":2,"TradeClusterRank":2,"CumulativeDistribution":0.95},
+				{"Ticker":"SPY","Sector":"ETF","Dollars":200000000,"DollarsMultiplier":4,"Volume":700,"TradeCount":1,"TradeClusterRank":3,"CumulativeDistribution":0.9}
+			]`))
+		case "/TradeClusterBombs/GetTradeClusterBombs":
+			fmt.Fprint(w, dataTablesJSON(`[
+				{"Ticker":"TSLA","Sector":"Consumer Cyclical","Dollars":125000000,"DollarsMultiplier":7,"Volume":400,"TradeCount":2,"TradeClusterBombRank":1,"CumulativeDistribution":0.98}
+			]`))
+		case "/TradeLevelTouches/GetTradeLevelTouches":
+			fmt.Fprint(w, dataTablesJSON(`[
+				{"Ticker":"AMD","Sector":"Technology","Price":120,"Dollars":90000000,"RelativeSize":12,"Volume":300,"Trades":2,"TradeLevelRank":1,"TradeLevelTouches":4},
+				{"Ticker":"SPY","Sector":"ETF","Price":500,"Dollars":110000000,"RelativeSize":5,"Volume":200,"Trades":1,"TradeLevelRank":2,"TradeLevelTouches":2}
+			]`))
+		case "/Trades/GetTrades":
+			fmt.Fprint(w, dataTablesJSON(`[
+				{"Date":"/Date(1777334400000)/","Ticker":"SH","Sector":"X Bear","Dollars":100000000},
+				{"Date":"/Date(1777334400000)/","Ticker":"TQQQ","Sector":"X Bull","Dollars":200000000}
+			]`))
+		case "/ExecutiveSummary/GetExhaustionScores":
+			fmt.Fprint(w, `{"DateKey":20260428,"ExhaustionScoreRank":4,"ExhaustionScoreRank30Day":6,"ExhaustionScoreRank90Day":12,"ExhaustionScoreRank365Day":20}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewDailyCommand()}}
+		if err := root.Run(ctx, []string{"app", "daily", "summary", "--date", "2026-04-28", "--limit", "2"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, path := range []string{
+		"/InstitutionalVolume/GetInstitutionalVolume",
+		"/TradeClusters/GetTradeClusters",
+		"/TradeClusterBombs/GetTradeClusterBombs",
+		"/TradeLevelTouches/GetTradeLevelTouches",
+		"/Trades/GetTrades",
+		"/ExecutiveSummary/GetExhaustionScores",
+	} {
+		if !seen[path] {
+			t.Fatalf("expected request to %s", path)
+		}
+	}
+
+	var got models.DailySummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal daily summary: %v", err)
+	}
+	if got.Date != "2026-04-28" {
+		t.Fatalf("date = %q, want 2026-04-28", got.Date)
+	}
+	if got.TopInstitutionalVolumeTickers[0].Ticker != "NVDA" {
+		t.Fatalf("expected NVDA top institutional volume, got %#v", got.TopInstitutionalVolumeTickers)
+	}
+	if got.TopClustersByMultiplier[0].Ticker != "NVDA" || got.TopClustersByMultiplier[0].DollarsMultiplier != 8 {
+		t.Fatalf("unexpected top multiplier clusters: %#v", got.TopClustersByMultiplier)
+	}
+	if len(got.RepeatedClusterTickers) != 1 || got.RepeatedClusterTickers[0].Ticker != "NVDA" {
+		t.Fatalf("unexpected repeated clusters: %#v", got.RepeatedClusterTickers)
+	}
+	if got.LevelTouches.ByRelativeSize[0].Ticker != "AMD" || got.LevelTouches.ByDollars[0].Ticker != "SPY" {
+		t.Fatalf("unexpected level touches: %#v", got.LevelTouches)
+	}
+	if got.LeveragedETFSentiment.Ratio == nil || *got.LeveragedETFSentiment.Ratio != 2 {
+		t.Fatalf("unexpected leveraged ETF sentiment: %#v", got.LeveragedETFSentiment)
+	}
+	if got.MarketExhaustion.DateKey != 20260428 {
+		t.Fatalf("unexpected exhaustion score: %#v", got.MarketExhaustion)
+	}
+}
+
+func TestDailySummaryRejectsInvalidLimit(t *testing.T) {
+	ctx := contextWithTestClient(t, "http://127.0.0.1")
+	root := &cli.Command{Commands: []*cli.Command{NewDailyCommand()}}
+	err := root.Run(ctx, []string{"app", "daily", "summary", "--date", "2026-04-28", "--limit", "0"})
+	assertErrContains(t, err, "--limit must be greater than 0")
+}
+
+func TestDailySummaryOutputUsesRequestedSectionNames(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ExecutiveSummary/GetExhaustionScores" {
+			fmt.Fprint(w, `{}`)
+			return
+		}
+		fmt.Fprint(w, dataTablesJSON(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewDailyCommand()}}
+		if err := root.Run(ctx, []string{"app", "daily", "summary", "--date", "2026-04-28"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, field := range []string{
+		"top_institutional_volume_tickers",
+		"top_clusters_by_dollars",
+		"top_clusters_by_multiplier",
+		"repeated_cluster_tickers",
+		"sector_totals",
+		"cluster_bombs",
+		"level_touches",
+		"leveraged_etf_sentiment",
+		"market_exhaustion",
+	} {
+		if !strings.Contains(output, field) {
+			t.Fatalf("expected output to contain %q, got %s", field, output)
+		}
+	}
+}

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -311,6 +311,39 @@ func TestTradeSentimentUsesCombinedLeverageFilter(t *testing.T) {
 	}
 }
 
+func TestTradeSentimentSupportsDelimitedFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[
+			{"Date":"/Date(1745193600000)/","Ticker":"SH","Sector":"X Bear","Dollars":100},
+			{"Date":"/Date(1745193600000)/","Ticker":"TQQQ","Sector":"X Bull","Dollars":200}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeSentimentCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "sentiment",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+			"--format", "csv",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "date,bear_trades,bear_dollars,bear_top_tickers,bull_trades,bull_dollars,bull_top_tickers,ratio,signal") {
+		t.Fatalf("expected sentiment CSV header, got %s", output)
+	}
+	if !strings.Contains(output, "2025-04-21,1,100,SH,1,200,TQQQ,2,neutral") {
+		t.Fatalf("expected daily sentiment CSV row, got %s", output)
+	}
+	if !strings.Contains(output, "total,1,100,SH,1,200,TQQQ,2,neutral") {
+		t.Fatalf("expected total sentiment CSV row, got %s", output)
+	}
+}
+
 func TestTradeSentimentRejectsMalformedPage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, dataTablesJSON(`{"not":"a trade array"}`))

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -91,6 +91,7 @@ volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-2
 				&cli.IntFlag{Name: "phantom", Value: 1, Usage: "Include phantom prints"},
 				&cli.IntFlag{Name: "offsetting", Value: 1, Usage: "Include offsetting trades"},
 			},
+			outputFormatFlags(),
 		),
 		Action: runTradeSentiment,
 	}
@@ -594,6 +595,11 @@ func tradeTickerDayKey(trade *models.Trade) string {
 }
 
 func runTradeSentiment(ctx context.Context, cmd *cli.Command) error {
+	format, err := parseOutputFormat(cmd.String("format"))
+	if err != nil {
+		return err
+	}
+
 	opts := &tradesOptions{
 		startDate:    cmd.String("start-date"),
 		endDate:      cmd.String("end-date"),
@@ -636,7 +642,51 @@ func runTradeSentiment(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	return printJSON(ctx, summarizeTradeSentiment(trades, cmd.String("start-date"), cmd.String("end-date")))
+	sentiment := summarizeTradeSentiment(trades, cmd.String("start-date"), cmd.String("end-date"))
+
+	if format == outputFormatJSON {
+		return printJSON(ctx, sentiment)
+	}
+
+	return printDataTablesResult(ctx, flattenTradeSentiment(&sentiment), nil, format)
+}
+
+func flattenTradeSentiment(summary *models.TradeSentiment) []models.TradeSentimentRow {
+	rows := make([]models.TradeSentimentRow, 0, len(summary.Daily)+1)
+	for i := range summary.Daily {
+		day := &summary.Daily[i]
+		rows = append(rows, tradeSentimentDayRow(day))
+	}
+	rows = append(rows, tradeSentimentTotalsRow(&summary.Totals))
+	return rows
+}
+
+func tradeSentimentDayRow(day *models.TradeSentimentDay) models.TradeSentimentRow {
+	return models.TradeSentimentRow{
+		Date:           day.Date,
+		BearTrades:     day.Bear.Trades,
+		BearDollars:    day.Bear.Dollars,
+		BearTopTickers: strings.Join(day.Bear.TopTickers, ";"),
+		BullTrades:     day.Bull.Trades,
+		BullDollars:    day.Bull.Dollars,
+		BullTopTickers: strings.Join(day.Bull.TopTickers, ";"),
+		Ratio:          day.Ratio,
+		Signal:         day.Signal,
+	}
+}
+
+func tradeSentimentTotalsRow(totals *models.TradeSentimentTotals) models.TradeSentimentRow {
+	return models.TradeSentimentRow{
+		Date:           "total",
+		BearTrades:     totals.Bear.Trades,
+		BearDollars:    totals.Bear.Dollars,
+		BearTopTickers: strings.Join(totals.Bear.TopTickers, ";"),
+		BullTrades:     totals.Bull.Trades,
+		BullDollars:    totals.Bull.Dollars,
+		BullTopTickers: strings.Join(totals.Bull.TopTickers, ";"),
+		Ratio:          totals.Ratio,
+		Signal:         totals.Signal,
+	}
 }
 
 func runTradeClusters(ctx context.Context, cmd *cli.Command) error {

--- a/internal/models/daily.go
+++ b/internal/models/daily.go
@@ -1,0 +1,96 @@
+package models
+
+// DailySummary is a compact cross-endpoint snapshot for one trading day.
+type DailySummary struct {
+	Date                          string                        `json:"date"`
+	TopInstitutionalVolumeTickers []DailyInstitutionalVolumeRow `json:"top_institutional_volume_tickers"`
+	TopClustersByDollars          []DailyClusterRow             `json:"top_clusters_by_dollars"`
+	TopClustersByMultiplier       []DailyClusterRow             `json:"top_clusters_by_multiplier"`
+	RepeatedClusterTickers        []DailyRepeatedClusterTicker  `json:"repeated_cluster_tickers"`
+	SectorTotals                  []DailySectorTotal            `json:"sector_totals"`
+	ClusterBombs                  []DailyClusterBombRow         `json:"cluster_bombs"`
+	LevelTouches                  DailyLevelTouchSummary        `json:"level_touches"`
+	LeveragedETFSentiment         DailyLeveragedETFSentiment    `json:"leveraged_etf_sentiment"`
+	MarketExhaustion              ExhaustionScore               `json:"market_exhaustion"`
+}
+
+// DailyInstitutionalVolumeRow summarizes high institutional volume tickers.
+type DailyInstitutionalVolumeRow struct {
+	Ticker                       string  `json:"ticker"`
+	Sector                       string  `json:"sector,omitempty"`
+	Price                        float64 `json:"price"`
+	Volume                       int     `json:"volume"`
+	TotalInstitutionalDollars    float64 `json:"total_institutional_dollars"`
+	TotalInstitutionalDollarRank int     `json:"total_institutional_dollar_rank"`
+}
+
+// DailyClusterRow summarizes one trade cluster in daily leaderboards.
+type DailyClusterRow struct {
+	Ticker                 string  `json:"ticker"`
+	Sector                 string  `json:"sector,omitempty"`
+	Dollars                float64 `json:"dollars"`
+	DollarsMultiplier      float64 `json:"dollars_multiplier"`
+	Volume                 int     `json:"volume"`
+	TradeCount             int     `json:"trade_count"`
+	TradeClusterRank       int     `json:"trade_cluster_rank"`
+	CumulativeDistribution float64 `json:"cumulative_distribution"`
+}
+
+// DailyRepeatedClusterTicker records tickers with multiple clusters in the day.
+type DailyRepeatedClusterTicker struct {
+	Ticker        string  `json:"ticker"`
+	Sector        string  `json:"sector,omitempty"`
+	Clusters      int     `json:"clusters"`
+	Dollars       float64 `json:"dollars"`
+	TradeCount    int     `json:"trade_count"`
+	MaxMultiplier float64 `json:"max_multiplier"`
+}
+
+// DailySectorTotal aggregates institutional activity by sector.
+type DailySectorTotal struct {
+	Sector     string  `json:"sector"`
+	Tickers    int     `json:"tickers"`
+	Trades     int     `json:"trades"`
+	Dollars    float64 `json:"dollars"`
+	Volume     int     `json:"volume"`
+	TradeCount int     `json:"trade_count"`
+}
+
+// DailyClusterBombRow summarizes high-priority cluster bomb entries.
+type DailyClusterBombRow struct {
+	Ticker                 string  `json:"ticker"`
+	Sector                 string  `json:"sector,omitempty"`
+	Dollars                float64 `json:"dollars"`
+	DollarsMultiplier      float64 `json:"dollars_multiplier"`
+	Volume                 int     `json:"volume"`
+	TradeCount             int     `json:"trade_count"`
+	TradeClusterBombRank   int     `json:"trade_cluster_bomb_rank"`
+	CumulativeDistribution float64 `json:"cumulative_distribution"`
+}
+
+// DailyLevelTouchSummary contains level-touch leaderboards using two sort keys.
+type DailyLevelTouchSummary struct {
+	ByRelativeSize []DailyLevelTouchRow `json:"by_relative_size"`
+	ByDollars      []DailyLevelTouchRow `json:"by_dollars"`
+}
+
+// DailyLevelTouchRow summarizes one notable level-touch event.
+type DailyLevelTouchRow struct {
+	Ticker            string  `json:"ticker"`
+	Sector            string  `json:"sector,omitempty"`
+	Price             float64 `json:"price"`
+	Dollars           float64 `json:"dollars"`
+	RelativeSize      float64 `json:"relative_size"`
+	Volume            int     `json:"volume"`
+	Trades            int     `json:"trades"`
+	TradeLevelRank    int     `json:"trade_level_rank"`
+	TradeLevelTouches int     `json:"trade_level_touches"`
+}
+
+// DailyLeveragedETFSentiment summarizes daily leveraged ETF directional flow.
+type DailyLeveragedETFSentiment struct {
+	Bear   TradeSentimentSide   `json:"bear"`
+	Bull   TradeSentimentSide   `json:"bull"`
+	Ratio  *float64             `json:"ratio"`
+	Signal TradeSentimentSignal `json:"signal"`
+}

--- a/internal/models/trade.go
+++ b/internal/models/trade.go
@@ -237,6 +237,20 @@ type TradeSentimentTotals struct {
 	Signal TradeSentimentSignal `json:"signal"`
 }
 
+// TradeSentimentRow is a flat representation of one day's sentiment data,
+// suitable for tabular (CSV/TSV) output.
+type TradeSentimentRow struct {
+	Date           string               `json:"date"`
+	BearTrades     int                  `json:"bear_trades"`
+	BearDollars    float64              `json:"bear_dollars"`
+	BearTopTickers string               `json:"bear_top_tickers"`
+	BullTrades     int                  `json:"bull_trades"`
+	BullDollars    float64              `json:"bull_dollars"`
+	BullTopTickers string               `json:"bull_top_tickers"`
+	Ratio          *float64             `json:"ratio"`
+	Signal         TradeSentimentSignal `json:"signal"`
+}
+
 // TradeSentimentSignal labels the bull/bear flow ratio for quick interpretation.
 type TradeSentimentSignal string
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -11,6 +11,7 @@ Output: compact JSON to stdout by default. List-style commands support `--format
 | I want to... | Command |
 |---|---|
 | Find large institutional trades in specific stocks | `trade list --tickers X --start-date D --end-date D` |
+| Get a compact daily institutional activity summary | `daily summary --date D` |
 | Compare leveraged ETF bull/bear flow | `trade sentiment --start-date D --end-date D` |
 | See where institutions are clustering trades | `trade clusters --start-date D --end-date D` |
 | Detect sudden aggressive institutional bursts | `trade cluster-bombs --start-date D --end-date D` |
@@ -36,11 +37,12 @@ Output: compact JSON to stdout by default. List-style commands support `--format
 
 Chain commands for deeper analysis:
 
-1. `volume institutional --date D` - find top institutional movers
-2. `trade list --tickers X --start-date D --end-date D` - drill into individual trades
-3. `trade levels --ticker X --start-date D --end-date D` - find key support/resistance levels
-4. `chart company --ticker X` - get company context
-5. `chart price-data --ticker X --start-date D --end-date D` - detailed price action with overlays
+1. `daily summary --date D` - get the compact market-wide institutional activity snapshot
+2. `volume institutional --date D` - inspect top institutional movers in detail
+3. `trade list --tickers X --start-date D --end-date D` - drill into individual trades
+4. `trade levels --ticker X --start-date D --end-date D` - find key support/resistance levels
+5. `chart company --ticker X` - get company context
+6. `chart price-data --ticker X --start-date D --end-date D` - detailed price action with overlays
 
 ## Conventions
 
@@ -50,7 +52,7 @@ Chain commands for deeper analysis:
 
 **Pagination**: `--start` (offset, default 0), `--length` (count, default varies, `-1` = all), `--order-col` (sort column index), `--order-dir` (`asc` or `desc`).
 
-**Output formats**: list-style object outputs accept `--format json|csv|tsv` (default `json`). CSV/TSV use output field names as headers. `--pretty` only affects JSON.
+**Output formats**: list-style object outputs accept `--format json|csv|tsv` (default `json`). CSV/TSV use output field names as headers. Nested summary commands, such as `daily summary`, are JSON-only unless their command docs say otherwise. `--pretty` only affects JSON.
 
 **Ticker flags**: `--tickers` takes comma-separated list (multi-ticker commands). `--ticker` takes a single symbol (single-ticker commands). Ticker-based trade subcommands accept `--ticker`, `--tickers`, `--symbol`, and `--symbols` aliases, so any form works there. `trade sentiment` intentionally does not accept ticker flags because it always analyzes the leveraged ETF universe.
 

--- a/skills/daily.md
+++ b/skills/daily.md
@@ -1,0 +1,50 @@
+# daily
+
+Compact cross-endpoint daily summaries for institutional activity. 1 subcommand. Use this first when you need a fast market-wide read before drilling into individual trade, volume, cluster, or level-touch commands.
+
+## daily summary
+
+Summarize one trading day across institutional volume, trade clusters, cluster bombs, level touches, leveraged ETF sentiment, sector totals, and market exhaustion. Output is compact JSON only because the response is a nested summary rather than a list-style table.
+
+Required: `--date`
+Optional: `--limit` (default `10`, maximum rows per leaderboard section)
+
+```bash
+volumeleaders-agent daily summary --date 2026-04-28
+volumeleaders-agent --pretty daily summary --date 2026-04-28 --limit 5
+```
+
+Output sections:
+
+- `date`: requested trading date.
+- `top_institutional_volume_tickers`: largest total institutional dollar volume tickers from `volume institutional` data.
+- `top_clusters_by_dollars`: largest trade clusters by dollar value.
+- `top_clusters_by_multiplier`: most unusual trade clusters by dollar multiplier.
+- `repeated_cluster_tickers`: tickers with two or more clusters on the requested day.
+- `sector_totals`: sector-level totals merged across institutional volume, clusters, cluster bombs, and level touches.
+- `cluster_bombs`: largest sudden aggressive cluster bursts.
+- `level_touches`: notable level-touch events split into `by_relative_size` and `by_dollars` leaderboards.
+- `leveraged_etf_sentiment`: leveraged ETF bull/bear flow using the same classifier and defaults as `trade sentiment`.
+- `market_exhaustion`: market exhaustion ranks from `market exhaustion` for the requested date.
+
+Data sources queried by this command:
+
+- `/InstitutionalVolume/GetInstitutionalVolume`
+- `/TradeClusters/GetTradeClusters`
+- `/TradeClusterBombs/GetTradeClusterBombs`
+- `/TradeLevelTouches/GetTradeLevelTouches`
+- `/Trades/GetTrades` with the leveraged ETF combined sector filter
+- `/ExecutiveSummary/GetExhaustionScores`
+
+Use follow-up commands for full detail:
+
+```bash
+# Drill into a ticker from the daily summary
+volumeleaders-agent trade list --tickers NVDA --start-date 2026-04-28 --end-date 2026-04-28
+
+# Inspect the full cluster table for the same day
+volumeleaders-agent trade clusters --start-date 2026-04-28 --end-date 2026-04-28 --length -1
+
+# Re-run leveraged ETF sentiment over a wider window
+volumeleaders-agent trade sentiment --start-date 2026-04-22 --end-date 2026-04-28
+```

--- a/skills/trade.md
+++ b/skills/trade.md
@@ -76,17 +76,20 @@ Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstit
 
 ## trade sentiment
 
-Summarize leveraged ETF institutional flow into daily bull/bear ratios. The command queries the combined leveraged ETF sector filter (`SectorIndustry=X B`) once, classifies bull and bear rows locally, aggregates dollars by day, and returns compact JSON for sentiment analysis.
+Summarize leveraged ETF institutional flow into daily bull/bear ratios. The command queries the combined leveraged ETF sector filter (`SectorIndustry=X B`) once, classifies bull and bear rows locally, aggregates dollars by day, and returns compact JSON by default for sentiment analysis.
 
 Required: `--start-date`, `--end-date`
-Optional: volume/price/dollar ranges, trade filters, trade type toggles, session toggles
+Optional: `--format json|csv|tsv`, volume/price/dollar ranges, trade filters, trade type toggles, session toggles
 Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`, `--relative-size 5`
 
 ```bash
 volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --min-dollars 5000000
+volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --format csv
 ```
 
-Output fields: `dateRange` (`start`, `end`), `daily` array, and `totals`. Each daily row includes `date`, `bear`, `bull`, `ratio`, and `signal`. `bear`, `bull`, and total side objects include `trades`, `dollars`, and `topTickers`. `ratio` is bull dollars divided by bear dollars; it is `null` when there is no bear flow. Signals use thresholds: `<0.2` `extreme_bear`, `<0.5` `moderate_bear`, `0.5-2.0` `neutral`, `>2.0-5.0` `moderate_bull`, `>5.0` `extreme_bull`.
+JSON output fields: `dateRange` (`start`, `end`), `daily` array, and `totals`. Each daily row includes `date`, `bear`, `bull`, `ratio`, and `signal`. `bear`, `bull`, and total side objects include `trades`, `dollars`, and `topTickers`. `ratio` is bull dollars divided by bear dollars; it is `null` when there is no bear flow. Signals use thresholds: `<0.2` `extreme_bear`, `<0.5` `moderate_bear`, `0.5-2.0` `neutral`, `>2.0-5.0` `moderate_bull`, `>5.0` `extreme_bull`.
+
+CSV/TSV output flattens each daily row plus a final `date=total` row with columns `date`, `bear_trades`, `bear_dollars`, `bear_top_tickers`, `bull_trades`, `bull_dollars`, `bull_top_tickers`, `ratio`, and `signal`.
 
 ## trade clusters
 


### PR DESCRIPTION
## Summary

- Add `daily summary` command aggregating 6 institutional data sources (volume, clusters, cluster bombs, level touches, sentiment, exhaustion) into a compact JSON snapshot. Closes #32.
- Add `--format json|csv|tsv` support to `trade sentiment` for consistency with other list-style commands. CSV/TSV flatten daily rows with a totals summary row. Closes #31.

## Changes

- **`internal/commands/daily.go`** / **`internal/models/daily.go`**: New command and response models for `daily summary`
- **`internal/commands/trade.go`** / **`internal/models/trade.go`**: `--format` flag on `trade sentiment`, `TradeSentimentRow` flat struct for tabular output
- **`internal/commands/app.go`**: Register `NewDailyCommand()`
- **`skills/`**: Updated skill docs and command chooser
- Tests: 3 new tests for daily aggregation + 1 new test for trade sentiment format flag