### PR TITLE
Refactor VolumeLeaders agent skills

### DIFF
--- a/skills/volumeleaders-agent/SKILL.md
+++ b/skills/volumeleaders-agent/SKILL.md
@@ -1,112 +1,86 @@
 # volumeleaders-agent
 
-CLI for querying institutional trade data from VolumeLeaders. Binary: `volumeleaders-agent`.
+CLI for VolumeLeaders institutional trade data. Use it for trades, daily summaries, volume leaderboards, charts, market data, alerts, and watchlists. Binary: `volumeleaders-agent`.
 
-Auth: extracts browser cookies automatically. User must be logged into volumeleaders.com. Auth errors mean the user needs to log in via their browser.
+Auth: reads browser cookies. If auth fails, the user must log in at volumeleaders.com in their browser.
 
-Output: compact JSON to stdout by default. List-style commands support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null/missing values as empty cells. Add `--pretty` before the command group for indented JSON output. Errors go to stderr.
+Output: compact JSON to stdout by default. Put `--pretty` before the command group for indented JSON. Errors/logs go to stderr.
 
 ## Command Chooser
 
-| I want to... | Command |
-|---|---|
-| Find large institutional trades in specific stocks | `trade list --tickers X --start-date D --end-date D` |
-| Get a compact daily institutional activity summary | `daily summary --date D` |
-| Compare leveraged ETF bull/bear flow | `trade sentiment --start-date D --end-date D` |
-| See where institutions are clustering trades | `trade clusters --start-date D --end-date D` |
-| Detect sudden aggressive institutional bursts | `trade cluster-bombs --start-date D --end-date D` |
-| Check system-flagged individual trade alerts | `trade alerts --date D` |
-| Check system-flagged cluster alerts | `trade cluster-alerts --date D` |
-| Find institutional support/resistance levels | `trade levels --ticker X --start-date D --end-date D` |
-| Track price revisiting institutional levels | `trade level-touches --start-date D --end-date D` |
-| See top institutional volume movers for a day | `volume institutional --date D` |
-| See after-hours institutional activity | `volume ah-institutional --date D` |
-| See overall volume leaders | `volume total --date D` |
-| Get 1-min price bars with trade overlays | `chart price-data --ticker X --start-date D --end-date D` |
-| Get a quick quote (bid/ask/last) | `chart snapshot --ticker X --date-key D` |
-| Get chart-ready institutional levels | `chart levels --ticker X --start-date D --end-date D` |
-| Get company metadata and averages | `chart company --ticker X` |
-| Get all current market prices | `market snapshots` |
-| Find upcoming earnings with institutional positioning | `market earnings --start-date D --end-date D` |
-| Check market exhaustion/reversal signals | `market exhaustion` |
-| View/create/edit/delete alert configs | `alert configs/create/edit/delete` |
-| View/create/edit/delete watchlists | `watchlist configs/create/edit/delete` |
-| Get tickers from a watchlist | `watchlist tickers` |
+| Goal | Command | Details |
+|---|---|---|
+| Find individual institutional trades | `trade list --tickers X --start-date D --end-date D` | `trade.md` |
+| Start with a market-wide daily snapshot | `daily summary --date D` | `daily.md` |
+| Compare leveraged ETF bull/bear flow | `trade sentiment --start-date D --end-date D` | Fixed leveraged ETF universe |
+| Find price-level trade clusters | `trade clusters --start-date D --end-date D` | Cluster conviction |
+| Find sudden aggressive bursts | `trade cluster-bombs --start-date D --end-date D` | Burst detection |
+| Check individual trade alerts | `trade alerts --date D` | System alerts |
+| Check cluster alerts | `trade cluster-alerts --date D` | System alerts |
+| Find support/resistance levels | `trade levels --ticker X --start-date D --end-date D` | One ticker |
+| Find price revisits to levels | `trade level-touches --start-date D --end-date D` | Level tests |
+| See institutional volume leaders | `volume institutional --date D` | `volume.md` |
+| See after-hours institutional leaders | `volume ah-institutional --date D` | `volume.md` |
+| See total volume leaders | `volume total --date D` | `volume.md` |
+| Get 1-min bars with trade overlays | `chart price-data --ticker X --start-date D --end-date D` | `chart.md` |
+| Get bid/ask/last quote | `chart snapshot --ticker X --date-key D` | JSON only |
+| Get chart-ready levels | `chart levels --ticker X --start-date D --end-date D` | Fewer filters than `trade levels` |
+| Get company metadata | `chart company --ticker X` | JSON only |
+| Get current prices | `market snapshots` | JSON object |
+| Find earnings with prior institutional activity | `market earnings --start-date D --end-date D` | CSV/TSV supported |
+| Check exhaustion/reversal signals | `market exhaustion [--date D]` | Lower rank = stronger signal |
+| Manage alert configs | `alert configs/create/edit/delete` | `alert.md` |
+| Manage watchlists | `watchlist configs/create/edit/delete` | `watchlist.md` |
+| Get watchlist tickers | `watchlist tickers --watchlist-key K` | Key from `watchlist configs` |
 
 ## Analysis Workflow
 
-Chain commands for deeper analysis:
+1. `daily summary --date D` for the broad read.
+2. `volume institutional --date D` for top dollar movers.
+3. `trade list --tickers X --start-date D --end-date D` for individual prints.
+4. `trade levels --ticker X --start-date D --end-date D` for support/resistance.
+5. `chart company --ticker X` for company context.
+6. `chart price-data --ticker X --start-date D --end-date D` for bar-level overlays.
 
-1. `daily summary --date D` - get the compact market-wide institutional activity snapshot
-2. `volume institutional --date D` - inspect top institutional movers in detail
-3. `trade list --tickers X --start-date D --end-date D` - drill into individual trades
-4. `trade levels --ticker X --start-date D --end-date D` - find key support/resistance levels
-5. `chart company --ticker X` - get company context
-6. `chart price-data --ticker X --start-date D --end-date D` - detailed price action with overlays
+## Global Conventions
 
-## Conventions
+- Dates: `YYYY-MM-DD`.
+- Pagination: `--start` offset, `--length` count, `--length -1` means all rows, `--order-col` sort column index, `--order-dir asc|desc`.
+- Toggle filters: `-1` all/unfiltered, `0` exclude, `1` include/only.
+- Tickers: `--tickers` is comma-separated, `--ticker` is single-symbol. Trade ticker filters also accept `--symbol` and `--symbols` aliases.
+- Output formats: list-style commands may support `--format json|csv|tsv`. CSV/TSV include headers, booleans render as `true`/`false`, null/missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless their command file says otherwise.
+- Performance: use explicit dates and tickers when possible. `--length -1` can return large datasets and slow summary aggregation.
 
-**Dates**: `YYYY-MM-DD` on all flags.
+## Trade Shared Flags
 
-**Toggle flags** (-1/0/1): `-1` = all/unfiltered, `0` = exclude, `1` = only. Applies to trade type and session flags.
-
-**Pagination**: `--start` (offset, default 0), `--length` (count, default varies, `-1` = all), `--order-col` (sort column index), `--order-dir` (`asc` or `desc`).
-
-**Output formats**: list-style object outputs accept `--format json|csv|tsv` (default `json`). CSV/TSV use output field names as headers. Nested summary commands, such as `daily summary`, are JSON-only unless their command docs say otherwise. `--pretty` only affects JSON.
-
-**Ticker flags**: `--tickers` takes comma-separated list (multi-ticker commands). `--ticker` takes a single symbol (single-ticker commands). Ticker-based trade subcommands accept `--ticker`, `--tickers`, `--symbol`, and `--symbols` aliases, so any form works there. `trade sentiment` intentionally does not accept ticker flags because it always analyzes the leveraged ETF universe.
-
-## Shared Flag Defaults
-
-These defaults apply across trade commands unless overridden (overrides noted per-subcommand).
+These defaults apply to trade commands only unless a subcommand overrides them. Chart commands use different names for some filters, see `chart.md`.
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--min-volume` / `--max-volume` | 0 / 2000000000 | |
-| `--min-price` / `--max-price` | 0 / 100000 | |
-| `--min-dollars` / `--max-dollars` | 500000 / 30000000000 | |
-| `--conditions` | -1 | |
-| `--vcd` | 0 | |
-| `--relative-size` | 5 | |
-| `--security-type` | -1 | |
-| `--market-cap` | 0 | |
-| `--trade-rank` | -1 | |
-| `--rank-snapshot` | -1 | |
-| `--dark-pools` | -1 | Toggle |
-| `--sweeps` | -1 | Toggle |
-| `--late-prints` | -1 | Toggle |
-| `--sig-prints` | -1 | Toggle |
-| `--even-shared` | -1 | |
-| `--premarket` | 1 | Session toggle |
-| `--rth` | 1 | Session toggle |
-| `--ah` | 1 | Session toggle |
-| `--opening` | 1 | Session toggle |
-| `--closing` | 1 | Session toggle |
-| `--phantom` | 1 | Session toggle |
-| `--offsetting` | 1 | Session toggle |
+| `--min-volume` / `--max-volume` | 0 / 2000000000 | Share range |
+| `--min-price` / `--max-price` | 0 / 100000 | Price range |
+| `--min-dollars` / `--max-dollars` | 500000 / 30000000000 | Dollar range |
+| `--conditions` | -1 | Trade condition filter |
+| `--vcd` | 0 | Volume Confirmation Distribution minimum |
+| `--relative-size` | 5 | Trade size vs normal activity |
+| `--security-type` | -1 | Security type filter |
+| `--market-cap` | 0 | Market cap filter |
+| `--trade-rank` / `--rank-snapshot` | -1 / -1 | Lower rank = more significant |
+| `--dark-pools`, `--sweeps`, `--late-prints`, `--sig-prints` | -1 | Toggle filters |
+| `--even-shared` | -1 | Even-share filter |
+| `--premarket`, `--rth`, `--ah`, `--opening`, `--closing`, `--phantom`, `--offsetting` | 1 | Session/event toggles |
 
-**Chart commands use different flag names** for some of these. See chart.md for the exact mapping.
+Trade sentiment overrides: `--min-dollars 5000000`, `--vcd 97`, and fixed `SectorIndustry=X B`; it keeps the shared `--relative-size 5` default. Users cannot override the sentiment universe with tickers or sector flags.
 
-**Trade sentiment overrides**: `trade sentiment` defaults to `--min-dollars 5000000` and `--vcd 97` because leveraged ETF sentiment is meant to highlight unusually large, high-confirmation flow.
-
-## Key Metrics Glossary
+## Key Metrics
 
 | Field | Meaning |
 |---|---|
-| `CumulativeDistribution` | Percentile position in volume distribution (0-1 scale, higher = more accumulation) |
-| `DollarsMultiplier` | Trade dollar value relative to average block size (higher = bigger than usual) |
-| `TradeRank` | VL proprietary significance ranking (lower = more significant) |
-| `TradeRankSnapshot` | TradeRank at time of trade (vs current recalculated rank) |
-| `RelativeSize` | Trade size vs average daily volume (higher = more unusual). Present on trade list, levels, and price-data outputs |
-| `PercentDailyVolume` | Trade volume as % of average daily volume. On trade list output |
+| `CumulativeDistribution` | Volume percentile, 0 to 1, higher = more accumulation |
+| `DollarsMultiplier` | Trade dollars relative to average block size |
+| `TradeRank`, `TradeRankSnapshot` | VL significance rank now vs at print time, lower = stronger |
+| `RelativeSize`, `PercentDailyVolume` | Trade size vs normal volume |
 | `VCD` | Volume Confirmation Distribution score |
-| `FrequencyLast30TD` | Count of similar-magnitude trades in last 30 trading days |
-| `FrequencyLast90TD` | Count of similar-magnitude trades in last 90 trading days |
-| `FrequencyLast1CY` | Count of similar-magnitude trades in last calendar year (~252 trading days) |
-| `RSIHour` / `RSIDay` | Relative Strength Index on hourly / daily timeframe |
-| `DarkPool` | Trade executed on a dark pool (boolean) |
-| `Sweep` | Aggressive order sweeping multiple price levels (boolean) |
-| `LatePrint` | Trade reported late to the tape (boolean) |
-| `SignaturePrint` | VL proprietary notable trade pattern (boolean) |
-| `PhantomPrint` | Trade that may not settle / gets cancelled (boolean) |
-| `InsideBar` | Price bar contained within prior bar's range (boolean) |
+| `FrequencyLast30TD`, `FrequencyLast90TD`, `FrequencyLast1CY` | Similar-magnitude trade frequency windows |
+| `RSIHour`, `RSIDay` | Hourly and daily RSI |
+| `DarkPool`, `Sweep`, `LatePrint`, `SignaturePrint`, `PhantomPrint`, `InsideBar` | Boolean trade/bar traits |

--- a/skills/volumeleaders-agent/alert.md
+++ b/skills/volumeleaders-agent/alert.md
@@ -1,55 +1,34 @@
 # alert
 
-Manage saved alert configurations. Alerts trigger when trades/clusters match threshold criteria.
+Manage saved alert configurations. Alerts trigger when trades or clusters match thresholds.
 
-## alert configs
-
-List all saved alert configurations.
-
-Optional: `--format json|csv|tsv`
+| Command | Use when | Required | Output |
+|---|---|---|---|
+| `alert configs` | List alert configs | none | JSON, CSV, TSV |
+| `alert delete` | Delete a config | `--key` | JSON |
+| `alert create` | Create a config | `--name` | JSON |
+| `alert edit` | Replace/update a config | `--key` | JSON |
 
 ```bash
-volumeleaders-agent alert configs
 volumeleaders-agent alert configs --format csv
-```
-
-Output fields: `AlertConfigKey` (use as `--key` for edit/delete), `Name`, `Tickers`, plus threshold fields. Threshold naming pattern: `{Category}{Metric}{LTE|GTE}` where LTE = max rank (lower rank = more significant) and GTE = minimum value (higher = bigger trade).
-
-Output format: `alert configs` defaults to JSON and supports CSV/TSV. Create/edit/delete responses remain JSON-only.
-
-## alert delete
-
-Required: `--key` (AlertConfigKey from `alert configs`)
-
-```bash
+volumeleaders-agent alert create --name "Top Trades" --tickers "AAPL,MSFT" --trade-rank-lte 5
+volumeleaders-agent alert edit --key 12345 --trade-rank-lte 3
 volumeleaders-agent alert delete --key 12345
 ```
 
-## alert create
+`alert configs` fields include `AlertConfigKey` for edit/delete, `Name`, `Tickers`, and threshold fields. Threshold names follow `{Category}{Metric}{LTE|GTE}` where LTE is maximum rank and GTE is minimum value.
 
-Required: `--name` (max 50 chars)
-Optional: `--ticker-group` (AllTickers or SelectedTickers, default AllTickers), `--tickers` (comma-separated, auto-sets SelectedTickers when provided)
+Create/edit options: `--name` max 50 chars, `--ticker-group AllTickers|SelectedTickers`, `--tickers` comma-separated and auto-selects `SelectedTickers`.
 
-Threshold flags (all default 0 = disabled):
+Threshold flags default to `0` disabled unless noted:
 
 | Category | Flags |
 |---|---|
-| **Trade** | `--trade-rank-lte` (0/1/3/5/10/25/50/100), `--trade-vcd-gte` (0/99/100), `--trade-mult-gte` (0/5/10/25/50/100), `--trade-volume-gte`, `--trade-dollars-gte`, `--trade-conditions` |
-| **Cluster** | `--cluster-rank-lte`, `--cluster-vcd-gte` (0/97/98/99/100), `--cluster-mult-gte`, `--cluster-volume-gte`, `--cluster-dollars-gte` |
-| **Closing** | `--closing-trade-rank-lte`, `--closing-trade-vcd-gte` (0/97/98/99/100), `--closing-trade-mult-gte`, `--closing-trade-volume-gte`, `--closing-trade-dollars-gte` |
-| **Total** | `--total-rank-lte` (0/1/3/10/25/50/100), `--total-volume-gte`, `--total-dollars-gte` |
-| **After-hours** | `--ah-rank-lte`, `--ah-volume-gte`, `--ah-dollars-gte` |
-| **Booleans** | `--dark-pool`, `--sweep`, `--offsetting-print`, `--phantom-print` (all default false) |
+| Trade | `--trade-rank-lte`, `--trade-vcd-gte`, `--trade-mult-gte`, `--trade-volume-gte`, `--trade-dollars-gte`, `--trade-conditions` |
+| Cluster | `--cluster-rank-lte`, `--cluster-vcd-gte`, `--cluster-mult-gte`, `--cluster-volume-gte`, `--cluster-dollars-gte` |
+| Closing | `--closing-trade-rank-lte`, `--closing-trade-vcd-gte`, `--closing-trade-mult-gte`, `--closing-trade-volume-gte`, `--closing-trade-dollars-gte`, `--closing-trade-conditions` |
+| Total | `--total-rank-lte`, `--total-volume-gte`, `--total-dollars-gte` |
+| After-hours | `--ah-rank-lte`, `--ah-volume-gte`, `--ah-dollars-gte` |
+| Booleans | `--dark-pool`, `--sweep`, `--offsetting-print`, `--phantom-print` |
 
-```bash
-volumeleaders-agent alert create --name "Top Trades" --tickers "AAPL,MSFT" --trade-rank-lte 5
-```
-
-## alert edit
-
-Required: `--key` (AlertConfigKey)
-All flags from `alert create` available. `--name` is optional for edit. Unspecified flags reset to their defaults.
-
-```bash
-volumeleaders-agent alert edit --key 12345 --trade-rank-lte 3
-```
+Edit gotcha: unspecified edit flags reset to defaults, so include every value that must remain set.

--- a/skills/volumeleaders-agent/chart.md
+++ b/skills/volumeleaders-agent/chart.md
@@ -1,85 +1,56 @@
 # chart
 
-Price data, snapshots, levels, and company metadata for individual tickers.
+Single-ticker price bars, quotes, chart-ready levels, and company metadata.
 
-**Flag name warning**: Chart commands use different flag names than trade commands for several filters. Differences are marked with bold annotations below.
+Chart filter names differ from trade commands: use `--signature-prints` not `--sig-prints`, `--trade-rank-snapshot` not `--rank-snapshot`, and `--include-premarket|rth|ah|opening|closing|phantom|offsetting` not bare session names.
 
 ## chart price-data
 
-One-minute OHLCV bars with institutional trade overlays. Each bar includes trade metadata when institutional trades occurred during that minute.
+One-minute OHLCV bars with institutional trade overlays.
 
-Required: `--ticker`, `--start-date`, `--end-date`
+Required: `--ticker`, `--start-date`, `--end-date`. Supports `--format json|csv|tsv`.
 
-Optional flags:
-
-| Flag | Default | Note |
-|---|---|---|
-| `--volume-profile` | 0 | 0=no, 1=yes |
-| `--levels` | 5 | Number of trade levels to overlay |
-| `--min-volume` / `--max-volume` | 0 / 2000000000 | |
-| `--min-price` / `--max-price` | 0 / 100000 | |
-| `--min-dollars` / `--max-dollars` | 500000 / 30000000000 | |
-| `--dark-pools` | -1 | Toggle |
-| `--sweeps` | -1 | Toggle |
-| `--late-prints` | -1 | Toggle |
-| **`--signature-prints`** | -1 | **Not `--sig-prints`** |
-| `--trade-count` | 3 | Min trades for overlay |
-| `--vcd` | 0 | |
-| `--trade-rank` | -1 | |
-| **`--trade-rank-snapshot`** | -1 | **Not `--rank-snapshot`** |
-| **`--include-premarket`** | 1 | **Not `--premarket`** |
-| **`--include-rth`** | 1 | **Not `--rth`** |
-| **`--include-ah`** | 1 | **Not `--ah`** |
-| **`--include-opening`** | 1 | **Not `--opening`** |
-| **`--include-closing`** | 1 | **Not `--closing`** |
-| **`--include-phantom`** | 1 | **Not `--phantom`** |
-| **`--include-offsetting`** | 1 | **Not `--offsetting`** |
-| `--format` | json | `json`, `csv`, or `tsv` |
+Important options: `--volume-profile 0|1`, `--levels 5`, `--trade-count 3`, volume/price/dollar ranges, `--dark-pools`, `--sweeps`, `--late-prints`, `--signature-prints`, `--vcd`, `--trade-rank`, `--trade-rank-snapshot`, include-session flags.
 
 ```bash
-volumeleaders-agent chart price-data --ticker AAPL --start-date 2025-04-23 --end-date 2025-04-23
-volumeleaders-agent chart price-data --ticker AAPL --start-date 2025-04-23 --end-date 2025-04-23 --format tsv
+volumeleaders-agent chart price-data --ticker AAPL --start-date 2026-04-28 --end-date 2026-04-28
+volumeleaders-agent chart price-data --ticker AAPL --start-date 2026-04-28 --end-date 2026-04-28 --format tsv
 ```
 
-Output fields (PriceBar model): `DateKey`, `TimeKey`, `Date`, `FullDateTime`, `FullTimeString24`, `OpenPrice`, `ClosePrice`, `HighPrice`, `LowPrice`, `Volume`, `Dollars`, `Trades`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `TradeLevelRank`, `DollarsMultiplier`, `RelativeSize`, `DarkPoolTrade` (note: NOT `DarkPool`), `LatePrint`, `OpeningTrade`, `ClosingTrade`, `SignaturePrint`, `PhantomPrint`, `Sweep`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FrequencyLast1CY`
+Key fields: `DateKey`, `TimeKey`, `Date`, `FullDateTime`, `OpenPrice`, `ClosePrice`, `HighPrice`, `LowPrice`, `Volume`, `Dollars`, `Trades`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `TradeLevelRank`, `DollarsMultiplier`, `RelativeSize`, `DarkPoolTrade`, `LatePrint`, `OpeningTrade`, `ClosingTrade`, `SignaturePrint`, `PhantomPrint`, `Sweep`, frequency fields.
 
 ## chart snapshot
 
-Quick quote with bid/ask/last for a single ticker.
+Quick quote for one ticker. JSON-only single object.
 
-Required: `--ticker`, `--date-key` (YYYY-MM-DD)
+Required: `--ticker`, `--date-key`.
 
 ```bash
-volumeleaders-agent chart snapshot --ticker AAPL --date-key 2025-04-23
+volumeleaders-agent chart snapshot --ticker AAPL --date-key 2026-04-28
 ```
 
-Output fields: `ticker`, `lastQuote` (nested: `p`=bid price, `s`=bid size, `P`=ask price, `S`=ask size, `t`=timestamp), `lastTrade` (nested: `p`=last trade price), `todaysChange`, `todaysChangePerc`
-
-Note: `lastQuote` and `lastTrade` use single-letter JSON keys, not descriptive names.
+Fields: `ticker`, `lastQuote`, `lastTrade`, `todaysChange`, `todaysChangePerc`. `lastQuote` and `lastTrade` use compact single-letter keys from the source API.
 
 ## chart levels
 
-Institutional price levels for charting. Simpler interface than `trade levels` with fewer filter options.
+Chart-ready institutional price levels with fewer filters than `trade levels`.
 
-Required: `--ticker`, `--start-date`, `--end-date`
-Optional: `--levels` (default 5), `--format json|csv|tsv`
+Required: `--ticker`, `--start-date`, `--end-date`. Optional: `--levels` default `5`, `--format json|csv|tsv`.
 
 ```bash
-volumeleaders-agent chart levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-04-23 --levels 10
+volumeleaders-agent chart levels --ticker AAPL --start-date 2026-01-01 --end-date 2026-04-28 --levels 10
 ```
 
-Output fields: same TradeLevel model as `trade levels`.
-
-Output format: `chart price-data` and `chart levels` default to JSON and support CSV/TSV. `chart snapshot` and `chart company` remain JSON-only single-object outputs.
+Fields: same TradeLevel model as `trade levels`.
 
 ## chart company
 
-Company metadata: fundamentals, sector/industry, and trading averages.
+Company metadata, fundamentals, sector/industry, and trading averages. JSON-only single object.
 
-Required: `--ticker`
+Required: `--ticker`.
 
 ```bash
 volumeleaders-agent chart company --ticker AAPL
 ```
 
-Output fields: `SecurityKey`, `Name`, `Ticker`, `Sector`, `Industry`, `Description`, `HomePageURL`, `MarketCap`, `CurrentPrice`, `OptionsEnabled`, `IPODate`, plus averages in all-time / 30-day / 90-day variants: `AverageBlockSizeDollars[30Days|90Days]`, `AverageDailyVolume[30Days|90Days]`, `AverageTradeShares[30Days|90Days]`, `AverageDailyRange[30Days|90Days]`, `AverageDailyRangePct[30Days|90Days]`, `AverageClosingTradeDollars[30Days|90Days]`, `AverageClusterSizeDollars`, `AverageLevelSizeDollars`
+Key fields: `SecurityKey`, `Name`, `Ticker`, `Sector`, `Industry`, `Description`, `HomePageURL`, `MarketCap`, `CurrentPrice`, `OptionsEnabled`, `IPODate`, all-time/30-day/90-day average block, volume, trade-share, range, closing-trade, cluster-size, and level-size fields.

--- a/skills/volumeleaders-agent/daily.md
+++ b/skills/volumeleaders-agent/daily.md
@@ -1,50 +1,26 @@
 # daily
 
-Compact cross-endpoint daily summaries for institutional activity. 1 subcommand. Use this first when you need a fast market-wide read before drilling into individual trade, volume, cluster, or level-touch commands.
+Use `daily summary` first when the user wants a fast market-wide institutional activity read before drilling into trades, volume, clusters, or levels.
 
 ## daily summary
 
-Summarize one trading day across institutional volume, trade clusters, cluster bombs, level touches, leveraged ETF sentiment, sector totals, and market exhaustion. Output is compact JSON only because the response is a nested summary rather than a list-style table.
+Nested JSON-only summary for one trading day.
 
-Required: `--date`
-Optional: `--limit` (default `10`, maximum rows per leaderboard section)
+Required: `--date`. Optional: `--limit` leaderboard row limit, default `10`.
 
 ```bash
 volumeleaders-agent daily summary --date 2026-04-28
 volumeleaders-agent --pretty daily summary --date 2026-04-28 --limit 5
 ```
 
-Output sections:
+Output sections: `date`, `top_institutional_volume_tickers`, `top_clusters_by_dollars`, `top_clusters_by_multiplier`, `repeated_cluster_tickers`, `sector_totals`, `cluster_bombs`, `level_touches` split by relative size and dollars, `leveraged_etf_sentiment`, `market_exhaustion`.
 
-- `date`: requested trading date.
-- `top_institutional_volume_tickers`: largest total institutional dollar volume tickers from `volume institutional` data.
-- `top_clusters_by_dollars`: largest trade clusters by dollar value.
-- `top_clusters_by_multiplier`: most unusual trade clusters by dollar multiplier.
-- `repeated_cluster_tickers`: tickers with two or more clusters on the requested day.
-- `sector_totals`: sector-level totals merged across institutional volume, clusters, cluster bombs, and level touches.
-- `cluster_bombs`: largest sudden aggressive cluster bursts.
-- `level_touches`: notable level-touch events split into `by_relative_size` and `by_dollars` leaderboards.
-- `leveraged_etf_sentiment`: leveraged ETF bull/bear flow using the same classifier and defaults as `trade sentiment`.
-- `market_exhaustion`: market exhaustion ranks from `market exhaustion` for the requested date.
+Data sources: institutional volume, trade clusters, cluster bombs, level touches, leveraged ETF sentiment via `Trades/GetTrades`, and exhaustion scores.
 
-Data sources queried by this command:
-
-- `/InstitutionalVolume/GetInstitutionalVolume`
-- `/TradeClusters/GetTradeClusters`
-- `/TradeClusterBombs/GetTradeClusterBombs`
-- `/TradeLevelTouches/GetTradeLevelTouches`
-- `/Trades/GetTrades` with the leveraged ETF combined sector filter
-- `/ExecutiveSummary/GetExhaustionScores`
-
-Use follow-up commands for full detail:
+Follow up with:
 
 ```bash
-# Drill into a ticker from the daily summary
 volumeleaders-agent trade list --tickers NVDA --start-date 2026-04-28 --end-date 2026-04-28
-
-# Inspect the full cluster table for the same day
 volumeleaders-agent trade clusters --start-date 2026-04-28 --end-date 2026-04-28 --length -1
-
-# Re-run leveraged ETF sentiment over a wider window
 volumeleaders-agent trade sentiment --start-date 2026-04-22 --end-date 2026-04-28
 ```

--- a/skills/volumeleaders-agent/market.md
+++ b/skills/volumeleaders-agent/market.md
@@ -1,51 +1,19 @@
 # market
 
-Market-wide data: prices, earnings calendar, exhaustion scores.
+Market-wide prices, earnings calendar, and exhaustion scores.
 
-## market snapshots
-
-Current prices for all tracked symbols. No flags.
+| Command | Use when | Required | Output |
+|---|---|---|---|
+| `market snapshots` | Get current prices for all tracked symbols | none | JSON object |
+| `market earnings` | Find earnings with prior institutional activity | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `market exhaustion` | Check reversal/exhaustion signals | none | JSON |
 
 ```bash
 volumeleaders-agent market snapshots
+volumeleaders-agent market earnings --start-date 2026-04-21 --end-date 2026-04-28 --format csv
+volumeleaders-agent market exhaustion --date 2026-04-28
 ```
 
-Output: JSON object mapping ticker to price data.
+`market earnings` fields: `Ticker`, `Name`, `Sector`, `Industry`, `EarningsDate`, `AfterMarketClose`, `TradeCount`, `TradeClusterCount`, `TradeClusterBombCount`.
 
-## market earnings
-
-Earnings calendar with institutional activity counts. Shows how much institutional positioning preceded each earnings event.
-
-Required: `--start-date`, `--end-date`
-Optional: `--format json|csv|tsv`
-
-```bash
-volumeleaders-agent market earnings --start-date 2025-04-21 --end-date 2025-04-25
-volumeleaders-agent market earnings --start-date 2025-04-21 --end-date 2025-04-25 --format csv
-```
-
-Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `EarningsDate`, `AfterMarketClose` (bool), `TradeCount`, `TradeClusterCount`, `TradeClusterBombCount`
-
-Output format: `market earnings` defaults to JSON and supports CSV/TSV. `market snapshots` and `market exhaustion` remain JSON-only.
-
-## market exhaustion
-
-Market exhaustion scores indicating potential trend reversals. Measures when institutional buying/selling pressure may be running out of steam.
-
-Optional: `--date` (omit for current day)
-
-```bash
-volumeleaders-agent market exhaustion
-```
-
-Output fields:
-
-| Field | Meaning |
-|---|---|
-| `DateKey` | Trading date (YYYYMMDD format) |
-| `ExhaustionScoreRank` | Raw exhaustion score (unbounded, higher = more exhausted) |
-| `ExhaustionScoreRank30Day` | Rank within last ~21 trading days (1 = most exhausted) |
-| `ExhaustionScoreRank90Day` | Rank within last ~63 trading days |
-| `ExhaustionScoreRank365Day` | Rank within last ~252 trading days |
-
-Interpreting: **lower rank = stronger exhaustion signal**. When multiple timeframes rank low simultaneously, the reversal signal is reinforced. High ranks across all timeframes means the trend likely has room to continue.
+`market exhaustion` optional flag: `--date`, omitted for current day. Fields: `DateKey`, `ExhaustionScoreRank`, `ExhaustionScoreRank30Day`, `ExhaustionScoreRank90Day`, `ExhaustionScoreRank365Day`. Lower rank = stronger exhaustion signal. Multiple low ranks across timeframes reinforce reversal risk.

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -1,179 +1,101 @@
 # trade
 
-Institutional trade discovery. 10 subcommands. See SKILL.md for shared flag defaults and metrics glossary.
+Institutional trade discovery. See `SKILL.md` for global conventions, trade shared flags, and metric meanings.
 
-## trade presets
+## Quick Reference
 
-List all built-in trade filter presets. No authentication required. Output is a JSON array by default, with `--format csv|tsv` available for tabular output. Fields: `Name`, `Group`, `Filters`.
+| Command | Use when | Required | Output |
+|---|---|---|---|
+| `trade presets` | List built-in filters | none | JSON, CSV, TSV |
+| `trade preset-tickers` | Inspect a preset universe | `--preset` | JSON |
+| `trade list` | Query individual trades | none | JSON, CSV, TSV, or summary JSON |
+| `trade sentiment` | Bull/bear leveraged ETF flow | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `trade clusters` | Converging trades at price levels | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `trade cluster-bombs` | Sudden aggressive bursts | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `trade alerts` | System trade alerts | `--date` | JSON, CSV, TSV |
+| `trade cluster-alerts` | System cluster alerts | `--date` | JSON, CSV, TSV |
+| `trade levels` | Support/resistance by ticker | `--ticker` | JSON, CSV, TSV |
+| `trade level-touches` | Price revisits institutional levels | `--start-date`, `--end-date` | JSON, CSV, TSV |
 
-Groups: "Common" (general-purpose filters), "Disproportionately Large" (>=5x avg size, sector/ticker-based).
+## Presets
+
+`trade presets` lists built-in filters. Groups: `Common`, `Disproportionately Large`.
+
+`trade preset-tickers --preset NAME` returns `Preset`, `Group`, `Type`, and either `Tickers` or `SectorIndustry`. Types: `tickers`, `sector-filter`, `unfiltered`. Ticker output takes precedence if both ticker and sector filters exist.
 
 ```bash
-volumeleaders-agent trade presets
 volumeleaders-agent trade presets --format csv
-volumeleaders-agent trade presets --pretty | jq '.[].Name'
-```
-
-## trade preset-tickers
-
-Extract ticker symbols from a named preset. No authentication required. Returns a JSON object with the preset name, group, type, and either a ticker list or sector filter value.
-
-Required: `--preset NAME` (case-insensitive)
-
-Types: `"tickers"` (explicit ticker list), `"sector-filter"` (SectorIndustry-based), `"unfiltered"` (no ticker/sector restriction).
-
-```bash
 volumeleaders-agent trade preset-tickers --preset "Megacaps"
-# {"Preset":"Megacaps","Group":"Disproportionately Large","Type":"tickers","Tickers":["AAPL","AMZN","META","GOOG","GOOGL","MSFT","NFLX","NVDA","TSLA"]}
-
-volumeleaders-agent trade preset-tickers --preset "Bear Leverage"
-# {"Preset":"Bear Leverage","Group":"Disproportionately Large","Type":"sector-filter","SectorIndustry":"X Bear"}
-
-volumeleaders-agent trade preset-tickers --preset "All Trades"
-# {"Preset":"All Trades","Group":"Common","Type":"unfiltered"}
 ```
-
-Output fields: `Preset`, `Group`, `Type`, `Tickers` (trimmed, deduplicated, omitted when empty), `SectorIndustry` (omitted when empty). If a preset defines both `Tickers` and `SectorIndustry`, ticker output takes precedence.
 
 ## trade list
 
-Query individual institutional block trades. The primary trade discovery command.
+Primary individual-print query. Optional flags: `--start-date`, `--end-date`, ticker aliases, `--sector`, `--preset`, `--watchlist`, `--fields`, `--format`, `--summary`, `--group-by`, trade shared flags, pagination.
 
-Required: none (dates have smart defaults)
-Optional: `--start-date`, `--end-date`, `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, `--preset`, `--watchlist`, `--fields`, `--format json|csv|tsv`, `--summary`, `--group-by`, all shared flags (volume/price/dollar ranges, trade filters, trade type toggles, session toggles), pagination (`--length 100 --order-col 1 --order-dir desc`)
+Date defaults: with tickers, 90-day lookback from today. Without tickers, today only. Explicit dates override defaults. Presets and watchlists never supply dates.
 
-**Date defaults**: When `--start-date` or `--end-date` are omitted, smart defaults apply. With `--tickers`: 90-day lookback from today. Without `--tickers` (broad scan): today only. Explicit `--start-date` and `--end-date` override these defaults. Dates are never inherited from presets or watchlists.
+Filter precedence: preset baseline, then watchlist merge, then explicit CLI flags override both.
 
-**`--preset NAME`**: Apply a built-in filter preset by name (case-insensitive). The preset sets baseline filters; any explicitly-provided CLI flags override the preset values. Use `trade presets` to list available names.
+Summary mode: `--summary` returns aggregate JSON instead of rows. Valid `--group-by`: `ticker`, `day`, `ticker,day`. Summary respects pagination, so use `--length -1` for all matching rows. `--fields` and non-JSON `--format` are invalid with `--summary`.
 
-**`--watchlist NAME`**: Apply filters from a saved user watchlist by name (case-insensitive). Fetches the watchlist config at runtime and converts its settings to trade filters. Use `watchlist configs` to list available names.
-
-**`--fields FIELD1,FIELD2`**: Return only the listed trade fields in each JSON object, or use the listed fields as CSV/TSV columns. Field names are case-sensitive and must match the output field names below. Invalid names fail before querying the API and include the valid field list in the error.
-
-**`--format json|csv|tsv`**: Select output format for list results. JSON is the default. CSV/TSV include a header row, render booleans as `true`/`false`, and render null/missing values as empty cells. Summary output is JSON-only.
-
-**`--summary`**: Return aggregate metrics instead of individual trade rows. The summary includes `totalTrades`, `totalDollars`, `dateRange`, and one grouped section. Metrics per group are `trades`, `dollars`, `avgDollarsMultiplier`, `pctDarkPool`, `pctSweep`, and `avgCumulativeDistribution`. Summaries respect pagination. Use `--length -1` to aggregate all matching rows. `--fields` and non-JSON `--format` values cannot be used with `--summary`.
-
-**`--group-by VALUE`**: Select the summary grouping. Valid values are `ticker` (default, outputs `byTicker` keyed by `TICKER`), `day` (outputs `byDay` keyed by `YYYY-MM-DD`), and `ticker,day` (outputs `byTickerDay` keyed by `TICKER|YYYY-MM-DD`). Only applies with `--summary`; explicit `--group-by` without `--summary` is rejected.
-
-Preset and watchlist filters can be combined: watchlist filters merge on top of preset filters, and explicit CLI flags override both.
+Fields mode: `--fields FIELD1,FIELD2` limits JSON keys or CSV/TSV columns. Names are case-sensitive and validated before the API query.
 
 ```bash
-# With tickers: defaults to 90-day lookback
 volumeleaders-agent trade list --tickers AAPL --dark-pools 1 --min-dollars 1000000
-# Without tickers (broad scan): defaults to today only
-volumeleaders-agent trade list --preset "Top-100 Rank"
-# Explicit dates override defaults
-volumeleaders-agent trade list --tickers AAPL --start-date 2025-04-16 --end-date 2025-04-23 --dark-pools 1 --min-dollars 1000000
-volumeleaders-agent trade list --preset "Megacaps" --start-date 2025-04-01 --end-date 2025-04-24 --trade-rank 10
-volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
-volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars,DollarsMultiplier,DarkPool,CumulativeDistribution
-volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2025-04-21 --end-date 2025-04-25 --summary --group-by ticker,day
-volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2025-04-21 --end-date 2025-04-25 --fields Date,Ticker,Dollars --format csv
+volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2026-04-28 --end-date 2026-04-28
+volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2026-04-01 --end-date 2026-04-28
+volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2026-04-21 --end-date 2026-04-28 --summary --group-by ticker,day --length -1
+volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2026-04-21 --end-date 2026-04-28 --fields Date,Ticker,Dollars --format csv
 ```
 
-Output fields: `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `Ask`, `AverageBlockSizeDollars`, `AverageBlockSizeShares`, `AverageDailyVolume`, `Bid`, `Cancelled`, `ClosePrice`, `ClosingTrade`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `CumulativeDistribution`, `DarkPool`, `Date`, `DateKey`, `Dollars`, `DollarsMultiplier`, `DoubleInsideBar`, `EOM`, `EOQ`, `EOY`, `EndDate`, `ExternalFeed`, `FrequencyLast1CY`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FullDateTime`, `FullTimeString24`, `IPODate`, `Industry`, `InsideBar`, `LastComparibleTradeDate`, `LatePrint`, `Name`, `NewPosition`, `OPEX`, `OffsettingTradeDate`, `OpeningTrade`, `PercentDailyVolume`, `PhantomPrint`, `PhantomPrintFulfillmentDate`, `PhantomPrintFulfillmentDays`, `Price`, `RelativeSize`, `RSIDay`, `RSIHour`, `Sector`, `SecurityKey`, `SequenceNumber`, `SignaturePrint`, `StartDate`, `Sweep`, `TD1CY`, `TD30`, `TD90`, `Ticker`, `TimeKey`, `TotalDollars`, `TotalDollarsRank`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `TotalRows`, `TotalTrades`, `TotalVolume`, `TradeConditions`, `TradeCount`, `TradeID`, `TradeRank`, `TradeRankSnapshot`, `VOLEX`, `Volume`
+Key row fields: `Date`, `FullDateTime`, `Ticker`, `Name`, `Sector`, `Industry`, `Price`, `Volume`, `Dollars`, `DollarsMultiplier`, `CumulativeDistribution`, `RelativeSize`, `PercentDailyVolume`, `TradeRank`, `TradeRankSnapshot`, `VCD`, `DarkPool`, `Sweep`, `LatePrint`, `SignaturePrint`, `PhantomPrint`, `OpeningTrade`, `ClosingTrade`, `RSIHour`, `RSIDay`, `TotalRows`.
 
 ## trade sentiment
 
-Summarize leveraged ETF institutional flow into daily bull/bear ratios. The command queries the combined leveraged ETF sector filter (`SectorIndustry=X B`) once, classifies bull and bear rows locally, aggregates dollars by day, and returns compact JSON by default for sentiment analysis.
+Daily bull/bear leveraged ETF flow. The command always queries the combined leveraged ETF sector filter `SectorIndustry=X B`, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags.
 
-Required: `--start-date`, `--end-date`
-Optional: `--format json|csv|tsv`, volume/price/dollar ranges, trade filters, trade type toggles, session toggles
-Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`, `--relative-size 5`
+Required: `--start-date`, `--end-date`. Optional: `--format json|csv|tsv`, trade shared flags except ticker/sector filters. Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`; shared `--relative-size 5` still applies.
 
 ```bash
-volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --min-dollars 5000000
-volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --format csv
+volumeleaders-agent trade sentiment --start-date 2026-04-21 --end-date 2026-04-28
+volumeleaders-agent trade sentiment --start-date 2026-04-21 --end-date 2026-04-28 --format csv
 ```
 
-JSON output fields: `dateRange` (`start`, `end`), `daily` array, and `totals`. Each daily row includes `date`, `bear`, `bull`, `ratio`, and `signal`. `bear`, `bull`, and total side objects include `trades`, `dollars`, and `topTickers`. `ratio` is bull dollars divided by bear dollars; it is `null` when there is no bear flow. Signals use thresholds: `<0.2` `extreme_bear`, `<0.5` `moderate_bear`, `0.5-2.0` `neutral`, `>2.0-5.0` `moderate_bull`, `>5.0` `extreme_bull`.
+JSON: `dateRange`, `daily`, `totals`. Daily rows include `date`, `bear`, `bull`, `ratio`, `signal`. Ratio is bull dollars divided by bear dollars, `null` when bear flow is zero. Signals: `<0.2 extreme_bear`, `<0.5 moderate_bear`, `0.5-2.0 neutral`, `>2.0-5.0 moderate_bull`, `>5.0 extreme_bull`. CSV/TSV flatten daily rows and add a final `date=total` row.
 
-CSV/TSV output flattens each daily row plus a final `date=total` row with columns `date`, `bear_trades`, `bear_dollars`, `bear_top_tickers`, `bull_trades`, `bull_dollars`, `bull_top_tickers`, `ratio`, and `signal`.
+## Clusters and cluster bombs
 
-## trade clusters
+`trade clusters` finds multiple institutional trades converging at similar prices. Defaults: `--min-dollars 10000000`, `--length 1000`, `--order-col 1`, `--order-dir desc`. Optional filters: ticker aliases, `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank`, format, pagination.
 
-Aggregated clusters where multiple institutional trades converge at similar price levels. Clusters signal stronger conviction than individual trades.
-
-Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank` (-1), `--format json|csv|tsv`, pagination (`--length 1000 --order-col 1 --order-dir desc`)
-Non-standard defaults: `--min-dollars 10000000`, `--length 1000`
+`trade cluster-bombs` finds sudden, aggressive bursts tightly grouped in time and price. Defaults: `--min-dollars 0`, `--security-type 0`, `--relative-size 0`, `--length 100`. It has no price range filters and uses `--trade-cluster-bomb-rank`.
 
 ```bash
-volumeleaders-agent trade clusters --start-date 2025-04-01 --end-date 2025-04-23 --min-dollars 50000000
+volumeleaders-agent trade clusters --start-date 2026-04-01 --end-date 2026-04-28 --min-dollars 50000000
+volumeleaders-agent trade cluster-bombs --start-date 2026-04-28 --end-date 2026-04-28
 ```
 
-Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `Price`, `Dollars`, `Volume`, `TradeCount`, `DollarsMultiplier`, `CumulativeDistribution`, `AverageDailyVolume`, `TradeClusterRank`, `MinFullDateTime`, `MaxFullDateTime`, `ClosePrice`, `InsideBar`, `DoubleInsideBar`, `LastComparibleTradeClusterDate`, `TotalRows`
+Key fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `Price`, `Dollars`, `Volume`, `TradeCount`, `DollarsMultiplier`, `CumulativeDistribution`, `TradeClusterRank` or `TradeClusterBombRank`, `MinFullDateTime`, `MaxFullDateTime`, `TotalRows`.
 
-## trade cluster-bombs
+## Alerts
 
-Sudden, aggressive institutional positioning bursts. Many trades clustered tightly in time and price.
-
-Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), `--sector`, volume/dollar ranges (no price range), `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-bomb-rank` (-1), `--format json|csv|tsv`, pagination (`--length 1000 --order-col 1 --order-dir desc`)
-Non-standard defaults: `--min-dollars 0`, `--security-type 0`, `--relative-size 0`
+`trade alerts --date D` returns system-generated individual trade alerts. `trade cluster-alerts --date D` returns system-generated cluster alerts. Both support `--format json|csv|tsv` and pagination.
 
 ```bash
-volumeleaders-agent trade cluster-bombs --start-date 2025-04-23 --end-date 2025-04-23
+volumeleaders-agent trade alerts --date 2026-04-28
+volumeleaders-agent trade cluster-alerts --date 2026-04-28 --format tsv
 ```
 
-Output fields: same as clusters but `TradeClusterBombRank` instead of `TradeClusterRank`, `LastComparableTradeClusterBombDate` instead of `LastComparibleTradeClusterDate`.
+Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, `VolumeCumulativeDistribution`, `DollarsMultiplier`, `Volume`, `Dollars`, booleans, `FullDateTime`, `InProcess`, `Complete`. Cluster alert fields match `trade clusters`.
 
-## trade alerts
+## Levels and level touches
 
-System-generated notifications about notable individual trades for a single date.
+`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted). Optional: `--start-date`, `--end-date`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--format`. Defaults to a 1-year lookback when dates are omitted. Non-standard default: `--relative-size 0`. No pagination.
 
-Required: `--date`
-Optional: `--format json|csv|tsv`, pagination
-
-```bash
-volumeleaders-agent trade alerts --date 2025-04-23
-```
-
-Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `AlertType`, `Price`, `TradeRank`, `VolumeCumulativeDistribution`, `DollarsMultiplier`, `Volume`, `Dollars`, `RSIHour`, `RSIDay`, `DarkPool`, `Sweep`, `LatePrint`, `SignaturePrint`, `ClosingTrade`, `PhantomPrint`, `FullDateTime`, `InProcess`, `Complete`
-
-## trade cluster-alerts
-
-System-generated notifications about notable trade clusters for a single date.
-
-Required: `--date`
-Optional: `--format json|csv|tsv`, pagination
+`trade level-touches` finds events where price revisits institutional levels. Required: `--start-date`, `--end-date`. Optional: ticker aliases, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--order-col 0`, `--order-dir desc`.
 
 ```bash
-volumeleaders-agent trade cluster-alerts --date 2025-04-23
-```
-
-Output fields: same as trade clusters.
-
-## trade levels
-
-Significant institutional price levels for a single ticker. These levels often act as support/resistance.
-
-Required: `--ticker` (single; aliases: `--tickers`, `--symbol`, `--symbols`)
-Optional: `--start-date`, `--end-date`, volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (-1), `--trade-level-count` (10), `--format json|csv|tsv`
-Non-standard defaults: `--relative-size 0`. No pagination flags.
-
-**Date defaults**: When dates are omitted, defaults to a 1-year lookback from today. Explicit `--start-date` and `--end-date` override these defaults.
-
-```bash
-# Defaults to 1-year lookback
 volumeleaders-agent trade levels --ticker AAPL
-# Explicit dates override defaults
-volumeleaders-agent trade levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-04-23
+volumeleaders-agent trade level-touches --start-date 2026-04-28 --end-date 2026-04-28
 ```
 
-Output fields: `Ticker`, `Name`, `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `MinDate`, `MaxDate`, `Dates`
-
-## trade level-touches
-
-Events where price revisits significant institutional price levels. Signals support/resistance tests or institutional re-engagement.
-
-Required: `--start-date`, `--end-date`
-Optional: `--tickers` (aliases: `--ticker`, `--symbol`, `--symbols`), volume/price/dollar ranges, `--vcd`, `--trade-level-rank` (10), `--format json|csv|tsv`, pagination (`--length 100 --order-col 0 --order-dir desc`)
-Non-standard defaults: `--relative-size 0`, `--order-col 0`, `--trade-level-rank 10`
-
-```bash
-volumeleaders-agent trade level-touches --start-date 2025-04-23 --end-date 2025-04-23
-```
-
-Output fields: `Ticker`, `Name`, `Sector`, `Industry`, `Date`, `FullDateTime`, `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `TradeLevelTouches`, `MinDate`, `MaxDate`, `Dates`, `TotalRows`
+Key fields: `Ticker`, `Name`, `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `MinDate`, `MaxDate`, `Dates`, plus `TradeLevelTouches` on level-touch rows.

--- a/skills/volumeleaders-agent/volume.md
+++ b/skills/volumeleaders-agent/volume.md
@@ -1,37 +1,18 @@
 # volume
 
-Volume leaderboards ranking stocks by trading activity. All three subcommands share the same flags and return Trade model objects.
+Volume leaderboards ranking stocks by trading activity. All commands require `--date`, support `--tickers`, `--format json|csv|tsv`, and pagination. Default sort is `--order-dir asc`, unlike trade commands.
 
-Required: `--date` (YYYY-MM-DD)
-Optional: `--tickers`, `--format json|csv|tsv`, pagination (`--length 100 --order-col 1 --order-dir asc`)
-
-Output format: JSON by default. CSV/TSV include a header row, render booleans as `true`/`false`, and render null/missing values as empty cells.
-
-Note: default sort direction is `asc` (ascending), unlike trade commands which default to `desc`.
-
-## volume institutional
-
-Stocks ranked by institutional dollar volume for a date. The primary "what are institutions trading today?" command.
+| Command | Use when |
+|---|---|
+| `volume institutional` | Rank stocks by institutional dollar volume |
+| `volume ah-institutional` | Rank after-hours institutional activity |
+| `volume total` | Rank total market volume across trade types |
 
 ```bash
-volumeleaders-agent volume institutional --date 2025-04-23
-volumeleaders-agent volume institutional --date 2025-04-23 --format csv
+volumeleaders-agent volume institutional --date 2026-04-28
+volumeleaders-agent volume institutional --date 2026-04-28 --format csv
+volumeleaders-agent volume ah-institutional --date 2026-04-28
+volumeleaders-agent volume total --date 2026-04-28
 ```
 
-## volume ah-institutional
-
-Stocks ranked by after-hours institutional activity. After-hours institutional trades often precede next-day moves.
-
-```bash
-volumeleaders-agent volume ah-institutional --date 2025-04-23
-```
-
-## volume total
-
-Overall volume leaders across all trade types. Compare institutional vs total volume.
-
-```bash
-volumeleaders-agent volume total --date 2025-04-23
-```
-
-Output fields (all three): same Trade model as `trade list`. Key fields for volume analysis: `Ticker`, `Name`, `Sector`, `Industry`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `TotalDollars`, `TotalDollarsRank`, `TotalVolume`, `AverageDailyVolume`, `PercentDailyVolume`, `ClosePrice`, `RSIHour`, `RSIDay`
+Output model: same Trade model as `trade list`. Key volume fields: `Ticker`, `Name`, `Sector`, `Industry`, `TotalInstitutionalDollars`, `TotalInstitutionalDollarsRank`, `TotalInstitutionalVolume`, `AHInstitutionalDollars`, `AHInstitutionalDollarsRank`, `AHInstitutionalVolume`, `ClosingTradeDollars`, `ClosingTradeDollarsRank`, `ClosingTradeVolume`, `TotalDollars`, `TotalDollarsRank`, `TotalVolume`, `AverageDailyVolume`, `PercentDailyVolume`, `ClosePrice`, `RSIHour`, `RSIDay`.

--- a/skills/volumeleaders-agent/watchlist.md
+++ b/skills/volumeleaders-agent/watchlist.md
@@ -1,82 +1,41 @@
 # watchlist
 
-Manage saved watchlist configurations.
+Manage saved watchlist configurations and watchlist ticker summaries.
 
-## watchlist configs
-
-List all saved watchlist configurations.
-
-Optional: `--format json|csv|tsv`
+| Command | Use when | Required | Output |
+|---|---|---|---|
+| `watchlist configs` | List watchlists | none | JSON, CSV, TSV |
+| `watchlist tickers` | Get watchlist tickers and nearest signals | none | JSON, CSV, TSV |
+| `watchlist delete` | Delete a watchlist | `--key` | JSON |
+| `watchlist add-ticker` | Add one ticker | `--watchlist-key`, `--ticker` | JSON |
+| `watchlist create` | Create a watchlist | `--name` | JSON |
+| `watchlist edit` | Replace/update a watchlist | `--key` | JSON |
 
 ```bash
-volumeleaders-agent watchlist configs
 volumeleaders-agent watchlist configs --format csv
-```
-
-Output fields: `SearchTemplateKey` (use as `--key` or `--watchlist-key` for other commands), `Name`, `Tickers`, plus filter settings (volume/price/dollar ranges, RSI conditions, trade type booleans, `SecurityTypeKey`, `MinVCD`, `SectorIndustry`).
-
-Output format: `watchlist configs` defaults to JSON and supports CSV/TSV. Mutation responses remain JSON-only.
-
-## watchlist tickers
-
-Get tickers and summary data from a watchlist.
-
-Optional: `--watchlist-key` (default -1 = all watchlists), `--format json|csv|tsv`. Get key from `watchlist configs` `SearchTemplateKey`.
-
-```bash
-volumeleaders-agent watchlist tickers --watchlist-key 12345
 volumeleaders-agent watchlist tickers --watchlist-key 12345 --format tsv
-```
-
-Output fields: `Ticker`, `Price`, `NearestTop10TradeDate`, `NearestTop10TradeClusterDate`, `NearestTop10TradeLevel`
-
-Output format: `watchlist tickers` defaults to JSON and supports CSV/TSV.
-
-## watchlist delete
-
-Required: `--key` (SearchTemplateKey from `watchlist configs`)
-
-```bash
+volumeleaders-agent watchlist add-ticker --watchlist-key 12345 --ticker AAPL
+volumeleaders-agent watchlist create --name "Tech Sweeps" --tickers "AAPL,MSFT,GOOGL" --no-dark-pools --min-dollars 1000000
+volumeleaders-agent watchlist edit --key 12345 --name "Updated Watchlist"
 volumeleaders-agent watchlist delete --key 12345
 ```
 
-## watchlist add-ticker
+`watchlist configs` fields include `SearchTemplateKey` for `--key` or `--watchlist-key`, `Name`, `Tickers`, volume/price/dollar ranges, RSI filters, trade type booleans, `SecurityTypeKey`, `MinVCD`, `SectorIndustry`.
 
-Add a single ticker to an existing watchlist.
+`watchlist tickers` optional flag: `--watchlist-key`, default `-1` means all watchlists. Fields: `Ticker`, `Price`, `NearestTop10TradeDate`, `NearestTop10TradeClusterDate`, `NearestTop10TradeLevel`.
 
-Required: `--watchlist-key`, `--ticker`
-
-```bash
-volumeleaders-agent watchlist add-ticker --watchlist-key 12345 --ticker AAPL
-```
-
-## watchlist create
-
-Required: `--name`
-
-Optional flags:
+Create/edit option groups:
 
 | Category | Flags | Defaults |
 |---|---|---|
-| **Tickers** | `--tickers` | (none, comma-separated, max 500) |
-| **Volume** | `--min-volume`, `--max-volume` | 0, 2000000000 |
-| **Dollars** | `--min-dollars`, `--max-dollars` | 0, 30000000000 |
-| **Price** | `--min-price`, `--max-price` | 0, 100000 |
-| **Quality** | `--min-vcd`, `--min-relative-size`, `--max-trade-rank` | 0, 0 (0/5/10/25/50/100), -1 (-1/1/3/5/10/25/50/100) |
-| **Security** | `--security-type`, `--sector-industry` | -1 (-1=all/1=stocks/26=ETFs/4=REITs), (none, max 100 chars) |
-| **Trade types** | `--normal-prints`, `--signature-prints`, `--late-prints`, `--timely-prints`, `--dark-pools`, `--lit-exchanges`, `--sweeps`, `--blocks` | all true. Disable with `--no-{name}` |
-| **Sessions** | `--premarket-trades`, `--rth-trades`, `--ah-trades`, `--opening-trades`, `--closing-trades`, `--phantom-trades`, `--offsetting-trades` | all true. Disable with `--no-{name}` |
-| **RSI** | `--rsi-overbought-daily`, `--rsi-overbought-hourly`, `--rsi-oversold-daily`, `--rsi-oversold-hourly` | all -1 (1=yes, 0=no, -1=ignore) |
+| Tickers | `--tickers` | none, comma-separated, max 500 |
+| Volume | `--min-volume`, `--max-volume` | 0, 2000000000 |
+| Dollars | `--min-dollars`, `--max-dollars` | 0, 30000000000 |
+| Price | `--min-price`, `--max-price` | 0, 100000 |
+| Quality | `--min-vcd`, `--min-relative-size`, `--max-trade-rank` | 0, 0, -1 |
+| Security | `--security-type`, `--sector-industry` | -1, none |
+| Trade types | `--normal-prints`, `--signature-prints`, `--late-prints`, `--timely-prints`, `--dark-pools`, `--lit-exchanges`, `--sweeps`, `--blocks` | true, disable with `--no-{name}` |
+| Sessions | `--premarket-trades`, `--rth-trades`, `--ah-trades`, `--opening-trades`, `--closing-trades`, `--phantom-trades`, `--offsetting-trades` | true, disable with `--no-{name}` |
+| RSI | `--rsi-overbought-daily`, `--rsi-overbought-hourly`, `--rsi-oversold-daily`, `--rsi-oversold-hourly` | -1, where 1=yes, 0=no, -1=ignore |
 
-```bash
-volumeleaders-agent watchlist create --name "Tech Sweeps" --tickers "AAPL,MSFT,GOOGL" --no-dark-pools --min-dollars 1000000
-```
-
-## watchlist edit
-
-Required: `--key` (SearchTemplateKey)
-All flags from `watchlist create` available. `--name` is optional for edit. Unspecified flags reset to their defaults.
-
-```bash
-volumeleaders-agent watchlist edit --key 12345 --name "Updated Watchlist"
-```
+Edit gotcha: unspecified edit flags reset to defaults, so include every value that must remain set.


### PR DESCRIPTION
## Summary
- Tightens the VolumeLeaders agent skill docs so agents can choose the right command with fewer tokens.
- Centralizes shared conventions in `SKILL.md` and compresses per-command docs around required flags, defaults, gotchas, and examples.
- Fixes documented edge cases for trade sentiment, chart-specific flag names, alert thresholds, and cluster-bomb pagination defaults.

## Test plan
- `make test`
- `make build`
- `make lint`
- Markdown fence check
- Em dash check
- `git diff --check -- skills/volumeleaders-agent`