### PR TITLE
fix: compact default trade outputs

### DIFF
--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -188,6 +188,166 @@ func TestTradeListPositionalTickers(t *testing.T) {
 	}
 }
 
+func TestTradeListDefaultJSONUsesCompactRows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{
+				"Date":"/Date(1745193600000)/",
+				"StartDate":"/Date(1745193600000)/",
+				"EndDate":"/Date(1745193600000)/",
+				"DateKey":20250421,
+				"SecurityKey":12345,
+				"TradeID":98765,
+				"SequenceNumber":7,
+				"Ticker":"SPY",
+				"Name":"SPDR S&P 500 ETF Trust",
+				"Sector":"ETF",
+				"Industry":"Index ETF",
+				"FullDateTime":"2025-04-21T14:30:00",
+				"FullTimeString24":"14:30:00",
+				"Price":520.5,
+				"Bid":520.49,
+				"Ask":520.51,
+				"Volume":50000,
+				"Dollars":26025000,
+				"AverageBlockSizeDollars":5000000,
+				"DollarsMultiplier":5.2,
+				"AverageDailyVolume":100000000,
+				"PercentDailyVolume":0.05,
+				"RelativeSize":8.1,
+				"CumulativeDistribution":0.97,
+				"TradeRank":12,
+				"TradeRankSnapshot":14,
+				"DarkPool":1,
+				"Sweep":0,
+				"LatePrint":1,
+				"SignaturePrint":1,
+				"OpeningTrade":0,
+				"ClosingTrade":0,
+				"PhantomPrint":0,
+				"TradeConditions":"Contingent",
+				"FrequencyLast30TD":1,
+				"FrequencyLast90TD":2,
+				"FrequencyLast1CY":3,
+				"TotalRows":100,
+				"ExternalFeed":1,
+				"RSIHour":55.5,
+				"RSIDay":61.25
+			}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal compact output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one row, got %d", len(got))
+	}
+
+	wantFields := []string{
+		"Date",
+		"FullDateTime",
+		"Ticker",
+		"Name",
+		"Sector",
+		"Industry",
+		"Price",
+		"Volume",
+		"Dollars",
+		"DollarsMultiplier",
+		"PercentDailyVolume",
+		"RelativeSize",
+		"CumulativeDistribution",
+		"TradeRank",
+		"TradeRankSnapshot",
+		"DarkPool",
+		"Sweep",
+		"LatePrint",
+		"SignaturePrint",
+		"TradeConditions",
+		"RSIHour",
+		"RSIDay",
+	}
+	for _, field := range wantFields {
+		if _, ok := got[0][field]; !ok {
+			t.Fatalf("expected compact field %s", field)
+		}
+	}
+
+	omittedFields := []string{
+		"StartDate",
+		"EndDate",
+		"DateKey",
+		"SecurityKey",
+		"TradeID",
+		"SequenceNumber",
+		"Bid",
+		"Ask",
+		"AverageDailyVolume",
+		"TotalRows",
+		"ExternalFeed",
+	}
+	for _, field := range omittedFields {
+		if _, ok := got[0][field]; ok {
+			t.Fatalf("did not expect noisy field %s", field)
+		}
+	}
+}
+
+func TestTradeListDefaultJSONUsesParsedFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Trades/GetTrades" {
+			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"SPY","TradeID":98765,"Dollars":26025000}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+			"--format", "JSON",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal compact output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one row, got %d", len(got))
+	}
+	if _, ok := got[0]["Ticker"]; !ok {
+		t.Fatal("expected compact Ticker field")
+	}
+	if _, ok := got[0]["TradeID"]; ok {
+		t.Fatal("did not expect raw TradeID field")
+	}
+}
+
 func TestTradeLevelsDefaultDates(t *testing.T) {
 	frozen := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
 	origTimeNow := timeNow
@@ -507,7 +667,7 @@ func TestTradeListFieldsFiltersOutput(t *testing.T) {
 		if r.URL.Path != "/Trades/GetTrades" {
 			t.Errorf("expected path /Trades/GetTrades, got %s", r.URL.Path)
 		}
-		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"SPY","Dollars":26025000,"Volume":50000}]`))
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"SPY","TradeID":98765,"Dollars":26025000,"Volume":50000}]`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -518,7 +678,7 @@ func TestTradeListFieldsFiltersOutput(t *testing.T) {
 			"app", "list",
 			"--start-date", "2025-01-01",
 			"--end-date", "2025-01-31",
-			"--fields", "Ticker,Dollars",
+			"--fields", "Ticker,TradeID,Dollars",
 		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -536,6 +696,9 @@ func TestTradeListFieldsFiltersOutput(t *testing.T) {
 	}
 	if _, ok := got[0]["Dollars"]; !ok {
 		t.Fatal("expected Dollars field")
+	}
+	if _, ok := got[0]["TradeID"]; !ok {
+		t.Fatal("expected raw TradeID field")
 	}
 	if _, ok := got[0]["Volume"]; ok {
 		t.Fatal("did not expect Volume field")

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -446,6 +446,124 @@ func TestTradeLevelsDefaultPayload(t *testing.T) {
 	}
 }
 
+func TestTradeLevelsDefaultJSONUsesCompactRows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/TradeLevels/GetTradeLevels" {
+			t.Errorf("expected path /TradeLevels/GetTradeLevels, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{
+				"Ticker":"AMD",
+				"Name":"Advanced Micro Devices, Inc.",
+				"Price":148.25,
+				"Dollars":25000000,
+				"Volume":168634,
+				"Trades":4,
+				"RelativeSize":6.75,
+				"CumulativeDistribution":0.94,
+				"TradeLevelRank":3,
+				"MinDate":"/Date(1745193600000)/",
+				"MaxDate":"/Date(1745280000000)/",
+				"Dates":"2025-04-21,2025-04-22"
+			}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeLevelsCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "levels", "AMD",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-22",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal compact output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one row, got %d", len(got))
+	}
+
+	wantFields := []string{
+		"Price",
+		"Dollars",
+		"Volume",
+		"Trades",
+		"RelativeSize",
+		"CumulativeDistribution",
+		"TradeLevelRank",
+		"MinDate",
+		"MaxDate",
+	}
+	for _, field := range wantFields {
+		if _, ok := got[0][field]; !ok {
+			t.Fatalf("expected compact field %s", field)
+		}
+	}
+
+	omittedFields := []string{"Ticker", "Name", "Dates"}
+	for _, field := range omittedFields {
+		if _, ok := got[0][field]; ok {
+			t.Fatalf("did not expect noisy field %s", field)
+		}
+	}
+}
+
+func TestTradeLevelsFieldsFiltersOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/TradeLevels/GetTradeLevels" {
+			t.Errorf("expected path /TradeLevels/GetTradeLevels, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[
+			{
+				"Ticker":"AMD",
+				"Name":"Advanced Micro Devices, Inc.",
+				"Price":148.25,
+				"Dollars":25000000,
+				"Dates":"2025-04-21,2025-04-22"
+			}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeLevelsCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "levels", "AMD",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-22",
+			"--fields", "Ticker,Name,Dates",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal field-filtered output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one row, got %d", len(got))
+	}
+
+	wantFields := []string{"Ticker", "Name", "Dates"}
+	for _, field := range wantFields {
+		if _, ok := got[0][field]; !ok {
+			t.Fatalf("expected requested field %s", field)
+		}
+	}
+	if _, ok := got[0]["Price"]; ok {
+		t.Fatal("did not expect unrequested Price field")
+	}
+}
+
 func TestTradeSentimentAggregatesLeveragedFlow(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/Trades/GetTrades" {

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -264,6 +266,7 @@ func TestTradeListDefaultJSONUsesCompactRows(t *testing.T) {
 	wantFields := []string{
 		"Date",
 		"FullDateTime",
+		"FullTimeString24",
 		"Ticker",
 		"Name",
 		"Sector",
@@ -281,7 +284,13 @@ func TestTradeListDefaultJSONUsesCompactRows(t *testing.T) {
 		"Sweep",
 		"LatePrint",
 		"SignaturePrint",
+		"OpeningTrade",
+		"ClosingTrade",
+		"PhantomPrint",
 		"TradeConditions",
+		"FrequencyLast30TD",
+		"FrequencyLast90TD",
+		"FrequencyLast1CY",
 		"RSIHour",
 		"RSIDay",
 	}
@@ -345,6 +354,59 @@ func TestTradeListDefaultJSONUsesParsedFormat(t *testing.T) {
 	}
 	if _, ok := got[0]["TradeID"]; ok {
 		t.Fatal("did not expect raw TradeID field")
+	}
+}
+
+func TestTradeListDefaultJSONAllResultsUsesPagination(t *testing.T) {
+	totalRecords := paginationPageSize + 1
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		params, _ := url.ParseQuery(string(body))
+
+		if params.Get("start") == "0" {
+			items := make([]string, paginationPageSize)
+			for i := range items {
+				items[i] = `{"Ticker":"SPY","TradeID":98765,"Dollars":1}`
+			}
+			fmt.Fprint(w, dataTablesJSONPage("["+strings.Join(items, ",")+"]", totalRecords))
+			return
+		}
+
+		fmt.Fprint(w, dataTablesJSONPage(`[{"Ticker":"QQQ","TradeID":98766,"Dollars":2}]`, totalRecords))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+			"--length", "-1",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal compact output: %v", err)
+	}
+	if gotRequests := requestCount.Load(); gotRequests != 2 {
+		t.Fatalf("request count = %d, want 2", gotRequests)
+	}
+	if len(got) != totalRecords {
+		t.Fatalf("row count = %d, want %d", len(got), totalRecords)
+	}
+	if _, ok := got[len(got)-1]["Ticker"]; !ok {
+		t.Fatal("expected compact Ticker field on final page")
+	}
+	if _, ok := got[len(got)-1]["TradeID"]; ok {
+		t.Fatal("did not expect raw TradeID field on final page")
 	}
 }
 
@@ -1085,6 +1147,35 @@ func TestTradeListSummaryRejectsNonJSONFormat(t *testing.T) {
 	assertErrContains(t, err, "--format cannot be used with --summary")
 }
 
+func TestTradeListSummaryUsesParsedJSONFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":100}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+			"--summary",
+			"--format", "JSON",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got models.TradeSummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal summary output: %v", err)
+	}
+	if got.TotalTrades != 1 {
+		t.Fatalf("total trades = %d, want 1", got.TotalTrades)
+	}
+}
+
 func TestTradeListRejectsGroupByWithoutSummary(t *testing.T) {
 	ctx := contextWithTestClient(t, "http://127.0.0.1")
 	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
@@ -1097,28 +1188,61 @@ func TestTradeListRejectsGroupByWithoutSummary(t *testing.T) {
 	assertErrContains(t, err, "--group-by only works with --summary")
 }
 
-func TestTradeListSummaryAllResultsStopsAtPaginationCap(t *testing.T) {
+func TestTradeListSummaryAllResultsContinuesPastFormerPaginationCap(t *testing.T) {
+	const formerPaginationCap = 100
+
+	totalRecords := paginationPageSize*formerPaginationCap + 1
 	items := make([]string, paginationPageSize)
 	for i := range items {
 		items[i] = `{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":1}`
 	}
 	fullPage := "[" + strings.Join(items, ",") + "]"
+	finalPage := `[{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":2}]`
+	var requestCount int
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, dataTablesJSONPage(fullPage, 0))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		body, _ := io.ReadAll(r.Body)
+		params, _ := url.ParseQuery(string(body))
+		start, _ := strconv.Atoi(params.Get("start"))
+
+		if start < paginationPageSize*formerPaginationCap {
+			fmt.Fprint(w, dataTablesJSONPage(fullPage, totalRecords))
+			return
+		}
+
+		fmt.Fprint(w, dataTablesJSONPage(finalPage, totalRecords))
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
-	err := root.Run(ctx, []string{
-		"app", "list",
-		"--start-date", "2025-04-21",
-		"--end-date", "2025-04-21",
-		"--summary",
-		"--length", "-1",
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "list",
+			"--start-date", "2025-04-21",
+			"--end-date", "2025-04-21",
+			"--summary",
+			"--length", "-1",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
-	assertErrContains(t, err, "query trades: pagination exceeded")
+
+	var got models.TradeSummary
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal summary output: %v", err)
+	}
+	if requestCount != formerPaginationCap+1 {
+		t.Fatalf("request count = %d, want %d", requestCount, formerPaginationCap+1)
+	}
+	if got.TotalTrades != totalRecords {
+		t.Fatalf("total trades = %d, want %d", got.TotalTrades, totalRecords)
+	}
+	wantDollars := float64(paginationPageSize*formerPaginationCap + 2)
+	if got.TotalDollars != wantDollars {
+		t.Fatalf("total dollars = %v, want %v", got.TotalDollars, wantDollars)
+	}
 }
 
 func TestTradeListInvalidFormatWithWatchlistDoesNotQueryAPI(t *testing.T) {

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -301,7 +301,8 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return fmt.Errorf("parsing fields flag: %w", err)
 	}
-	if _, err := parseOutputFormat(cmd.String("format")); err != nil {
+	format, err := parseOutputFormat(cmd.String("format"))
+	if err != nil {
 		return err
 	}
 
@@ -403,6 +404,14 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("--format cannot be used with --summary")
 		}
 		return runTradeSummary(ctx, optsDataTable, cmd.String("group-by"), startDate, endDate)
+	}
+	if format == outputFormatJSON && len(fields) == 0 {
+		trades, err := fetchTradeList(ctx, optsDataTable)
+		if err != nil {
+			return err
+		}
+
+		return printJSON(ctx, models.NewTradeListRows(trades))
 	}
 
 	return runDataTablesCommand[models.Trade](

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -259,6 +259,7 @@ Dates are optional. Defaults to 1-year lookback ending today. Use --days for sho
 				&cli.IntFlag{Name: "relative-size", Value: 0, Usage: "Relative size threshold"},
 				&cli.IntFlag{Name: "trade-level-rank", Value: -1, Usage: "Trade level rank filter"},
 				&cli.IntFlag{Name: "trade-level-count", Value: 10, Usage: "Number of price levels to return"},
+				&cli.StringFlag{Name: "fields", Usage: "Comma-separated trade level fields to include in output"},
 			},
 			outputFormatFlags(),
 		),
@@ -793,6 +794,15 @@ func runTradeClusterAlerts(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
+	fields, err := parseJSONFieldList[models.TradeLevel](cmd.String("fields"))
+	if err != nil {
+		return fmt.Errorf("parsing fields flag: %w", err)
+	}
+	format, err := parseOutputFormat(cmd.String("format"))
+	if err != nil {
+		return err
+	}
+
 	startDate, endDate, err := optionalDateRange(cmd, 365)
 	if err != nil {
 		return err
@@ -816,16 +826,43 @@ func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
 		tradeLevelRank:  cmd.Int("trade-level-rank"),
 		tradeLevelCount: cmd.Int("trade-level-count"),
 	}
+	dataOpts := dataTableOptions{
+		start:    0,
+		length:   -1,
+		orderCol: 1,
+		orderDir: "desc",
+		filters:  buildTradeLevelFilters(opts),
+		fields:   fields,
+	}
+
+	if format == outputFormatJSON && len(fields) == 0 {
+		levels, err := fetchTradeLevels(ctx, dataOpts)
+		if err != nil {
+			return err
+		}
+
+		return printJSON(ctx, models.NewTradeLevelRows(levels))
+	}
+
 	return runDataTablesSingleRequestCommand[models.TradeLevel](ctx, "/TradeLevels/GetTradeLevels", datatables.TradeLevelColumns,
-		dataTableOptions{
-			start:    0,
-			length:   -1,
-			orderCol: 1,
-			orderDir: "desc",
-			filters:  buildTradeLevelFilters(opts),
-		},
+		dataOpts,
 		cmd.String("format"),
 		"query trade levels")
+}
+
+func fetchTradeLevels(ctx context.Context, opts dataTableOptions) ([]models.TradeLevel, error) {
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	request := newDataTablesRequest(datatables.TradeLevelColumns, opts)
+	var result []models.TradeLevel
+	if err := vlClient.PostDataTables(ctx, "/TradeLevels/GetTradeLevels", request.Encode(), &result); err != nil {
+		slog.Error("failed to query trade levels", "error", err)
+		return nil, fmt.Errorf("query trade levels: %w", err)
+	}
+	return result, nil
 }
 
 func runTradeLevelTouches(ctx context.Context, cmd *cli.Command) error {

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -401,18 +401,13 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		if len(fields) > 0 {
 			return fmt.Errorf("--fields cannot be used with --summary")
 		}
-		if cmd.String("format") != string(outputFormatJSON) {
+		if format != outputFormatJSON {
 			return fmt.Errorf("--format cannot be used with --summary")
 		}
 		return runTradeSummary(ctx, optsDataTable, cmd.String("group-by"), startDate, endDate)
 	}
 	if format == outputFormatJSON && len(fields) == 0 {
-		trades, err := fetchTradeList(ctx, optsDataTable)
-		if err != nil {
-			return err
-		}
-
-		return printJSON(ctx, models.NewTradeListRows(trades))
+		return runTradeListRows(ctx, optsDataTable)
 	}
 
 	return runDataTablesCommand[models.Trade](
@@ -423,6 +418,58 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 		cmd.String("format"),
 		"query trades",
 	)
+}
+
+func runTradeListRows(ctx context.Context, opts dataTableOptions) error {
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if opts.length < 0 {
+		return runPaginatedTradeListRows(ctx, vlClient, opts)
+	}
+
+	request := newDataTablesRequest(datatables.TradeColumns, opts)
+	var result []models.Trade
+	if err := vlClient.PostDataTables(ctx, "/Trades/GetTrades", request.Encode(), &result); err != nil {
+		slog.Error("failed to query trades", "error", err)
+		return fmt.Errorf("query trades: %w", err)
+	}
+	return printJSON(ctx, models.NewTradeListRows(result))
+}
+
+func runPaginatedTradeListRows(ctx context.Context, vlClient *client.Client, opts dataTableOptions) error {
+	opts.length = paginationPageSize
+	all := make([]models.TradeListRow, 0)
+
+	for {
+		request := newDataTablesRequest(datatables.TradeColumns, opts)
+		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
+		if err != nil {
+			slog.Error("failed to query trades", "error", err)
+			return fmt.Errorf("query trades: %w", err)
+		}
+
+		var page []models.Trade
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
+			slog.Error("failed to decode trades", "error", err)
+			return fmt.Errorf("query trades: decode response: %w", err)
+		}
+		if len(page) == 0 {
+			return printJSON(ctx, all)
+		}
+
+		all = append(all, models.NewTradeListRows(page)...)
+		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
+			return printJSON(ctx, all)
+		}
+		if len(page) < paginationPageSize {
+			return printJSON(ctx, all)
+		}
+
+		opts.start += len(page)
+	}
 }
 
 func runTradeSummary(ctx context.Context, opts dataTableOptions, groupBy, startDate, endDate string) error {
@@ -460,11 +507,9 @@ func fetchTradeList(ctx context.Context, opts dataTableOptions) ([]models.Trade,
 }
 
 func fetchAllTradePages(ctx context.Context, vlClient *client.Client, opts dataTableOptions) ([]models.Trade, error) {
-	const maxTradeSummaryPages = 100
-
 	opts.length = paginationPageSize
 	all := make([]models.Trade, 0)
-	for range maxTradeSummaryPages {
+	for {
 		request := newDataTablesRequest(datatables.TradeColumns, opts)
 		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
 		if err != nil {
@@ -491,13 +536,6 @@ func fetchAllTradePages(ctx context.Context, vlClient *client.Client, opts dataT
 
 		opts.start += len(page)
 	}
-
-	return nil, fmt.Errorf(
-		"query trades: pagination exceeded %d pages at start=%d with %d records fetched",
-		maxTradeSummaryPages,
-		opts.start,
-		len(all),
-	)
 }
 
 type tradeSummaryGroup string

--- a/internal/models/level.go
+++ b/internal/models/level.go
@@ -16,6 +16,44 @@ type TradeLevel struct {
 	Dates                  string     `json:"Dates"`
 }
 
+// TradeLevelRow is the compact default JSON shape for trade levels output.
+// The command already scopes results to one ticker, so per-row ticker and
+// company metadata stay available through explicit --fields requests instead
+// of repeating on every default row.
+type TradeLevelRow struct {
+	Price                  float64    `json:"Price"`
+	Dollars                float64    `json:"Dollars"`
+	Volume                 int        `json:"Volume"`
+	Trades                 int        `json:"Trades"`
+	RelativeSize           float64    `json:"RelativeSize"`
+	CumulativeDistribution float64    `json:"CumulativeDistribution"`
+	TradeLevelRank         int        `json:"TradeLevelRank"`
+	MinDate                AspNetDate `json:"MinDate"`
+	MaxDate                AspNetDate `json:"MaxDate"`
+}
+
+// NewTradeLevelRows projects full API level rows into the compact default
+// shape used by trade levels JSON output.
+func NewTradeLevelRows(levels []TradeLevel) []TradeLevelRow {
+	rows := make([]TradeLevelRow, 0, len(levels))
+	for i := range levels {
+		level := &levels[i]
+		rows = append(rows, TradeLevelRow{
+			Price:                  level.Price,
+			Dollars:                level.Dollars,
+			Volume:                 level.Volume,
+			Trades:                 level.Trades,
+			RelativeSize:           level.RelativeSize,
+			CumulativeDistribution: level.CumulativeDistribution,
+			TradeLevelRank:         level.TradeLevelRank,
+			MinDate:                level.MinDate,
+			MaxDate:                level.MaxDate,
+		})
+	}
+
+	return rows
+}
+
 // TradeLevelTouch represents a trade event at a notable price level.
 type TradeLevelTouch struct {
 	Ticker                 string     `json:"Ticker"`

--- a/internal/models/trade.go
+++ b/internal/models/trade.go
@@ -174,6 +174,84 @@ type Trade struct {
 	ExternalFeed                  FlexBool   `json:"ExternalFeed"`
 }
 
+// TradeListRow is the compact default JSON shape for trade list output.
+// It keeps the fields most useful for institutional-trade analysis while
+// leaving raw API identifiers and redundant query metadata available through
+// explicit --fields requests.
+type TradeListRow struct {
+	Date                   AspNetDate `json:"Date"`
+	FullDateTime           *string    `json:"FullDateTime"`
+	FullTimeString24       *string    `json:"FullTimeString24"`
+	Ticker                 string     `json:"Ticker"`
+	Name                   string     `json:"Name"`
+	Sector                 string     `json:"Sector"`
+	Industry               *string    `json:"Industry"`
+	Price                  float64    `json:"Price"`
+	Volume                 int        `json:"Volume"`
+	Dollars                float64    `json:"Dollars"`
+	DollarsMultiplier      float64    `json:"DollarsMultiplier"`
+	PercentDailyVolume     float64    `json:"PercentDailyVolume"`
+	RelativeSize           float64    `json:"RelativeSize"`
+	CumulativeDistribution float64    `json:"CumulativeDistribution"`
+	TradeRank              int        `json:"TradeRank"`
+	TradeRankSnapshot      int        `json:"TradeRankSnapshot"`
+	DarkPool               FlexBool   `json:"DarkPool"`
+	Sweep                  FlexBool   `json:"Sweep"`
+	LatePrint              FlexBool   `json:"LatePrint"`
+	SignaturePrint         FlexBool   `json:"SignaturePrint"`
+	OpeningTrade           FlexBool   `json:"OpeningTrade"`
+	ClosingTrade           FlexBool   `json:"ClosingTrade"`
+	PhantomPrint           FlexBool   `json:"PhantomPrint"`
+	TradeConditions        *string    `json:"TradeConditions"`
+	FrequencyLast30TD      int        `json:"FrequencyLast30TD"`
+	FrequencyLast90TD      int        `json:"FrequencyLast90TD"`
+	FrequencyLast1CY       int        `json:"FrequencyLast1CY"`
+	RSIHour                float64    `json:"RSIHour"`
+	RSIDay                 float64    `json:"RSIDay"`
+}
+
+// NewTradeListRows projects full API trade rows into the compact default
+// shape used by trade list JSON output.
+func NewTradeListRows(trades []Trade) []TradeListRow {
+	rows := make([]TradeListRow, 0, len(trades))
+	for i := range trades {
+		trade := &trades[i]
+		rows = append(rows, TradeListRow{
+			Date:                   trade.Date,
+			FullDateTime:           trade.FullDateTime,
+			FullTimeString24:       trade.FullTimeString24,
+			Ticker:                 trade.Ticker,
+			Name:                   trade.Name,
+			Sector:                 trade.Sector,
+			Industry:               trade.Industry,
+			Price:                  trade.Price,
+			Volume:                 trade.Volume,
+			Dollars:                trade.Dollars,
+			DollarsMultiplier:      trade.DollarsMultiplier,
+			PercentDailyVolume:     trade.PercentDailyVolume,
+			RelativeSize:           trade.RelativeSize,
+			CumulativeDistribution: trade.CumulativeDistribution,
+			TradeRank:              trade.TradeRank,
+			TradeRankSnapshot:      trade.TradeRankSnapshot,
+			DarkPool:               trade.DarkPool,
+			Sweep:                  trade.Sweep,
+			LatePrint:              trade.LatePrint,
+			SignaturePrint:         trade.SignaturePrint,
+			OpeningTrade:           trade.OpeningTrade,
+			ClosingTrade:           trade.ClosingTrade,
+			PhantomPrint:           trade.PhantomPrint,
+			TradeConditions:        trade.TradeConditions,
+			FrequencyLast30TD:      trade.FrequencyLast30TD,
+			FrequencyLast90TD:      trade.FrequencyLast90TD,
+			FrequencyLast1CY:       trade.FrequencyLast1CY,
+			RSIHour:                trade.RSIHour,
+			RSIDay:                 trade.RSIDay,
+		})
+	}
+
+	return rows
+}
+
 // TradeSummary represents aggregate trade metrics for a trade list query.
 type TradeSummary struct {
 	TotalTrades  int                          `json:"totalTrades"`

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -94,7 +94,9 @@ Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, 
 
 ## Levels and level touches
 
-`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--format`. Defaults to a 1-year lookback when dates are omitted, `--trade-level-count 10`, and non-standard `--relative-size 0`. It does not expose pagination flags, but sends one request with `start=0` and `length=-1` to match the observed VolumeLeaders levels request and return all matching levels.
+`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--fields`, `--format`. Defaults to a 1-year lookback when dates are omitted, `--trade-level-count 10`, and non-standard `--relative-size 0`. It does not expose pagination flags, but sends one request with `start=0` and `length=-1` to match the observed VolumeLeaders levels request and return all matching levels.
+
+Default `trade levels` JSON returns compact analysis rows. It keeps level price, dollars, volume, trade count, relative size, cumulative distribution, rank, and min/max dates. Repetitive single-ticker metadata (`Ticker`, `Name`) and the verbose `Dates` list are omitted to reduce tokens. Use `--fields Ticker,Name,Dates` or another explicit field list when those raw API fields are needed. CSV/TSV without `--fields` still use the full raw trade level row columns.
 
 `trade level-touches` finds events where price revisits institutional levels. Required: complete `--start-date`/`--end-date` range or `--days`. Optional: ticker aliases, positional tickers, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--order-col 0`, `--order-dir desc`.
 
@@ -103,4 +105,6 @@ volumeleaders-agent trade levels AAPL --days 30
 volumeleaders-agent trade level-touches XLE --days 5
 ```
 
-Key fields: `Ticker`, `Name`, `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `MinDate`, `MaxDate`, `Dates`, plus `TradeLevelTouches` on level-touch rows.
+Default `trade levels` JSON row fields: `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `MinDate`, `MaxDate`.
+
+Raw level fields available through `--fields`, CSV, or TSV: `Ticker`, `Name`, `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `MinDate`, `MaxDate`, `Dates`. Level-touch rows include those context fields plus `Sector`, `Industry`, `Date`, `FullDateTime`, `FullTimeString24`, `TotalRows`, and `TradeLevelTouches`.

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -32,13 +32,15 @@ volumeleaders-agent trade preset-tickers --preset "Megacaps"
 
 Primary individual-print query. Optional flags: `--start-date`, `--end-date`, `--days`, ticker aliases, positional tickers, `--sector`, `--preset`, `--watchlist`, `--fields`, `--format`, `--summary`, `--group-by`, trade shared flags, pagination.
 
+Default JSON returns compact analysis rows, not the full raw API row. It keeps trade timing, ticker/company context, price/volume/dollar size, rank, relative-size metrics, key boolean traits, frequency windows, trade conditions, and RSI. Repetitive query dates, internal numeric keys, raw bid/ask, redundant volume leaderboard totals, `TotalRows`, and feed metadata are omitted to reduce tokens.
+
 Date defaults: with tickers, 365-day lookback from today. Without tickers, today only. Explicit dates override defaults. `--days N` uses today or explicit `--end-date` as the range end and computes the start date; do not combine `--days` with `--start-date`. Presets and watchlists never supply dates.
 
 Filter precedence: preset baseline, then watchlist merge, then explicit CLI flags override both.
 
 Summary mode: `--summary` returns aggregate JSON instead of rows. Valid `--group-by`: `ticker`, `day`, `ticker,day`. Summary respects pagination, so use `--length -1` for all matching rows. `--fields` and non-JSON `--format` are invalid with `--summary`.
 
-Fields mode: `--fields FIELD1,FIELD2` limits JSON keys or CSV/TSV columns. Names are case-sensitive and validated before the API query.
+Fields mode: `--fields FIELD1,FIELD2` limits JSON keys or CSV/TSV columns using raw API field names. Use it to request fields omitted from default compact JSON, such as `TradeID`, `Bid`, `Ask`, `AverageDailyVolume`, or `TotalRows`. Names are case-sensitive and validated before the API query. CSV/TSV without `--fields` still use the full raw trade row columns.
 
 ```bash
 volumeleaders-agent trade list --tickers AAPL --dark-pools 1 --min-dollars 1000000
@@ -49,7 +51,7 @@ volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2026-04-21 --end-d
 volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2026-04-21 --end-date 2026-04-28 --fields Date,Ticker,Dollars --format csv
 ```
 
-Key row fields: `Date`, `FullDateTime`, `Ticker`, `Name`, `Sector`, `Industry`, `Price`, `Volume`, `Dollars`, `DollarsMultiplier`, `CumulativeDistribution`, `RelativeSize`, `PercentDailyVolume`, `TradeRank`, `TradeRankSnapshot`, `VCD`, `DarkPool`, `Sweep`, `LatePrint`, `SignaturePrint`, `PhantomPrint`, `OpeningTrade`, `ClosingTrade`, `RSIHour`, `RSIDay`, `TotalRows`.
+Default JSON row fields: `Date`, `FullDateTime`, `FullTimeString24`, `Ticker`, `Name`, `Sector`, `Industry`, `Price`, `Volume`, `Dollars`, `DollarsMultiplier`, `PercentDailyVolume`, `RelativeSize`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `DarkPool`, `Sweep`, `LatePrint`, `SignaturePrint`, `OpeningTrade`, `ClosingTrade`, `PhantomPrint`, `TradeConditions`, `FrequencyLast30TD`, `FrequencyLast90TD`, `FrequencyLast1CY`, `RSIHour`, `RSIDay`.
 
 ## trade sentiment
 


### PR DESCRIPTION
## Summary
- Return compact analysis-focused rows for default JSON `trade list` and `trade levels` requests.
- Keep raw API fields available through `--fields`, with CSV/TSV behavior unchanged.
- Address review feedback by pinning the full trade-list compact schema and preserving unbounded `--length -1` pagination semantics.
- Document the compact default row shapes in the VolumeLeaders agent trade skill.

## Verification
- LSP diagnostics on modified Go files
- `go test ./internal/commands -run 'TestTradeListDefaultJSONUsesCompactRows|TestTradeListDefaultJSONUsesParsedFormat|TestTradeListSummary|TestTradeListSummaryAllResultsContinuesPastFormerPaginationCap|TestTradeListSummaryRejectsNonJSONFormat'`
- `make test`
- `make lint`
- `make build`