### PR TITLE
fix: improve expired session auth errors

### DIFF
--- a/cmd/volumeleaders-agent/main.go
+++ b/cmd/volumeleaders-agent/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/major/volumeleaders-agent/internal/auth"
 	"github.com/major/volumeleaders-agent/internal/commands"
 )
 
@@ -13,7 +14,21 @@ var version = "dev"
 
 func main() {
 	if err := commands.NewApp(version).Run(context.Background(), os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, userFacingError(err))
+		os.Exit(exitCode(err))
 	}
+}
+
+func userFacingError(err error) string {
+	if auth.IsSessionExpired(err) {
+		return auth.SessionExpiredMessage
+	}
+	return err.Error()
+}
+
+func exitCode(err error) int {
+	if auth.IsSessionExpired(err) {
+		return 2
+	}
+	return 1
 }

--- a/cmd/volumeleaders-agent/main_test.go
+++ b/cmd/volumeleaders-agent/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/major/volumeleaders-agent/internal/auth"
+)
+
+func TestUserFacingError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "session expired",
+			err:  fmt.Errorf("create client: %w", auth.ErrSessionExpired),
+			want: auth.SessionExpiredMessage,
+		},
+		{
+			name: "generic error",
+			err:  fmt.Errorf("create client: missing cookies"),
+			want: "create client: missing cookies",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := userFacingError(tt.err); got != tt.want {
+				t.Fatalf("userFacingError() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "session expired",
+			err:  fmt.Errorf("fetch XSRF token: %w", auth.ErrSessionExpired),
+			want: 2,
+		},
+		{
+			name: "generic error",
+			err:  fmt.Errorf("fetch XSRF token: status 403"),
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := exitCode(tt.err); got != tt.want {
+				t.Fatalf("exitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,9 +22,36 @@ const UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 
 
 const volumeLeadersDomain = "volumeleaders.com"
 
+// ErrSessionExpired marks auth failures caused by an expired browser session.
+var ErrSessionExpired = errors.New("session expired")
+
+// SessionExpiredMessage is the user-facing remediation for expired sessions.
+const SessionExpiredMessage = "Authentication required: VolumeLeaders session has expired. Log in at https://www.volumeleaders.com in your browser, then retry."
+
 var requiredCookieNames = []string{"ASP.NET_SessionId", ".ASPXAUTH"}
 
 var xsrfTokenPattern = regexp.MustCompile(`<input\s+name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"`)
+
+type sessionExpiredError struct {
+	redirectPath string
+}
+
+func (e sessionExpiredError) Error() string {
+	return SessionExpiredMessage
+}
+
+func (e sessionExpiredError) Unwrap() error {
+	return ErrSessionExpired
+}
+
+func (e sessionExpiredError) Detail() string {
+	return fmt.Sprintf("requested host www.%s redirected to %s", volumeLeadersDomain, e.redirectPath)
+}
+
+// IsSessionExpired reports whether err indicates an expired VolumeLeaders session.
+func IsSessionExpired(err error) bool {
+	return errors.Is(err, ErrSessionExpired)
+}
 
 // ExtractCookies reads required VolumeLeaders cookies from supported browsers.
 //
@@ -62,7 +90,7 @@ func FetchXSRFToken(ctx context.Context, httpClient *http.Client, cookies map[st
 	defer resp.Body.Close()
 
 	if strings.Contains(resp.Request.URL.Path, "/Login") {
-		return "", fmt.Errorf("session expired: requested host www.%s redirected to %s", volumeLeadersDomain, safeRedirectPath(resp))
+		return "", sessionExpiredError{redirectPath: safeRedirectPath(resp)}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("fetch XSRF token page: status %d", resp.StatusCode)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"regexp"
 	"slices"
 	"strings"
@@ -89,8 +90,9 @@ func FetchXSRFToken(ctx context.Context, httpClient *http.Client, cookies map[st
 	}
 	defer resp.Body.Close()
 
-	if strings.Contains(resp.Request.URL.Path, "/Login") {
-		return "", sessionExpiredError{redirectPath: safeRedirectPath(resp)}
+	redirectPath := safeRedirectPath(resp)
+	if normalizeRedirectPath(redirectPath) == "/login" {
+		return "", sessionExpiredError{redirectPath: redirectPath}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("fetch XSRF token page: status %d", resp.StatusCode)
@@ -190,11 +192,21 @@ func safeRedirectPath(resp *http.Response) string {
 	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
 		return "unknown redirect target"
 	}
-	path := resp.Request.URL.EscapedPath()
-	if path == "" {
+	escapedPath := resp.Request.URL.EscapedPath()
+	if escapedPath == "" {
 		return "/"
 	}
-	return path
+	return escapedPath
+}
+
+func normalizeRedirectPath(redirectPath string) string {
+	if redirectPath == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(redirectPath, "/") {
+		redirectPath = "/" + redirectPath
+	}
+	return strings.ToLower(path.Clean(redirectPath))
 }
 
 func setBrowserHeaders(req *http.Request) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -68,10 +68,11 @@ func TestFetchXSRFToken(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		handler   http.HandlerFunc
-		wantToken string
-		wantErr   string
+		name               string
+		handler            http.HandlerFunc
+		wantToken          string
+		wantErr            string
+		wantSessionExpired bool
 	}{
 		{
 			name: "success",
@@ -91,7 +92,8 @@ func TestFetchXSRFToken(t *testing.T) {
 				}
 				fmt.Fprint(w, "login")
 			},
-			wantErr: "session expired: requested host www.volumeleaders.com redirected to /Login",
+			wantErr:            SessionExpiredMessage,
+			wantSessionExpired: true,
 		},
 		{
 			name: "non 200 status",
@@ -139,6 +141,12 @@ func TestFetchXSRFToken(t *testing.T) {
 				}
 				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				if got := IsSessionExpired(err); got != tt.wantSessionExpired {
+					t.Fatalf("IsSessionExpired() = %t, want %t", got, tt.wantSessionExpired)
+				}
+				if tt.wantSessionExpired && strings.Contains(err.Error(), "/Login") {
+					t.Fatalf("session expired error exposed redirect detail: %v", err)
 				}
 				return
 			}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -96,6 +96,17 @@ func TestFetchXSRFToken(t *testing.T) {
 			wantSessionExpired: true,
 		},
 		{
+			name: "non login redirect does not mark session expired",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/ExecutiveSummary" {
+					http.Redirect(w, r, "/NotLogin", http.StatusFound)
+					return
+				}
+				fmt.Fprint(w, "not login")
+			},
+			wantErr: "XSRF token not found",
+		},
+		{
 			name: "non 200 status",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				http.Error(w, "forbidden", http.StatusForbidden)
@@ -236,6 +247,53 @@ func TestSafeRedirectPath(t *testing.T) {
 	got := safeRedirectPath(&http.Response{Request: req})
 	if got != "/Login" {
 		t.Fatalf("expected sanitized redirect path, got %q", got)
+	}
+}
+
+func TestNormalizeRedirectPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "login path lowercased",
+			path: "/Login",
+			want: "/login",
+		},
+		{
+			name: "missing leading slash",
+			path: "Login",
+			want: "/login",
+		},
+		{
+			name: "clean path",
+			path: "/Account/../Login",
+			want: "/login",
+		},
+		{
+			name: "non login remains exact path",
+			path: "/NotLogin",
+			want: "/notlogin",
+		},
+		{
+			name: "empty path becomes root",
+			path: "",
+			want: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizeRedirectPath(tt.path)
+			if got != tt.want {
+				t.Fatalf("normalizeRedirectPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/major/volumeleaders-agent/internal/auth"
 	"github.com/major/volumeleaders-agent/internal/client"
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	cli "github.com/urfave/cli/v3"
@@ -311,6 +313,13 @@ func newCommandClient(ctx context.Context) (*client.Client, error) {
 	}
 	vlClient, err := client.New(ctx)
 	if err != nil {
+		if auth.IsSessionExpired(err) {
+			var detail interface{ Detail() string }
+			if errors.As(err, &detail) {
+				slog.Debug("VolumeLeaders session expired", "detail", detail.Detail())
+			}
+			return nil, fmt.Errorf("%s: %w", auth.SessionExpiredMessage, err)
+		}
 		slog.Error("failed to create client", "error", err)
 		return nil, fmt.Errorf("create client: %w", err)
 	}

--- a/skills/volumeleaders-agent/SKILL.md
+++ b/skills/volumeleaders-agent/SKILL.md
@@ -2,7 +2,7 @@
 
 CLI for VolumeLeaders institutional trade data. Use it for trades, daily summaries, volume leaderboards, charts, market data, alerts, and watchlists. Binary: `volumeleaders-agent`.
 
-Auth: reads browser cookies. If auth fails, the user must log in at volumeleaders.com in their browser.
+Auth: reads browser cookies. If auth fails with exit code 2 and `Authentication required: VolumeLeaders session has expired.`, the user must log in at https://www.volumeleaders.com in their browser, then retry.
 
 Output: compact JSON to stdout by default. Put `--pretty` before the command group for indented JSON. Errors/logs go to stderr.
 


### PR DESCRIPTION
## Summary
- Show a direct auth-required message when VolumeLeaders redirects expired sessions to login.
- Preserve typed error wrapping so expired sessions exit with code 2 while other failures keep exit code 1.
- Update tests and agent docs for the new remediation path.

Closes #40

## Verification
- go test ./internal/auth ./internal/commands ./cmd/volumeleaders-agent
- make test
- make lint
- make build