### PR TITLE
fix: improve trade query ergonomics

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -75,6 +75,9 @@ func (c *Client) PostDataTablesPage(ctx context.Context, path, body string) (*mo
 	if err := json.Unmarshal(responseBody, &wrapper); err != nil {
 		return nil, fmt.Errorf("decode DataTables response: %w", err)
 	}
+	if len(wrapper.Data) == 0 || bytes.Equal(wrapper.Data, []byte("null")) {
+		wrapper.Data = []byte("[]")
+	}
 	return &wrapper, nil
 }
 
@@ -83,9 +86,6 @@ func (c *Client) PostDataTables(ctx context.Context, path, body string, result a
 	wrapper, err := c.PostDataTablesPage(ctx, path, body)
 	if err != nil {
 		return err
-	}
-	if len(wrapper.Data) == 0 || bytes.Equal(wrapper.Data, []byte("null")) {
-		return fmt.Errorf("decode DataTables response: missing data field")
 	}
 	if err := json.Unmarshal(wrapper.Data, result); err != nil {
 		return fmt.Errorf("decode DataTables data: %w", err)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -46,13 +46,13 @@ func TestPostDataTables(t *testing.T) {
 			name:       "empty data field",
 			statusCode: http.StatusOK,
 			body:       `{"draw":1}`,
-			wantErr:    "missing data field",
+			want:       []string{},
 		},
 		{
 			name:       "null data field",
 			statusCode: http.StatusOK,
 			body:       `{"draw":1,"data":null}`,
-			wantErr:    "missing data field",
+			want:       []string{},
 		},
 		{
 			name:       "non 200 status",
@@ -179,8 +179,10 @@ func TestPostForm(t *testing.T) {
 			name:       "valid response",
 			statusCode: http.StatusOK,
 			body:       `{"name":"AAPL"}`,
-			result:     &struct{ Name string `json:"name"` }{},
-			wantName:   "AAPL",
+			result: &struct {
+				Name string `json:"name"`
+			}{},
+			wantName: "AAPL",
 		},
 		{
 			name:       "nil result skips decode",
@@ -217,7 +219,9 @@ func TestPostForm(t *testing.T) {
 			err := client.PostForm(t.Context(), "/form", url.Values{"ticker": {"AAPL"}}, tt.result)
 			assertErrorContains(t, err, tt.wantErr)
 			if tt.wantName != "" {
-				got := tt.result.(*struct{ Name string `json:"name"` })
+				got := tt.result.(*struct {
+					Name string `json:"name"`
+				})
 				if got.Name != tt.wantName {
 					t.Errorf("expected name %q, got %q", tt.wantName, got.Name)
 				}
@@ -322,19 +326,19 @@ func TestSetHeaders(t *testing.T) {
 	client.setHeaders(req)
 
 	checks := map[string]string{
-		"User-Agent":        auth.UserAgent,
-		"x-xsrf-token":      "test-token",
-		"x-requested-with":  "XMLHttpRequest",
-		"Accept":            "application/json, text/javascript, */*; q=0.01",
-		"Content-Type":      "application/json",
-		"Sec-Ch-Ua":         `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
-		"Sec-Ch-Ua-Mobile":  "?0",
+		"User-Agent":         auth.UserAgent,
+		"x-xsrf-token":       "test-token",
+		"x-requested-with":   "XMLHttpRequest",
+		"Accept":             "application/json, text/javascript, */*; q=0.01",
+		"Content-Type":       "application/json",
+		"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
+		"Sec-Ch-Ua-Mobile":   "?0",
 		"Sec-Ch-Ua-Platform": `"Windows"`,
-		"Sec-Fetch-Dest":    "empty",
-		"Sec-Fetch-Mode":    "cors",
-		"Sec-Fetch-Site":    "same-origin",
-		"Accept-Language":   "en-US,en;q=0.9",
-		"Accept-Encoding":   "gzip, deflate, br",
+		"Sec-Fetch-Dest":     "empty",
+		"Sec-Fetch-Mode":     "cors",
+		"Sec-Fetch-Site":     "same-origin",
+		"Accept-Language":    "en-US,en;q=0.9",
+		"Accept-Encoding":    "gzip, deflate, br",
 	}
 	for key, expected := range checks {
 		if got := req.Header.Get(key); got != expected {

--- a/internal/commands/chart.go
+++ b/internal/commands/chart.go
@@ -56,7 +56,8 @@ func newPriceDataCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "price-data",
 		Usage: "Query one-minute chart bars with trade metadata for a ticker",
-		UsageText: `volumeleaders-agent chart price-data --ticker AAPL --start-date 2025-01-15 --end-date 2025-01-15
+		UsageText: `volumeleaders-agent chart price-data AAPL --days 1
+volumeleaders-agent chart price-data --ticker AAPL --start-date 2025-01-15 --end-date 2025-01-15
 volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end-date 2025-01-31 --dark-pools 1`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
@@ -64,7 +65,7 @@ volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end
 			priceRangeFlags(),
 			dollarRangeFlags(500000),
 			[]cli.Flag{
-				&cli.StringFlag{Name: "ticker", Required: true, Usage: "Ticker symbol"},
+				&cli.StringFlag{Name: "ticker", Usage: "Ticker symbol"},
 				&cli.IntFlag{Name: "volume-profile", Value: 0, Usage: "Volume profile flag"},
 				&cli.IntFlag{Name: "levels", Value: 5, Usage: "Number of trade levels"},
 				&cli.IntFlag{Name: "dark-pools", Value: -1, Usage: "Dark pool filter (-1=all, 0=exclude, 1=only)"},
@@ -86,11 +87,19 @@ volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end
 			outputFormatFlags(),
 		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
+			startDate, endDate, err := requiredDateRange(cmd)
+			if err != nil {
+				return err
+			}
+			ticker, err := singleTickerValue(cmd)
+			if err != nil {
+				return err
+			}
 			opts := priceDataOptions{
-				ticker:            cmd.String("ticker"),
+				ticker:            ticker,
 				format:            cmd.String("format"),
-				startDate:         cmd.String("start-date"),
-				endDate:           cmd.String("end-date"),
+				startDate:         startDate,
+				endDate:           endDate,
 				volumeProfile:     cmd.Int("volume-profile"),
 				levels:            cmd.Int("levels"),
 				minVolume:         cmd.Int("min-volume"),
@@ -124,13 +133,17 @@ func newChartSnapshotCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "snapshot",
 		Usage:     "Query quote snapshot for a ticker and date",
-		UsageText: "volumeleaders-agent chart snapshot --ticker AAPL --date-key 2025-01-15",
+		UsageText: "volumeleaders-agent chart snapshot AAPL --date-key 2025-01-15",
 		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "ticker", Required: true, Usage: "Ticker symbol"},
+			&cli.StringFlag{Name: "ticker", Usage: "Ticker symbol"},
 			&cli.StringFlag{Name: "date-key", Required: true, Usage: "Date key YYYY-MM-DD or YYYYMMDD"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return runChartSnapshot(ctx, cmd.String("ticker"), cmd.String("date-key"))
+			ticker, err := singleTickerValue(cmd)
+			if err != nil {
+				return err
+			}
+			return runChartSnapshot(ctx, ticker, cmd.String("date-key"))
 		},
 	}
 }
@@ -139,21 +152,30 @@ func newChartLevelsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "levels",
 		Usage: "Query chart-level overlays for a ticker and date range",
-		UsageText: `volumeleaders-agent chart levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-01-31
+		UsageText: `volumeleaders-agent chart levels AAPL --days 30
+volumeleaders-agent chart levels --ticker AAPL --start-date 2025-01-01 --end-date 2025-01-31
 volumeleaders-agent chart levels --ticker TSLA --start-date 2025-01-01 --levels 10`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
 			[]cli.Flag{
-				&cli.StringFlag{Name: "ticker", Required: true, Usage: "Ticker symbol"},
+				&cli.StringFlag{Name: "ticker", Usage: "Ticker symbol"},
 				&cli.IntFlag{Name: "levels", Value: 5, Usage: "Number of trade levels"},
 			},
 			outputFormatFlags(),
 		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
+			startDate, endDate, err := requiredDateRange(cmd)
+			if err != nil {
+				return err
+			}
+			ticker, err := singleTickerValue(cmd)
+			if err != nil {
+				return err
+			}
 			opts := chartLevelsOptions{
-				ticker:    cmd.String("ticker"),
-				startDate: cmd.String("start-date"),
-				endDate:   cmd.String("end-date"),
+				ticker:    ticker,
+				startDate: startDate,
+				endDate:   endDate,
 				levels:    cmd.Int("levels"),
 				format:    cmd.String("format"),
 			}
@@ -166,12 +188,16 @@ func newCompanyCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "company",
 		Usage:     "Query company metadata for a ticker",
-		UsageText: "volumeleaders-agent chart company --ticker AAPL",
+		UsageText: "volumeleaders-agent chart company AAPL",
 		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "ticker", Required: true, Usage: "Ticker symbol"},
+			&cli.StringFlag{Name: "ticker", Usage: "Ticker symbol"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return runCompany(ctx, cmd.String("ticker"))
+			ticker, err := singleTickerValue(cmd)
+			if err != nil {
+				return err
+			}
+			return runCompany(ctx, ticker)
 		},
 	}
 }

--- a/internal/commands/chart_test.go
+++ b/internal/commands/chart_test.go
@@ -1,11 +1,14 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	cli "github.com/urfave/cli/v3"
 )
@@ -211,4 +214,42 @@ func TestChartCompanyCLI(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestChartPriceDataPositionalTickerAndDays(t *testing.T) {
+	var gotTicker, gotStart, gotEnd string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		gotTicker, _ = payload["Ticker"].(string)
+		gotStart, _ = payload["StartDateKey"].(string)
+		gotEnd, _ = payload["EndDateKey"].(string)
+		fmt.Fprint(w, `[[{}]]`)
+	}))
+	t.Cleanup(server.Close)
+
+	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	origTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	t.Cleanup(func() { timeNow = origTimeNow })
+
+	ctx := contextWithTestClient(t, server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
+		if err := root.Run(ctx, []string{"app", "chart", "price-data", "AAPL", "--days", "2"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if gotTicker != "AAPL" {
+		t.Errorf("Ticker = %q, want AAPL", gotTicker)
+	}
+	if gotStart != "20250613" {
+		t.Errorf("StartDateKey = %q, want 20250613", gotStart)
+	}
+	if gotEnd != "20250615" {
+		t.Errorf("EndDateKey = %q, want 20250615", gotEnd)
+	}
 }

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -331,24 +331,28 @@ func newDataTablesRequest(columns []string, opts dataTableOptions) datatables.Re
 	}
 }
 
-// dateRangeFlags returns required --start-date and --end-date flags.
+// dateRangeFlags returns --start-date, --end-date, and --days flags for
+// commands that require a range. Callers must resolve the range with
+// requiredDateRange because --days can satisfy the range without explicit dates.
 func dateRangeFlags() []cli.Flag {
 	return []cli.Flag{
-		&cli.StringFlag{Name: "start-date", Required: true, Usage: "Start date YYYY-MM-DD"},
-		&cli.StringFlag{Name: "end-date", Required: true, Usage: "End date YYYY-MM-DD"},
+		&cli.StringFlag{Name: "start-date", Usage: "Start date YYYY-MM-DD (required unless --days is set)"},
+		&cli.StringFlag{Name: "end-date", Usage: "End date YYYY-MM-DD (required unless --days is set)"},
+		&cli.IntFlag{Name: "days", Usage: "Look back this many days from --end-date or today"},
 	}
 }
 
-// optionalDateRangeFlags returns --start-date and --end-date flags without
-// Required, for commands that supply sensible defaults when dates are omitted.
+// optionalDateRangeFlags returns --start-date, --end-date, and --days flags for
+// commands that supply sensible defaults when dates are omitted.
 func optionalDateRangeFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{Name: "start-date", Usage: "Start date YYYY-MM-DD (default: auto)"},
 		&cli.StringFlag{Name: "end-date", Usage: "End date YYYY-MM-DD (default: today)"},
+		&cli.IntFlag{Name: "days", Usage: "Look back this many days from --end-date or today"},
 	}
 }
 
-// timeNow is the clock function used by defaultDates.
+// timeNow is the clock function used by date-range defaults.
 // Tests replace it to control the current time.
 var timeNow = time.Now
 
@@ -356,24 +360,112 @@ var timeNow = time.Now
 // the user did not explicitly set them. lookbackDays controls how far back the
 // start date goes; pass 0 for a today-only default.
 func defaultDates(cmd *cli.Command, lookbackDays int) (startDate, endDate string) {
+	startDate, endDate, _ = resolveDateRange(cmd, lookbackDays, false)
+	return startDate, endDate
+}
+
+func requiredDateRange(cmd *cli.Command) (startDate, endDate string, err error) {
+	return resolveDateRange(cmd, 0, true)
+}
+
+func optionalDateRange(cmd *cli.Command, lookbackDays int) (startDate, endDate string, err error) {
+	return resolveDateRange(cmd, lookbackDays, false)
+}
+
+func resolveDateRange(cmd *cli.Command, lookbackDays int, required bool) (startDate, endDate string, err error) {
 	now := timeNow()
 	today := now.Format("2006-01-02")
+	days := cmd.Int("days")
+	hasDays := cmd.IsSet("days")
+	if hasDays && days < 0 {
+		return "", "", fmt.Errorf("--days must be greater than or equal to 0")
+	}
+	if hasDays && cmd.IsSet("start-date") {
+		return "", "", fmt.Errorf("--days cannot be used with --start-date")
+	}
 
 	endDate = cmd.String("end-date")
 	if !cmd.IsSet("end-date") {
+		if required && !hasDays {
+			return "", "", fmt.Errorf("--start-date and --end-date are required unless --days is set")
+		}
 		endDate = today
 	}
 
 	startDate = cmd.String("start-date")
 	if !cmd.IsSet("start-date") {
-		if lookbackDays > 0 {
+		switch {
+		case hasDays:
+			base := now
+			if cmd.IsSet("end-date") {
+				parsed, parseErr := time.Parse("2006-01-02", endDate)
+				if parseErr != nil {
+					return "", "", fmt.Errorf("parse --end-date for --days: %w", parseErr)
+				}
+				base = parsed
+			}
+			startDate = base.AddDate(0, 0, -days).Format("2006-01-02")
+		case required:
+			return "", "", fmt.Errorf("--start-date and --end-date are required unless --days is set")
+		case lookbackDays > 0:
 			startDate = now.AddDate(0, 0, -lookbackDays).Format("2006-01-02")
-		} else {
+		default:
 			startDate = today
 		}
 	}
 
-	return startDate, endDate
+	return startDate, endDate, nil
+}
+
+func multiTickerValue(cmd *cli.Command) string {
+	values := splitTickerValues(cmd.String("tickers"))
+	values = append(values, splitTickerValues(strings.Join(cmd.Args().Slice(), ","))...)
+	return strings.Join(dedupeStrings(values), ",")
+}
+
+func singleTickerValue(cmd *cli.Command) (string, error) {
+	flagValue := strings.TrimSpace(cmd.String("ticker"))
+	args := cmd.Args().Slice()
+	if len(args) > 1 {
+		return "", fmt.Errorf("expected at most one ticker argument, got %d", len(args))
+	}
+	if flagValue != "" && len(args) == 1 {
+		return "", fmt.Errorf("use either --ticker or a ticker argument, not both")
+	}
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if len(args) == 1 {
+		return strings.TrimSpace(args[0]), nil
+	}
+	return "", fmt.Errorf("--ticker or a ticker argument is required")
+}
+
+func splitTickerValues(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	items := make([]string, 0, strings.Count(value, ",")+1)
+	for item := range strings.SplitSeq(value, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 // volumeRangeFlags returns --min-volume and --max-volume flags with

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -281,24 +281,26 @@ func TestDateRangeFlags(t *testing.T) {
 	t.Parallel()
 
 	flags := dateRangeFlags()
-	if len(flags) != 2 {
-		t.Fatalf("expected 2 flags, got %d", len(flags))
+	if len(flags) != 3 {
+		t.Fatalf("expected 3 flags, got %d", len(flags))
 	}
 	assertFlagName(t, flags[0], "start-date")
 	assertFlagName(t, flags[1], "end-date")
-	assertStringFlagRequired(t, flags[0], true)
-	assertStringFlagRequired(t, flags[1], true)
+	assertFlagName(t, flags[2], "days")
+	assertStringFlagRequired(t, flags[0], false)
+	assertStringFlagRequired(t, flags[1], false)
 }
 
 func TestOptionalDateRangeFlags(t *testing.T) {
 	t.Parallel()
 
 	flags := optionalDateRangeFlags()
-	if len(flags) != 2 {
-		t.Fatalf("expected 2 flags, got %d", len(flags))
+	if len(flags) != 3 {
+		t.Fatalf("expected 3 flags, got %d", len(flags))
 	}
 	assertFlagName(t, flags[0], "start-date")
 	assertFlagName(t, flags[1], "end-date")
+	assertFlagName(t, flags[2], "days")
 	assertStringFlagRequired(t, flags[0], false)
 	assertStringFlagRequired(t, flags[1], false)
 }
@@ -360,13 +362,27 @@ func TestDefaultDates(t *testing.T) {
 			wantStart:    "2025-03-17",
 			wantEnd:      "2025-03-01",
 		},
+		{
+			name:         "days defaults from today",
+			args:         []string{"app", "sub", "--days", "5"},
+			lookbackDays: 90,
+			wantStart:    "2025-06-10",
+			wantEnd:      "2025-06-15",
+		},
+		{
+			name:         "days uses explicit end-date as base",
+			args:         []string{"app", "sub", "--end-date", "2025-03-01", "--days", "5"},
+			lookbackDays: 90,
+			wantStart:    "2025-02-24",
+			wantEnd:      "2025-03-01",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotStart, gotEnd string
 			sub := &cli.Command{
-				Name: "sub",
+				Name:  "sub",
 				Flags: slices.Concat(optionalDateRangeFlags()),
 				Action: func(_ context.Context, cmd *cli.Command) error {
 					gotStart, gotEnd = defaultDates(cmd, tt.lookbackDays)
@@ -382,6 +398,136 @@ func TestDefaultDates(t *testing.T) {
 			}
 			if gotEnd != tt.wantEnd {
 				t.Errorf("end date = %q, want %q", gotEnd, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestRequiredDateRange(t *testing.T) {
+	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	origTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	t.Cleanup(func() { timeNow = origTimeNow })
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantStart string
+		wantEnd   string
+		wantErr   string
+	}{
+		{
+			name:      "explicit range",
+			args:      []string{"app", "sub", "--start-date", "2025-01-01", "--end-date", "2025-01-31"},
+			wantStart: "2025-01-01",
+			wantEnd:   "2025-01-31",
+		},
+		{
+			name:      "days supplies range",
+			args:      []string{"app", "sub", "--days", "7"},
+			wantStart: "2025-06-08",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:    "missing range",
+			args:    []string{"app", "sub"},
+			wantErr: "required unless --days is set",
+		},
+		{
+			name:    "negative days",
+			args:    []string{"app", "sub", "--days", "-1"},
+			wantErr: "--days must be greater than or equal to 0",
+		},
+		{
+			name:    "days conflicts with start-date",
+			args:    []string{"app", "sub", "--start-date", "2025-06-01", "--days", "7"},
+			wantErr: "--days cannot be used with --start-date",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotStart, gotEnd string
+			sub := &cli.Command{
+				Name:  "sub",
+				Flags: dateRangeFlags(),
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					var err error
+					gotStart, gotEnd, err = requiredDateRange(cmd)
+					return err
+				},
+			}
+			root := &cli.Command{Commands: []*cli.Command{sub}}
+			err := root.Run(context.Background(), tt.args)
+			assertErrContains(t, err, tt.wantErr)
+			if tt.wantErr != "" {
+				return
+			}
+			if gotStart != tt.wantStart {
+				t.Errorf("start date = %q, want %q", gotStart, tt.wantStart)
+			}
+			if gotEnd != tt.wantEnd {
+				t.Errorf("end date = %q, want %q", gotEnd, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestSingleTickerValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "flag ticker",
+			args: []string{"app", "sub", "--ticker", "AAPL"},
+			want: "AAPL",
+		},
+		{
+			name: "positional ticker",
+			args: []string{"app", "sub", "MSFT"},
+			want: "MSFT",
+		},
+		{
+			name:    "flag and positional ticker conflict",
+			args:    []string{"app", "sub", "MSFT", "--ticker", "AAPL"},
+			wantErr: "use either --ticker or a ticker argument, not both",
+		},
+		{
+			name:    "too many positional tickers",
+			args:    []string{"app", "sub", "AAPL", "MSFT"},
+			wantErr: "expected at most one ticker argument",
+		},
+		{
+			name:    "missing ticker",
+			args:    []string{"app", "sub"},
+			wantErr: "--ticker or a ticker argument is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			sub := &cli.Command{
+				Name: "sub",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "ticker"},
+				},
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					var err error
+					got, err = singleTickerValue(cmd)
+					return err
+				},
+			}
+			root := &cli.Command{Commands: []*cli.Command{sub}}
+			err := root.Run(context.Background(), tt.args)
+			assertErrContains(t, err, tt.wantErr)
+			if tt.wantErr == "" && got != tt.want {
+				t.Errorf("ticker = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -41,10 +41,14 @@ func newEarningsCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "earnings",
 		Usage:     "Query earnings calendar within a date range",
-		UsageText: "volumeleaders-agent market earnings --start-date 2025-01-20 --end-date 2025-01-24",
+		UsageText: "volumeleaders-agent market earnings --days 5",
 		Flags:     slices.Concat(dateRangeFlags(), outputFormatFlags()),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return runEarnings(ctx, cmd.String("start-date"), cmd.String("end-date"), cmd.String("format"))
+			startDate, endDate, err := requiredDateRange(cmd)
+			if err != nil {
+				return err
+			}
+			return runEarnings(ctx, startDate, endDate, cmd.String("format"))
 		},
 	}
 }

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -106,9 +106,21 @@ func TestTradeListDefaultDates(t *testing.T) {
 		wantEnd   string
 	}{
 		{
-			name:      "with tickers defaults to 90-day lookback",
+			name:      "with tickers defaults to 5-day lookback",
 			args:      []string{"app", "list", "--tickers", "AAPL"},
-			wantStart: "2025-03-17",
+			wantStart: "2025-06-10",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:      "with positional ticker defaults to 5-day lookback",
+			args:      []string{"app", "list", "AAPL"},
+			wantStart: "2025-06-10",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:      "days overrides ticker lookback",
+			args:      []string{"app", "list", "XLE", "--days", "5"},
+			wantStart: "2025-06-10",
 			wantEnd:   "2025-06-15",
 		},
 		{
@@ -154,6 +166,28 @@ func TestTradeListDefaultDates(t *testing.T) {
 	}
 }
 
+func TestTradeListPositionalTickers(t *testing.T) {
+	var gotTickers string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		gotTickers = form.Get("Tickers")
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{"app", "list", "AAPL", "MSFT", "--tickers", "NVDA,MSFT"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if gotTickers != "NVDA,MSFT,AAPL" {
+		t.Errorf("Tickers = %q, want %q", gotTickers, "NVDA,MSFT,AAPL")
+	}
+}
+
 func TestTradeLevelsDefaultDates(t *testing.T) {
 	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
 	origTimeNow := timeNow
@@ -170,6 +204,12 @@ func TestTradeLevelsDefaultDates(t *testing.T) {
 			name:      "defaults to 1-year lookback",
 			args:      []string{"app", "levels", "--ticker", "AAPL"},
 			wantStart: "2024-06-15",
+			wantEnd:   "2025-06-15",
+		},
+		{
+			name:      "accepts positional ticker with days",
+			args:      []string{"app", "levels", "AAPL", "--days", "30"},
+			wantStart: "2025-05-16",
 			wantEnd:   "2025-06-15",
 		},
 		{

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -16,6 +16,8 @@ import (
 	cli "github.com/urfave/cli/v3"
 )
 
+const tradeListTickerLookbackDays = 5
+
 // --- Option structs ---
 
 type tradesOptions struct {
@@ -64,6 +66,7 @@ func newTradeSentimentCommand() *cli.Command {
 		Name:  "sentiment",
 		Usage: "Summarize leveraged ETF bull/bear flow by day",
 		UsageText: `volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25
+volumeleaders-agent trade sentiment --days 7
 volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25 --min-dollars 5000000`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
@@ -103,13 +106,14 @@ func newTradeListCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "list",
 		Usage: "Query institutional trades",
-		UsageText: `volumeleaders-agent trade list --tickers AAPL,MSFT
+		UsageText: `volumeleaders-agent trade list AAPL MSFT
+volumeleaders-agent trade list --tickers AAPL,MSFT
 volumeleaders-agent trade list --tickers NVDA --dark-pools 1 --min-dollars 1000000
 volumeleaders-agent trade list --sector Technology --relative-size 10 --length 50
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
 
-Dates are optional. With --tickers: defaults to 90-day lookback. Without: defaults to today only.`,
+Dates are optional. With tickers: defaults to 5-day lookback. Without: defaults to today only. Use --days to choose another lookback.`,
 		Flags: slices.Concat(
 			optionalDateRangeFlags(),
 			volumeRangeFlags(),
@@ -154,7 +158,8 @@ func newTradeClustersCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "clusters",
 		Usage: "Query aggregated trade clusters",
-		UsageText: `volumeleaders-agent trade clusters --tickers AAPL --start-date 2025-01-01 --end-date 2025-01-31
+		UsageText: `volumeleaders-agent trade clusters AAPL --days 7
+volumeleaders-agent trade clusters --tickers AAPL --start-date 2025-01-01 --end-date 2025-01-31
 volumeleaders-agent trade clusters --min-dollars 50000000 --vcd 1`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
@@ -180,7 +185,8 @@ func newTradeClusterBombsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "cluster-bombs",
 		Usage: "Query trade cluster bombs",
-		UsageText: `volumeleaders-agent trade cluster-bombs --tickers TSLA --start-date 2025-01-01
+		UsageText: `volumeleaders-agent trade cluster-bombs TSLA --days 3
+volumeleaders-agent trade cluster-bombs --tickers TSLA --start-date 2025-01-01
 volumeleaders-agent trade cluster-bombs --vcd 1 --min-volume 100000`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
@@ -237,17 +243,18 @@ func newTradeLevelsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "levels",
 		Usage: "Query significant price levels for a ticker",
-		UsageText: `volumeleaders-agent trade levels --ticker AAPL
+		UsageText: `volumeleaders-agent trade levels AAPL
+volumeleaders-agent trade levels --ticker AAPL
 volumeleaders-agent trade levels --ticker MSFT --trade-level-count 20 --min-dollars 1000000
 
-Dates are optional. Defaults to 1-year lookback ending today.`,
+Dates are optional. Defaults to 1-year lookback ending today. Use --days for shorter lookbacks.`,
 		Flags: slices.Concat(
 			optionalDateRangeFlags(),
 			volumeRangeFlags(),
 			priceRangeFlags(),
 			dollarRangeFlags(500000),
 			[]cli.Flag{
-				&cli.StringFlag{Name: "ticker", Aliases: []string{"tickers", "symbol", "symbols"}, Required: true, Usage: "Ticker symbol"},
+				&cli.StringFlag{Name: "ticker", Aliases: []string{"tickers", "symbol", "symbols"}, Usage: "Ticker symbol"},
 				&cli.IntFlag{Name: "vcd", Value: 0, Usage: "VCD filter"},
 				&cli.IntFlag{Name: "relative-size", Value: 0, Usage: "Relative size threshold"},
 				&cli.IntFlag{Name: "trade-level-rank", Value: -1, Usage: "Trade level rank filter"},
@@ -263,7 +270,8 @@ func newTradeLevelTouchesCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "level-touches",
 		Usage: "Query trade events at notable price levels",
-		UsageText: `volumeleaders-agent trade level-touches --tickers AAPL --start-date 2025-01-01
+		UsageText: `volumeleaders-agent trade level-touches AAPL --days 14
+volumeleaders-agent trade level-touches --tickers AAPL --start-date 2025-01-01
 volumeleaders-agent trade level-touches --tickers NVDA,AMD --trade-level-rank 5`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
@@ -288,6 +296,7 @@ volumeleaders-agent trade level-touches --tickers NVDA,AMD --trade-level-rank 5`
 func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	presetName := cmd.String("preset")
 	watchlistName := cmd.String("watchlist")
+	tickers := multiTickerValue(cmd)
 	fields, err := parseJSONFieldList[models.Trade](cmd.String("fields"))
 	if err != nil {
 		return fmt.Errorf("parsing fields flag: %w", err)
@@ -296,18 +305,21 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	// Apply sensible date defaults: 90-day lookback when tickers are scoped,
-	// today-only for broad (untickered) scans.
+	// Apply a short ticker-scoped default so high-volume symbols do not request
+	// huge result sets before users have narrowed the query themselves.
 	lookbackDays := 0
-	if cmd.String("tickers") != "" {
-		lookbackDays = 90
+	if tickers != "" {
+		lookbackDays = tradeListTickerLookbackDays
 	}
-	startDate, endDate := defaultDates(cmd, lookbackDays)
+	startDate, endDate, err := optionalDateRange(cmd, lookbackDays)
+	if err != nil {
+		return err
+	}
 
 	// Build the full filter map from CLI flags (includes defaults for unset
 	// flags). Every key the API requires is present after this call.
 	opts := &tradesOptions{
-		tickers:      cmd.String("tickers"),
+		tickers:      tickers,
 		startDate:    startDate,
 		endDate:      endDate,
 		minVolume:    cmd.Int("min-volume"),
@@ -361,6 +373,10 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		applyExplicitFlags(cmd, filters)
 	}
 
+	if tickers != "" {
+		filters["Tickers"] = tickers
+	}
+
 	// Dates always come from CLI or computed defaults (never from presets).
 	filters["StartDate"] = startDate
 	filters["EndDate"] = endDate
@@ -386,7 +402,7 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		if cmd.String("format") != string(outputFormatJSON) {
 			return fmt.Errorf("--format cannot be used with --summary")
 		}
-		return runTradeSummary(ctx, optsDataTable, cmd.String("group-by"), cmd.String("start-date"), cmd.String("end-date"))
+		return runTradeSummary(ctx, optsDataTable, cmd.String("group-by"), startDate, endDate)
 	}
 
 	return runDataTablesCommand[models.Trade](
@@ -599,10 +615,14 @@ func runTradeSentiment(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	startDate, endDate, err := requiredDateRange(cmd)
+	if err != nil {
+		return err
+	}
 
 	opts := &tradesOptions{
-		startDate:    cmd.String("start-date"),
-		endDate:      cmd.String("end-date"),
+		startDate:    startDate,
+		endDate:      endDate,
 		minVolume:    cmd.Int("min-volume"),
 		maxVolume:    cmd.Int("max-volume"),
 		minPrice:     cmd.Float("min-price"),
@@ -642,7 +662,7 @@ func runTradeSentiment(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	sentiment := summarizeTradeSentiment(trades, cmd.String("start-date"), cmd.String("end-date"))
+	sentiment := summarizeTradeSentiment(trades, startDate, endDate)
 
 	if format == outputFormatJSON {
 		return printJSON(ctx, sentiment)
@@ -690,14 +710,19 @@ func tradeSentimentTotalsRow(totals *models.TradeSentimentTotals) models.TradeSe
 }
 
 func runTradeClusters(ctx context.Context, cmd *cli.Command) error {
+	startDate, endDate, err := requiredDateRange(cmd)
+	if err != nil {
+		return err
+	}
+	tickers := multiTickerValue(cmd)
 	return runDataTablesCommand[models.TradeCluster](ctx, "/TradeClusters/GetTradeClusters", datatables.TradeClusterColumns,
 		dataTableOptions{
 			start: cmd.Int("start"), length: cmd.Int("length"),
 			orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"),
 			filters: map[string]string{
-				"Tickers":          cmd.String("tickers"),
-				"StartDate":        cmd.String("start-date"),
-				"EndDate":          cmd.String("end-date"),
+				"Tickers":          tickers,
+				"StartDate":        startDate,
+				"EndDate":          endDate,
 				"MinVolume":        intStr(cmd.Int("min-volume")),
 				"MaxVolume":        intStr(cmd.Int("max-volume")),
 				"MinPrice":         formatFloat(cmd.Float("min-price")),
@@ -714,14 +739,19 @@ func runTradeClusters(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runTradeClusterBombs(ctx context.Context, cmd *cli.Command) error {
+	startDate, endDate, err := requiredDateRange(cmd)
+	if err != nil {
+		return err
+	}
+	tickers := multiTickerValue(cmd)
 	return runDataTablesCommand[models.TradeClusterBomb](ctx, "/TradeClusterBombs/GetTradeClusterBombs", datatables.TradeClusterBombColumns,
 		dataTableOptions{
 			start: cmd.Int("start"), length: cmd.Int("length"),
 			orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"),
 			filters: map[string]string{
-				"Tickers":              cmd.String("tickers"),
-				"StartDate":            cmd.String("start-date"),
-				"EndDate":              cmd.String("end-date"),
+				"Tickers":              tickers,
+				"StartDate":            startDate,
+				"EndDate":              endDate,
 				"MinVolume":            intStr(cmd.Int("min-volume")),
 				"MaxVolume":            intStr(cmd.Int("max-volume")),
 				"MinDollars":           formatFloat(cmd.Float("min-dollars")),
@@ -754,9 +784,16 @@ func runTradeClusterAlerts(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
-	startDate, endDate := defaultDates(cmd, 365)
+	startDate, endDate, err := optionalDateRange(cmd, 365)
+	if err != nil {
+		return err
+	}
+	ticker, err := singleTickerValue(cmd)
+	if err != nil {
+		return err
+	}
 	opts := &tradeLevelOptions{
-		ticker:          cmd.String("ticker"),
+		ticker:          ticker,
 		startDate:       startDate,
 		endDate:         endDate,
 		minVolume:       cmd.Int("min-volume"),
@@ -783,14 +820,19 @@ func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runTradeLevelTouches(ctx context.Context, cmd *cli.Command) error {
+	startDate, endDate, err := requiredDateRange(cmd)
+	if err != nil {
+		return err
+	}
+	tickers := multiTickerValue(cmd)
 	return runDataTablesCommand[models.TradeLevelTouch](ctx, "/TradeLevelTouches/GetTradeLevelTouches", datatables.TradeLevelTouchColumns,
 		dataTableOptions{
 			start: cmd.Int("start"), length: cmd.Int("length"),
 			orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"),
 			filters: map[string]string{
-				"Tickers":        cmd.String("tickers"),
-				"StartDate":      cmd.String("start-date"),
-				"EndDate":        cmd.String("end-date"),
+				"Tickers":        tickers,
+				"StartDate":      startDate,
+				"EndDate":        endDate,
 				"MinVolume":      intStr(cmd.Int("min-volume")),
 				"MaxVolume":      intStr(cmd.Int("max-volume")),
 				"MinPrice":       formatFloat(cmd.Float("min-price")),

--- a/internal/commands/volume.go
+++ b/internal/commands/volume.go
@@ -19,7 +19,7 @@ func volumeFlags() []cli.Flag {
 	return slices.Concat(
 		[]cli.Flag{
 			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-			&cli.StringFlag{Name: "tickers", Usage: "Comma-separated ticker symbols"},
+			&cli.StringFlag{Name: "tickers", Aliases: []string{"ticker", "symbol", "symbols"}, Usage: "Comma-separated ticker symbols"},
 		},
 		outputFormatFlags(),
 		paginationFlags(100, 1, "asc"),
@@ -30,7 +30,7 @@ func volumeFlags() []cli.Flag {
 func parseVolumeOptions(cmd *cli.Command) *volumeOptions {
 	return &volumeOptions{
 		date:     cmd.String("date"),
-		tickers:  cmd.String("tickers"),
+		tickers:  multiTickerValue(cmd),
 		start:    cmd.Int("start"),
 		length:   cmd.Int("length"),
 		orderCol: cmd.Int("order-col"),
@@ -48,7 +48,7 @@ func NewVolumeCommand() *cli.Command {
 			{
 				Name:      "institutional",
 				Usage:     "Query institutional volume leaderboard",
-				UsageText: "volumeleaders-agent volume institutional --date 2025-01-15 --tickers AAPL,MSFT",
+				UsageText: "volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15",
 				Flags:     volumeFlags(),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					return runVolume(ctx, parseVolumeOptions(cmd),
@@ -70,7 +70,7 @@ func NewVolumeCommand() *cli.Command {
 			{
 				Name:      "total",
 				Usage:     "Query total volume leaderboard",
-				UsageText: "volumeleaders-agent volume total --date 2025-01-15 --length 20",
+				UsageText: "volumeleaders-agent volume total XLE --date 2025-01-15 --length 20",
 				Flags:     volumeFlags(),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					return runVolume(ctx, parseVolumeOptions(cmd),

--- a/internal/commands/volume_test.go
+++ b/internal/commands/volume_test.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
@@ -75,5 +77,27 @@ func TestVolumeSubcommands(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestVolumePositionalTickers(t *testing.T) {
+	var gotTickers string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		gotTickers = form.Get("Tickers")
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{NewVolumeCommand()}}
+		if err := root.Run(ctx, []string{"app", "volume", "institutional", "XLE", "XLK", "--date", "2025-01-15"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if gotTickers != "XLE,XLK" {
+		t.Errorf("Tickers = %q, want %q", gotTickers, "XLE,XLK")
 	}
 }

--- a/skills/volumeleaders-agent/SKILL.md
+++ b/skills/volumeleaders-agent/SKILL.md
@@ -37,24 +37,24 @@ This is the entry point. Command details are split by command group:
 
 | Goal | Command | Details |
 |---|---|---|
-| Find individual institutional trades | `trade list --tickers X --start-date D --end-date D` | [trade.md](trade.md) |
+| Find individual institutional trades | `trade list X --days N` | [trade.md](trade.md) |
 | Start with a market-wide daily snapshot | `daily summary --date D` | [daily.md](daily.md) |
-| Compare leveraged ETF bull/bear flow | `trade sentiment --start-date D --end-date D` | Fixed leveraged ETF universe |
-| Find price-level trade clusters | `trade clusters --start-date D --end-date D` | Cluster conviction |
-| Find sudden aggressive bursts | `trade cluster-bombs --start-date D --end-date D` | Burst detection |
+| Compare leveraged ETF bull/bear flow | `trade sentiment --days N` | Fixed leveraged ETF universe |
+| Find price-level trade clusters | `trade clusters --days N` | Cluster conviction |
+| Find sudden aggressive bursts | `trade cluster-bombs --days N` | Burst detection |
 | Check individual trade alerts | `trade alerts --date D` | System alerts |
 | Check cluster alerts | `trade cluster-alerts --date D` | System alerts |
-| Find support/resistance levels | `trade levels --ticker X --start-date D --end-date D` | One ticker |
-| Find price revisits to levels | `trade level-touches --start-date D --end-date D` | Level tests |
+| Find support/resistance levels | `trade levels X --days N` | One ticker |
+| Find price revisits to levels | `trade level-touches X --days N` | Level tests |
 | See institutional volume leaders | `volume institutional --date D` | [volume.md](volume.md) |
 | See after-hours institutional leaders | `volume ah-institutional --date D` | [volume.md](volume.md) |
 | See total volume leaders | `volume total --date D` | [volume.md](volume.md) |
-| Get 1-min bars with trade overlays | `chart price-data --ticker X --start-date D --end-date D` | [chart.md](chart.md) |
-| Get bid/ask/last quote | `chart snapshot --ticker X --date-key D` | JSON only |
-| Get chart-ready levels | `chart levels --ticker X --start-date D --end-date D` | Fewer filters than `trade levels` |
-| Get company metadata | `chart company --ticker X` | JSON only |
+| Get 1-min bars with trade overlays | `chart price-data X --days N` | [chart.md](chart.md) |
+| Get bid/ask/last quote | `chart snapshot X --date-key D` | JSON only |
+| Get chart-ready levels | `chart levels X --days N` | Fewer filters than `trade levels` |
+| Get company metadata | `chart company X` | JSON only |
 | Get current prices | `market snapshots` | JSON object |
-| Find earnings with prior institutional activity | `market earnings --start-date D --end-date D` | CSV/TSV supported |
+| Find earnings with prior institutional activity | `market earnings --days N` | CSV/TSV supported |
 | Check exhaustion/reversal signals | `market exhaustion [--date D]` | Lower rank = stronger signal |
 | Manage alert configs | `alert configs/create/edit/delete` | [alert.md](alert.md) |
 | Manage watchlists | `watchlist configs/create/edit/delete` | [watchlist.md](watchlist.md) |
@@ -64,17 +64,17 @@ This is the entry point. Command details are split by command group:
 
 1. `daily summary --date D` for the broad read.
 2. `volume institutional --date D` for top dollar movers.
-3. `trade list --tickers X --start-date D --end-date D` for individual prints.
-4. `trade levels --ticker X --start-date D --end-date D` for support/resistance.
-5. `chart company --ticker X` for company context.
-6. `chart price-data --ticker X --start-date D --end-date D` for bar-level overlays.
+3. `trade list X --days N` for individual prints.
+4. `trade levels X --days N` for support/resistance.
+5. `chart company X` for company context.
+6. `chart price-data X --days N` for bar-level overlays.
 
 ## Global Conventions
 
-- Dates: `YYYY-MM-DD`.
+- Dates: `YYYY-MM-DD`. Commands with date ranges accept either `--start-date D --end-date D` or `--days N`; `--days` counts backward from today unless `--end-date` is also set, and cannot be combined with `--start-date`.
 - Pagination: `--start` offset, `--length` count, `--length -1` means all rows, `--order-col` sort column index, `--order-dir asc|desc`.
 - Toggle filters: `-1` all/unfiltered, `0` exclude, `1` include/only.
-- Tickers: `--tickers` is comma-separated, `--ticker` is single-symbol. Trade ticker filters also accept `--symbol` and `--symbols` aliases.
+- Tickers: `--tickers` is comma-separated, `--ticker` is single-symbol. Commands that take tickers generally accept positional tickers too, for example `trade list XLE XLK` or `chart company AAPL`. Trade and volume ticker filters also accept `--symbol` and `--symbols` aliases.
 - Output formats: list-style commands may support `--format json|csv|tsv`. CSV/TSV include headers, booleans render as `true`/`false`, null/missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless their command file says otherwise.
 - Performance: use explicit dates and tickers when possible. `--length -1` can return large datasets and slow summary aggregation.
 

--- a/skills/volumeleaders-agent/chart.md
+++ b/skills/volumeleaders-agent/chart.md
@@ -8,12 +8,13 @@ Chart filter names differ from trade commands: use `--signature-prints` not `--s
 
 One-minute OHLCV bars with institutional trade overlays.
 
-Required: `--ticker`, `--start-date`, `--end-date`. Supports `--format json|csv|tsv`.
+Required: ticker flag or positional ticker, plus a complete `--start-date`/`--end-date` range or `--days`. Supports `--format json|csv|tsv`.
 
 Important options: `--volume-profile 0|1`, `--levels 5`, `--trade-count 3`, volume/price/dollar ranges, `--dark-pools`, `--sweeps`, `--late-prints`, `--signature-prints`, `--vcd`, `--trade-rank`, `--trade-rank-snapshot`, include-session flags.
 
 ```bash
 volumeleaders-agent chart price-data --ticker AAPL --start-date 2026-04-28 --end-date 2026-04-28
+volumeleaders-agent chart price-data AAPL --days 2
 volumeleaders-agent chart price-data --ticker AAPL --start-date 2026-04-28 --end-date 2026-04-28 --format tsv
 ```
 
@@ -23,10 +24,10 @@ Key fields: `DateKey`, `TimeKey`, `Date`, `FullDateTime`, `OpenPrice`, `ClosePri
 
 Quick quote for one ticker. JSON-only single object.
 
-Required: `--ticker`, `--date-key`.
+Required: ticker flag or positional ticker, plus `--date-key`.
 
 ```bash
-volumeleaders-agent chart snapshot --ticker AAPL --date-key 2026-04-28
+volumeleaders-agent chart snapshot AAPL --date-key 2026-04-28
 ```
 
 Fields: `ticker`, `lastQuote`, `lastTrade`, `todaysChange`, `todaysChangePerc`. `lastQuote` and `lastTrade` use compact single-letter keys from the source API.
@@ -35,10 +36,11 @@ Fields: `ticker`, `lastQuote`, `lastTrade`, `todaysChange`, `todaysChangePerc`. 
 
 Chart-ready institutional price levels with fewer filters than `trade levels`.
 
-Required: `--ticker`, `--start-date`, `--end-date`. Optional: `--levels` default `5`, `--format json|csv|tsv`.
+Required: ticker flag or positional ticker, plus a complete `--start-date`/`--end-date` range or `--days`. Optional: `--levels` default `5`, `--format json|csv|tsv`.
 
 ```bash
 volumeleaders-agent chart levels --ticker AAPL --start-date 2026-01-01 --end-date 2026-04-28 --levels 10
+volumeleaders-agent chart levels AAPL --days 30 --levels 10
 ```
 
 Fields: same TradeLevel model as `trade levels`.
@@ -47,10 +49,10 @@ Fields: same TradeLevel model as `trade levels`.
 
 Company metadata, fundamentals, sector/industry, and trading averages. JSON-only single object.
 
-Required: `--ticker`.
+Required: ticker flag or positional ticker.
 
 ```bash
-volumeleaders-agent chart company --ticker AAPL
+volumeleaders-agent chart company AAPL
 ```
 
 Key fields: `SecurityKey`, `Name`, `Ticker`, `Sector`, `Industry`, `Description`, `HomePageURL`, `MarketCap`, `CurrentPrice`, `OptionsEnabled`, `IPODate`, all-time/30-day/90-day average block, volume, trade-share, range, closing-trade, cluster-size, and level-size fields.

--- a/skills/volumeleaders-agent/market.md
+++ b/skills/volumeleaders-agent/market.md
@@ -5,12 +5,13 @@ Market-wide prices, earnings calendar, and exhaustion scores.
 | Command | Use when | Required | Output |
 |---|---|---|---|
 | `market snapshots` | Get current prices for all tracked symbols | none | JSON object |
-| `market earnings` | Find earnings with prior institutional activity | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `market earnings` | Find earnings with prior institutional activity | date range or `--days` | JSON, CSV, TSV |
 | `market exhaustion` | Check reversal/exhaustion signals | none | JSON |
 
 ```bash
 volumeleaders-agent market snapshots
 volumeleaders-agent market earnings --start-date 2026-04-21 --end-date 2026-04-28 --format csv
+volumeleaders-agent market earnings --days 7
 volumeleaders-agent market exhaustion --date 2026-04-28
 ```
 

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -9,13 +9,13 @@ Institutional trade discovery. See `SKILL.md` for global conventions, trade shar
 | `trade presets` | List built-in filters | none | JSON, CSV, TSV |
 | `trade preset-tickers` | Inspect a preset universe | `--preset` | JSON |
 | `trade list` | Query individual trades | none | JSON, CSV, TSV, or summary JSON |
-| `trade sentiment` | Bull/bear leveraged ETF flow | `--start-date`, `--end-date` | JSON, CSV, TSV |
-| `trade clusters` | Converging trades at price levels | `--start-date`, `--end-date` | JSON, CSV, TSV |
-| `trade cluster-bombs` | Sudden aggressive bursts | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `trade sentiment` | Bull/bear leveraged ETF flow | date range or `--days` | JSON, CSV, TSV |
+| `trade clusters` | Converging trades at price levels | date range or `--days` | JSON, CSV, TSV |
+| `trade cluster-bombs` | Sudden aggressive bursts | date range or `--days` | JSON, CSV, TSV |
 | `trade alerts` | System trade alerts | `--date` | JSON, CSV, TSV |
 | `trade cluster-alerts` | System cluster alerts | `--date` | JSON, CSV, TSV |
-| `trade levels` | Support/resistance by ticker | `--ticker` | JSON, CSV, TSV |
-| `trade level-touches` | Price revisits institutional levels | `--start-date`, `--end-date` | JSON, CSV, TSV |
+| `trade levels` | Support/resistance by ticker | ticker flag or positional ticker | JSON, CSV, TSV |
+| `trade level-touches` | Price revisits institutional levels | date range or `--days` | JSON, CSV, TSV |
 
 ## Presets
 
@@ -30,9 +30,9 @@ volumeleaders-agent trade preset-tickers --preset "Megacaps"
 
 ## trade list
 
-Primary individual-print query. Optional flags: `--start-date`, `--end-date`, ticker aliases, `--sector`, `--preset`, `--watchlist`, `--fields`, `--format`, `--summary`, `--group-by`, trade shared flags, pagination.
+Primary individual-print query. Optional flags: `--start-date`, `--end-date`, `--days`, ticker aliases, positional tickers, `--sector`, `--preset`, `--watchlist`, `--fields`, `--format`, `--summary`, `--group-by`, trade shared flags, pagination.
 
-Date defaults: with tickers, 90-day lookback from today. Without tickers, today only. Explicit dates override defaults. Presets and watchlists never supply dates.
+Date defaults: with tickers, 5-day lookback from today. Without tickers, today only. Explicit dates override defaults. `--days N` uses today or explicit `--end-date` as the range end and computes the start date; do not combine `--days` with `--start-date`. Presets and watchlists never supply dates.
 
 Filter precedence: preset baseline, then watchlist merge, then explicit CLI flags override both.
 
@@ -42,6 +42,7 @@ Fields mode: `--fields FIELD1,FIELD2` limits JSON keys or CSV/TSV columns. Names
 
 ```bash
 volumeleaders-agent trade list --tickers AAPL --dark-pools 1 --min-dollars 1000000
+volumeleaders-agent trade list XLE --days 5
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2026-04-28 --end-date 2026-04-28
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2026-04-01 --end-date 2026-04-28
 volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2026-04-21 --end-date 2026-04-28 --summary --group-by ticker,day --length -1
@@ -54,10 +55,11 @@ Key row fields: `Date`, `FullDateTime`, `Ticker`, `Name`, `Sector`, `Industry`, 
 
 Daily bull/bear leveraged ETF flow. The command always queries the combined leveraged ETF sector filter `SectorIndustry=X B`, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags.
 
-Required: `--start-date`, `--end-date`. Optional: `--format json|csv|tsv`, trade shared flags except ticker/sector filters. Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`; shared `--relative-size 5` still applies.
+Required: complete `--start-date`/`--end-date` range or `--days`. Optional: `--format json|csv|tsv`, trade shared flags except ticker/sector filters. Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`; shared `--relative-size 5` still applies.
 
 ```bash
 volumeleaders-agent trade sentiment --start-date 2026-04-21 --end-date 2026-04-28
+volumeleaders-agent trade sentiment --days 7
 volumeleaders-agent trade sentiment --start-date 2026-04-21 --end-date 2026-04-28 --format csv
 ```
 
@@ -65,12 +67,13 @@ JSON: `dateRange`, `daily`, `totals`. Daily rows include `date`, `bear`, `bull`,
 
 ## Clusters and cluster bombs
 
-`trade clusters` finds multiple institutional trades converging at similar prices. Defaults: `--min-dollars 10000000`, `--length 1000`, `--order-col 1`, `--order-dir desc`. Optional filters: ticker aliases, `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank`, format, pagination.
+`trade clusters` finds multiple institutional trades converging at similar prices. Requires a complete date range or `--days`. Defaults: `--min-dollars 10000000`, `--length 1000`, `--order-col 1`, `--order-dir desc`. Optional filters: ticker aliases, positional tickers, `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank`, format, pagination.
 
-`trade cluster-bombs` finds sudden, aggressive bursts tightly grouped in time and price. Defaults: `--min-dollars 0`, `--security-type 0`, `--relative-size 0`, `--length 100`. It has no price range filters and uses `--trade-cluster-bomb-rank`.
+`trade cluster-bombs` finds sudden, aggressive bursts tightly grouped in time and price. Requires a complete date range or `--days`. Defaults: `--min-dollars 0`, `--security-type 0`, `--relative-size 0`, `--length 100`. It accepts ticker aliases and positional tickers, has no price range filters, and uses `--trade-cluster-bomb-rank`.
 
 ```bash
 volumeleaders-agent trade clusters --start-date 2026-04-01 --end-date 2026-04-28 --min-dollars 50000000
+volumeleaders-agent trade clusters AAPL MSFT --days 5
 volumeleaders-agent trade cluster-bombs --start-date 2026-04-28 --end-date 2026-04-28
 ```
 
@@ -89,13 +92,13 @@ Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, 
 
 ## Levels and level touches
 
-`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted). Optional: `--start-date`, `--end-date`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--format`. Defaults to a 1-year lookback when dates are omitted. Non-standard default: `--relative-size 0`. No pagination.
+`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--format`. Defaults to a 1-year lookback when dates are omitted. Non-standard default: `--relative-size 0`. No pagination.
 
-`trade level-touches` finds events where price revisits institutional levels. Required: `--start-date`, `--end-date`. Optional: ticker aliases, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--order-col 0`, `--order-dir desc`.
+`trade level-touches` finds events where price revisits institutional levels. Required: complete `--start-date`/`--end-date` range or `--days`. Optional: ticker aliases, positional tickers, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--order-col 0`, `--order-dir desc`.
 
 ```bash
-volumeleaders-agent trade levels --ticker AAPL
-volumeleaders-agent trade level-touches --start-date 2026-04-28 --end-date 2026-04-28
+volumeleaders-agent trade levels AAPL --days 30
+volumeleaders-agent trade level-touches XLE --days 5
 ```
 
 Key fields: `Ticker`, `Name`, `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `MinDate`, `MaxDate`, `Dates`, plus `TradeLevelTouches` on level-touch rows.

--- a/skills/volumeleaders-agent/volume.md
+++ b/skills/volumeleaders-agent/volume.md
@@ -1,6 +1,6 @@
 # volume
 
-Volume leaderboards ranking stocks by trading activity. All commands require `--date`, support `--tickers`, `--format json|csv|tsv`, and pagination. Default sort is `--order-dir asc`, unlike trade commands.
+Volume leaderboards ranking stocks by trading activity. All commands require `--date`, support `--tickers` with aliases (`--ticker`, `--symbol`, `--symbols`) or positional tickers, `--format json|csv|tsv`, and pagination. Default sort is `--order-dir asc`, unlike trade commands.
 
 | Command | Use when |
 |---|---|
@@ -10,6 +10,7 @@ Volume leaderboards ranking stocks by trading activity. All commands require `--
 
 ```bash
 volumeleaders-agent volume institutional --date 2026-04-28
+volumeleaders-agent volume institutional XLE XLK --date 2026-04-28
 volumeleaders-agent volume institutional --date 2026-04-28 --format csv
 volumeleaders-agent volume ah-institutional --date 2026-04-28
 volumeleaders-agent volume total --date 2026-04-28


### PR DESCRIPTION
## Summary
- Add `--days` date ranges and positional ticker arguments across trade, chart, volume, and market commands.
- Shorten ticker-scoped `trade list` defaults to a 5-day lookback so high-volume symbols avoid oversized default queries.
- Treat missing or null DataTables `data` payloads as empty result sets instead of failing decode.

## Issues
Closes #37
Closes #38
Closes #39
Addresses #43 by removing the missing/null DataTables `data` decode failure. Live APH row parity was not auto-closed here because the direct reproduction query still timed out during local verification.

## Verification
- `go test ./internal/commands ./internal/client`
- `make test`
- `make lint`
- `make build`