### PR TITLE
fix: match trade levels defaults

### DIFF
--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -75,6 +75,30 @@ func runDataTablesCommand[T any](ctx context.Context, path string, columns []str
 	return printDataTablesResult(ctx, result, opts.fields, format)
 }
 
+// runDataTablesSingleRequestCommand sends exactly one DataTables request, even
+// when opts.length is -1. Some VolumeLeaders endpoints, such as trade levels,
+// use -1 as part of their native form payload instead of the CLI's paginated
+// all-results mode.
+func runDataTablesSingleRequestCommand[T any](ctx context.Context, path string, columns []string, opts dataTableOptions, formatValue, label string) error {
+	format, err := parseOutputFormat(formatValue)
+	if err != nil {
+		return err
+	}
+
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	request := newDataTablesRequest(columns, opts)
+	var result []T
+	if err := vlClient.PostDataTables(ctx, path, request.Encode(), &result); err != nil {
+		slog.Error("failed to "+label, "error", err)
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	return printDataTablesResult(ctx, result, opts.fields, format)
+}
+
 // runPaginatedCommand fetches all records by paginating through the DataTables
 // endpoint in pages of paginationPageSize. It accumulates results across pages
 // and stops when all filtered records have been retrieved or the server returns

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -106,15 +106,15 @@ func TestTradeListDefaultDates(t *testing.T) {
 		wantEnd   string
 	}{
 		{
-			name:      "with tickers defaults to 5-day lookback",
+			name:      "with tickers defaults to 365-day lookback",
 			args:      []string{"app", "list", "--tickers", "AAPL"},
-			wantStart: "2025-06-10",
+			wantStart: "2024-06-15",
 			wantEnd:   "2025-06-15",
 		},
 		{
-			name:      "with positional ticker defaults to 5-day lookback",
+			name:      "with positional ticker defaults to 365-day lookback",
 			args:      []string{"app", "list", "AAPL"},
-			wantStart: "2025-06-10",
+			wantStart: "2024-06-15",
 			wantEnd:   "2025-06-15",
 		},
 		{

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -226,8 +226,8 @@ func TestTradeLevelsDefaultDates(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
 				form, _ := url.ParseQuery(string(body))
-				gotStart = form.Get("MinDate")
-				gotEnd = form.Get("MaxDate")
+				gotStart = form.Get("StartDate")
+				gotEnd = form.Get("EndDate")
 				fmt.Fprint(w, dataTablesJSON(`[{}]`))
 			}))
 			t.Cleanup(server.Close)
@@ -240,12 +240,49 @@ func TestTradeLevelsDefaultDates(t *testing.T) {
 				}
 			})
 			if gotStart != tt.wantStart {
-				t.Errorf("MinDate = %q, want %q", gotStart, tt.wantStart)
+				t.Errorf("StartDate = %q, want %q", gotStart, tt.wantStart)
 			}
 			if gotEnd != tt.wantEnd {
-				t.Errorf("MaxDate = %q, want %q", gotEnd, tt.wantEnd)
+				t.Errorf("EndDate = %q, want %q", gotEnd, tt.wantEnd)
 			}
 		})
+	}
+}
+
+func TestTradeLevelsDefaultPayload(t *testing.T) {
+	frozen := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	origTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	t.Cleanup(func() { timeNow = origTimeNow })
+
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ = url.ParseQuery(string(body))
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeLevelsCommand()}}
+		if err := root.Run(ctx, []string{"app", "levels", "--ticker", "AMD"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	want := map[string]string{
+		"start":     "0",
+		"length":    "-1",
+		"StartDate": "2025-04-29",
+		"EndDate":   "2026-04-29",
+		"Ticker":    "AMD",
+		"Levels":    "10",
+	}
+	for key, value := range want {
+		if got := form.Get(key); got != value {
+			t.Errorf("%s = %q, want %q", key, got, value)
+		}
 	}
 }
 

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -16,7 +16,7 @@ import (
 	cli "github.com/urfave/cli/v3"
 )
 
-const tradeListTickerLookbackDays = 5
+const tradeListTickerLookbackDays = 365
 
 // --- Option structs ---
 
@@ -113,7 +113,7 @@ volumeleaders-agent trade list --sector Technology --relative-size 10 --length 5
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
 
-Dates are optional. With tickers: defaults to 5-day lookback. Without: defaults to today only. Use --days to choose another lookback.`,
+Dates are optional. With tickers: defaults to 365-day lookback. Without: defaults to today only. Use --days to choose another lookback.`,
 		Flags: slices.Concat(
 			optionalDateRangeFlags(),
 			volumeRangeFlags(),
@@ -305,8 +305,8 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	// Apply a short ticker-scoped default so high-volume symbols do not request
-	// huge result sets before users have narrowed the query themselves.
+	// Apply a ticker-scoped default that lets the server sort the wider history
+	// and return only the highest-value rows within the requested page size.
 	lookbackDays := 0
 	if tickers != "" {
 		lookbackDays = tradeListTickerLookbackDays

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -807,7 +807,7 @@ func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
 		tradeLevelRank:  cmd.Int("trade-level-rank"),
 		tradeLevelCount: cmd.Int("trade-level-count"),
 	}
-	return runDataTablesCommand[models.TradeLevel](ctx, "/TradeLevels/GetTradeLevels", datatables.TradeLevelColumns,
+	return runDataTablesSingleRequestCommand[models.TradeLevel](ctx, "/TradeLevels/GetTradeLevels", datatables.TradeLevelColumns,
 		dataTableOptions{
 			start:    0,
 			length:   -1,
@@ -1123,18 +1123,18 @@ func buildTradeFilters(opts *tradesOptions) map[string]string {
 
 func buildTradeLevelFilters(opts *tradeLevelOptions) map[string]string {
 	return map[string]string{
-		"Ticker":          opts.ticker,
-		"MinVolume":       intStr(opts.minVolume),
-		"MaxVolume":       intStr(opts.maxVolume),
-		"MinPrice":        formatFloat(opts.minPrice),
-		"MaxPrice":        formatFloat(opts.maxPrice),
-		"MinDollars":      formatFloat(opts.minDollars),
-		"MaxDollars":      formatFloat(opts.maxDollars),
-		"VCD":             intStr(opts.vcd),
-		"RelativeSize":    intStr(opts.relativeSize),
-		"MinDate":         opts.startDate,
-		"MaxDate":         opts.endDate,
-		"TradeLevelRank":  intStr(opts.tradeLevelRank),
-		"TradeLevelCount": intStr(opts.tradeLevelCount),
+		"Ticker":         opts.ticker,
+		"MinVolume":      intStr(opts.minVolume),
+		"MaxVolume":      intStr(opts.maxVolume),
+		"MinPrice":       formatFloat(opts.minPrice),
+		"MaxPrice":       formatFloat(opts.maxPrice),
+		"MinDollars":     formatFloat(opts.minDollars),
+		"MaxDollars":     formatFloat(opts.maxDollars),
+		"VCD":            intStr(opts.vcd),
+		"RelativeSize":   intStr(opts.relativeSize),
+		"StartDate":      opts.startDate,
+		"EndDate":        opts.endDate,
+		"TradeLevelRank": intStr(opts.tradeLevelRank),
+		"Levels":         intStr(opts.tradeLevelCount),
 	}
 }

--- a/internal/commands/trade_test.go
+++ b/internal/commands/trade_test.go
@@ -50,12 +50,12 @@ func TestParseJSONFieldList(t *testing.T) {
 				}
 				return
 			}
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !slices.Equal(got, tt.want) {
-			t.Fatalf("fields mismatch\nexpected: %#v\ngot:      %#v", tt.want, got)
-		}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("fields mismatch\nexpected: %#v\ngot:      %#v", tt.want, got)
+			}
 		})
 	}
 }
@@ -131,13 +131,13 @@ func TestBuildTradeFiltersPreservesAPIKeys(t *testing.T) {
 	}
 }
 
-func TestBuildTradeLevelFiltersUseLevelDateKeys(t *testing.T) {
+func TestBuildTradeLevelFiltersUseObservedLevelKeys(t *testing.T) {
 	t.Parallel()
 
 	filters := buildTradeLevelFilters(&tradeLevelOptions{
-		ticker:          "AAPL",
-		startDate:       "2026-04-01",
-		endDate:         "2026-04-24",
+		ticker:          "AMD",
+		startDate:       "2025-04-29",
+		endDate:         "2026-04-29",
 		minVolume:       100,
 		maxVolume:       200,
 		minPrice:        1.5,
@@ -147,23 +147,23 @@ func TestBuildTradeLevelFiltersUseLevelDateKeys(t *testing.T) {
 		vcd:             99,
 		relativeSize:    10,
 		tradeLevelRank:  5,
-		tradeLevelCount: 20,
+		tradeLevelCount: 10,
 	})
 
 	expected := map[string]string{
-		"Ticker":          "AAPL",
-		"MinVolume":       "100",
-		"MaxVolume":       "200",
-		"MinPrice":        "1.5",
-		"MaxPrice":        "99.25",
-		"MinDollars":      "500000",
-		"MaxDollars":      "30000000000",
-		"VCD":             "99",
-		"RelativeSize":    "10",
-		"MinDate":         "2026-04-01",
-		"MaxDate":         "2026-04-24",
-		"TradeLevelRank":  "5",
-		"TradeLevelCount": "20",
+		"Ticker":         "AMD",
+		"MinVolume":      "100",
+		"MaxVolume":      "200",
+		"MinPrice":       "1.5",
+		"MaxPrice":       "99.25",
+		"MinDollars":     "500000",
+		"MaxDollars":     "30000000000",
+		"VCD":            "99",
+		"RelativeSize":   "10",
+		"StartDate":      "2025-04-29",
+		"EndDate":        "2026-04-29",
+		"TradeLevelRank": "5",
+		"Levels":         "10",
 	}
 	if !maps.Equal(filters, expected) {
 		t.Fatalf("filters mismatch\nexpected: %#v\ngot:      %#v", expected, filters)

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -92,7 +92,7 @@ Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, 
 
 ## Levels and level touches
 
-`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--format`. Defaults to a 1-year lookback when dates are omitted. Non-standard default: `--relative-size 0`. No pagination.
+`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--format`. Defaults to a 1-year lookback when dates are omitted, `--trade-level-count 10`, and non-standard `--relative-size 0`. It does not expose pagination flags, but sends one request with `start=0` and `length=-1` to match the observed VolumeLeaders levels request and return all matching levels.
 
 `trade level-touches` finds events where price revisits institutional levels. Required: complete `--start-date`/`--end-date` range or `--days`. Optional: ticker aliases, positional tickers, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--order-col 0`, `--order-dir desc`.
 

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -32,7 +32,7 @@ volumeleaders-agent trade preset-tickers --preset "Megacaps"
 
 Primary individual-print query. Optional flags: `--start-date`, `--end-date`, `--days`, ticker aliases, positional tickers, `--sector`, `--preset`, `--watchlist`, `--fields`, `--format`, `--summary`, `--group-by`, trade shared flags, pagination.
 
-Date defaults: with tickers, 5-day lookback from today. Without tickers, today only. Explicit dates override defaults. `--days N` uses today or explicit `--end-date` as the range end and computes the start date; do not combine `--days` with `--start-date`. Presets and watchlists never supply dates.
+Date defaults: with tickers, 365-day lookback from today. Without tickers, today only. Explicit dates override defaults. `--days N` uses today or explicit `--end-date` as the range end and computes the start date; do not combine `--days` with `--start-date`. Presets and watchlists never supply dates.
 
 Filter precedence: preset baseline, then watchlist merge, then explicit CLI flags override both.
 


### PR DESCRIPTION
## Summary
- Match observed VolumeLeaders `trade levels` defaults by sending one DataTables request with `start=0`, `length=-1`, and level filters keyed as `StartDate`, `EndDate`, `Ticker`, and `Levels`.
- Keep the default 1-year levels lookback and document the non-paginated levels request behavior.
- Includes the rebased PR #46 trade-list lookback commit because this work was stacked on top of it.

## Verification
- `go test ./internal/commands -run 'TestTradeListDefaultDates|TestTradeLevels(DefaultDates|DefaultPayload)|TestBuildTradeLevelFiltersUseObservedLevelKeys'`
- `make test`
- `make build`

Note: PR #46 is currently still open and conflicted. Once it merges or is refreshed, this branch can be rebased again so the trade-levels PR only carries the levels commit.