### PR TITLE
fix: cap trade retrieval requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,5 +46,5 @@ make install    # Install to $GOPATH/bin
 - All commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Errors go to stderr via `slog`.
 - Dates use `YYYY-MM-DD` format on the CLI, converted internally as needed.
 - Boolean/toggle filters use integers: `-1` = all/unfiltered, `0` = exclude, `1` = include/only.
-- Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results.
+- Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results except for individual trade retrieval. `trade list`, including `--summary`, only allows `--length` values from 1 to 50 because the VolumeLeaders backend cannot safely retrieve more than 50 individual trades per request.
 - The binary name is `volumeleaders-agent`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,5 +46,5 @@ make install    # Install to $GOPATH/bin
 - All commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Errors go to stderr via `slog`.
 - Dates use `YYYY-MM-DD` format on the CLI, converted internally as needed.
 - Boolean/toggle filters use integers: `-1` = all/unfiltered, `0` = exclude, `1` = include/only.
-- Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results except for individual trade retrieval. `trade list`, including `--summary`, only allows `--length` values from 1 to 50 because the VolumeLeaders backend cannot safely retrieve more than 50 individual trades per request.
+- Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results except for capped trade retrieval endpoints. `trade list`, including `--summary`, only allows `--length` values from 1 to 50 because the VolumeLeaders backend cannot safely retrieve more than 50 individual trades per request. `trade levels` caps `--trade-level-count` at 50, and `trade level-touches` only allows `--length` values from 1 to 50.
 - The binary name is `volumeleaders-agent`.

--- a/internal/commands/daily.go
+++ b/internal/commands/daily.go
@@ -199,9 +199,10 @@ func fetchDailySentimentTrades(ctx context.Context, vlClient *client.Client, dat
 		offsetting:   1,
 		sector:       "X B",
 	}
-	return fetchAllTradeSentimentPages(ctx, vlClient, dataTableOptions{
+	return fetchTradeSentimentTrades(ctx, vlClient, dataTableOptions{
 		orderCol: 1,
 		orderDir: "desc",
+		length:   maxTradeRequestLength,
 		filters:  buildTradeFilters(opts),
 	})
 }

--- a/internal/commands/daily_test.go
+++ b/internal/commands/daily_test.go
@@ -3,8 +3,10 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -38,6 +40,11 @@ func TestDailySummaryAggregatesInstitutionalActivity(t *testing.T) {
 				{"Ticker":"SPY","Sector":"ETF","Price":500,"Dollars":110000000,"RelativeSize":5,"Volume":200,"Trades":1,"TradeLevelRank":2,"TradeLevelTouches":2}
 			]`))
 		case "/Trades/GetTrades":
+			body, _ := io.ReadAll(r.Body)
+			params, _ := url.ParseQuery(string(body))
+			if got := params.Get("length"); got != "50" {
+				t.Fatalf("daily sentiment trade length = %q, want 50", got)
+			}
 			fmt.Fprint(w, dataTablesJSON(`[
 				{"Date":"/Date(1777334400000)/","Ticker":"SH","Sector":"X Bear","Dollars":100000000},
 				{"Date":"/Date(1777334400000)/","Ticker":"TQQQ","Sector":"X Bull","Dollars":200000000}

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -7,9 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -357,25 +355,13 @@ func TestTradeListDefaultJSONUsesParsedFormat(t *testing.T) {
 	}
 }
 
-func TestTradeListDefaultJSONAllResultsUsesPagination(t *testing.T) {
-	totalRecords := paginationPageSize + 1
-	var requestCount atomic.Int32
-
+func TestTradeListDefaultJSONUsesMaxTradeRequestLength(t *testing.T) {
+	var gotLength string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
 		body, _ := io.ReadAll(r.Body)
 		params, _ := url.ParseQuery(string(body))
-
-		if params.Get("start") == "0" {
-			items := make([]string, paginationPageSize)
-			for i := range items {
-				items[i] = `{"Ticker":"SPY","TradeID":98765,"Dollars":1}`
-			}
-			fmt.Fprint(w, dataTablesJSONPage("["+strings.Join(items, ",")+"]", totalRecords))
-			return
-		}
-
-		fmt.Fprint(w, dataTablesJSONPage(`[{"Ticker":"QQQ","TradeID":98766,"Dollars":2}]`, totalRecords))
+		gotLength = params.Get("length")
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"SPY","TradeID":98765,"Dollars":1}]`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -386,7 +372,6 @@ func TestTradeListDefaultJSONAllResultsUsesPagination(t *testing.T) {
 			"app", "list",
 			"--start-date", "2025-04-21",
 			"--end-date", "2025-04-21",
-			"--length", "-1",
 		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -396,17 +381,52 @@ func TestTradeListDefaultJSONAllResultsUsesPagination(t *testing.T) {
 	if err := json.Unmarshal([]byte(output), &got); err != nil {
 		t.Fatalf("unmarshal compact output: %v", err)
 	}
-	if gotRequests := requestCount.Load(); gotRequests != 2 {
-		t.Fatalf("request count = %d, want 2", gotRequests)
+	if gotLength != "50" {
+		t.Fatalf("length = %q, want 50", gotLength)
 	}
-	if len(got) != totalRecords {
-		t.Fatalf("row count = %d, want %d", len(got), totalRecords)
+	if len(got) != 1 {
+		t.Fatalf("row count = %d, want 1", len(got))
 	}
-	if _, ok := got[len(got)-1]["Ticker"]; !ok {
+	if _, ok := got[0]["Ticker"]; !ok {
 		t.Fatal("expected compact Ticker field on final page")
 	}
-	if _, ok := got[len(got)-1]["TradeID"]; ok {
+	if _, ok := got[0]["TradeID"]; ok {
 		t.Fatal("did not expect raw TradeID field on final page")
+	}
+}
+
+func TestTradeListRejectsUnsafeTradeRequestLength(t *testing.T) {
+	tests := []struct {
+		name   string
+		length string
+	}{
+		{name: "all results sentinel", length: "-1"},
+		{name: "zero", length: "0"},
+		{name: "over max", length: "51"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
+				fmt.Fprint(w, dataTablesJSON(`[]`))
+			}))
+			t.Cleanup(server.Close)
+
+			ctx := contextWithTestClient(t, server.URL)
+			root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+			err := root.Run(ctx, []string{
+				"app", "list",
+				"--start-date", "2025-04-21",
+				"--end-date", "2025-04-21",
+				"--length", tt.length,
+			})
+			assertErrContains(t, err, "--length must be between 1 and 50 for trade retrieval")
+			if requestCount != 0 {
+				t.Fatalf("expected invalid length to fail before API query, got %d requests", requestCount)
+			}
+		})
 	}
 }
 
@@ -721,7 +741,7 @@ func TestTradeSentimentUsesCombinedLeverageFilter(t *testing.T) {
 		}
 	})
 
-	for _, want := range []string{"SectorIndustry=X+B", "VCD=97", "MinDollars=7000000", "length=1000"} {
+	for _, want := range []string{"SectorIndustry=X+B", "VCD=97", "MinDollars=7000000", "length=50"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected request body to contain %q, got %s", want, body)
 		}
@@ -761,7 +781,7 @@ func TestTradeSentimentSupportsDelimitedFormat(t *testing.T) {
 	}
 }
 
-func TestTradeSentimentRejectsMalformedPage(t *testing.T) {
+func TestTradeSentimentRejectsMalformedResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, dataTablesJSON(`{"not":"a trade array"}`))
 	}))
@@ -774,7 +794,7 @@ func TestTradeSentimentRejectsMalformedPage(t *testing.T) {
 		"--start-date", "2025-04-21",
 		"--end-date", "2025-04-25",
 	})
-	assertErrContains(t, err, "query trade sentiment: decode response")
+	assertErrContains(t, err, "query trade sentiment: decode DataTables data")
 }
 
 func TestTradeSentimentTickerFallbackClassifiesCWEBAsBull(t *testing.T) {
@@ -1038,74 +1058,31 @@ func TestTradeListSummaryGroupsByDay(t *testing.T) {
 	}
 }
 
-func TestTradeListSummaryAllResultsUsesPagination(t *testing.T) {
-	totalRecords := paginationPageSize + 1
-	var requestCount int
+func TestTradeListSummaryRejectsUnsafeTradeRequestLength(t *testing.T) {
+	for _, length := range []string{"-1", "0", "51"} {
+		t.Run(length, func(t *testing.T) {
+			var requestCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
+				fmt.Fprint(w, dataTablesJSON(`[]`))
+			}))
+			t.Cleanup(server.Close)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		body, _ := io.ReadAll(r.Body)
-		params, _ := url.ParseQuery(string(body))
-
-		if params.Get("start") == "0" {
-			items := make([]string, paginationPageSize)
-			for i := range items {
-				items[i] = `{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":1}`
+			ctx := contextWithTestClient(t, server.URL)
+			root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
+			err := root.Run(ctx, []string{
+				"app", "list",
+				"--start-date", "2025-04-21",
+				"--end-date", "2025-04-21",
+				"--summary",
+				"--length", length,
+			})
+			assertErrContains(t, err, "--length must be between 1 and 50 for trade retrieval")
+			if requestCount != 0 {
+				t.Fatalf("expected invalid summary length to fail before API query, got %d requests", requestCount)
 			}
-			fmt.Fprint(w, dataTablesJSONPage("["+strings.Join(items, ",")+"]", totalRecords))
-			return
-		}
-
-		fmt.Fprint(w, dataTablesJSONPage(`[{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":2}]`, totalRecords))
-	}))
-	t.Cleanup(server.Close)
-
-	ctx := contextWithTestClient(t, server.URL)
-	output := captureStdout(t, func() {
-		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
-		if err := root.Run(ctx, []string{
-			"app", "list",
-			"--start-date", "2025-04-21",
-			"--end-date", "2025-04-21",
-			"--summary",
-			"--length", "-1",
-		}); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	var got models.TradeSummary
-	if err := json.Unmarshal([]byte(output), &got); err != nil {
-		t.Fatalf("unmarshal summary output: %v", err)
+		})
 	}
-	if requestCount != 2 {
-		t.Fatalf("request count = %d, want 2", requestCount)
-	}
-	if got.TotalTrades != totalRecords {
-		t.Fatalf("total trades = %d, want %d", got.TotalTrades, totalRecords)
-	}
-	wantDollars := float64(paginationPageSize + 2)
-	if got.TotalDollars != wantDollars {
-		t.Fatalf("total dollars = %v, want %v", got.TotalDollars, wantDollars)
-	}
-}
-
-func TestTradeListSummaryAllResultsRejectsMalformedPage(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, dataTablesJSONPage(`{}`, 1))
-	}))
-	t.Cleanup(server.Close)
-
-	ctx := contextWithTestClient(t, server.URL)
-	root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
-	err := root.Run(ctx, []string{
-		"app", "list",
-		"--start-date", "2025-04-21",
-		"--end-date", "2025-04-21",
-		"--summary",
-		"--length", "-1",
-	})
-	assertErrContains(t, err, "query trades: decode response")
 }
 
 func TestTradeListSummaryRejectsInvalidGroupBy(t *testing.T) {
@@ -1186,63 +1163,6 @@ func TestTradeListRejectsGroupByWithoutSummary(t *testing.T) {
 		"--group-by", "day",
 	})
 	assertErrContains(t, err, "--group-by only works with --summary")
-}
-
-func TestTradeListSummaryAllResultsContinuesPastFormerPaginationCap(t *testing.T) {
-	const formerPaginationCap = 100
-
-	totalRecords := paginationPageSize*formerPaginationCap + 1
-	items := make([]string, paginationPageSize)
-	for i := range items {
-		items[i] = `{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":1}`
-	}
-	fullPage := "[" + strings.Join(items, ",") + "]"
-	finalPage := `[{"Date":"/Date(1745193600000)/","Ticker":"SPY","Dollars":2}]`
-	var requestCount int
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		body, _ := io.ReadAll(r.Body)
-		params, _ := url.ParseQuery(string(body))
-		start, _ := strconv.Atoi(params.Get("start"))
-
-		if start < paginationPageSize*formerPaginationCap {
-			fmt.Fprint(w, dataTablesJSONPage(fullPage, totalRecords))
-			return
-		}
-
-		fmt.Fprint(w, dataTablesJSONPage(finalPage, totalRecords))
-	}))
-	t.Cleanup(server.Close)
-
-	ctx := contextWithTestClient(t, server.URL)
-	output := captureStdout(t, func() {
-		root := &cli.Command{Commands: []*cli.Command{newTradeListCommand()}}
-		if err := root.Run(ctx, []string{
-			"app", "list",
-			"--start-date", "2025-04-21",
-			"--end-date", "2025-04-21",
-			"--summary",
-			"--length", "-1",
-		}); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	var got models.TradeSummary
-	if err := json.Unmarshal([]byte(output), &got); err != nil {
-		t.Fatalf("unmarshal summary output: %v", err)
-	}
-	if requestCount != formerPaginationCap+1 {
-		t.Fatalf("request count = %d, want %d", requestCount, formerPaginationCap+1)
-	}
-	if got.TotalTrades != totalRecords {
-		t.Fatalf("total trades = %d, want %d", got.TotalTrades, totalRecords)
-	}
-	wantDollars := float64(paginationPageSize*formerPaginationCap + 2)
-	if got.TotalDollars != wantDollars {
-		t.Fatalf("total dollars = %v, want %v", got.TotalDollars, wantDollars)
-	}
 }
 
 func TestTradeListInvalidFormatWithWatchlistDoesNotQueryAPI(t *testing.T) {

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -515,7 +515,7 @@ func TestTradeLevelsDefaultPayload(t *testing.T) {
 
 	want := map[string]string{
 		"start":     "0",
-		"length":    "-1",
+		"length":    "10",
 		"StartDate": "2025-04-29",
 		"EndDate":   "2026-04-29",
 		"Ticker":    "AMD",
@@ -525,6 +525,56 @@ func TestTradeLevelsDefaultPayload(t *testing.T) {
 		if got := form.Get(key); got != value {
 			t.Errorf("%s = %q, want %q", key, got, value)
 		}
+	}
+}
+
+func TestTradeLevelsRejectsUnsafeLevelCount(t *testing.T) {
+	for _, count := range []string{"-1", "0", "51"} {
+		t.Run(count, func(t *testing.T) {
+			var requestCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
+				fmt.Fprint(w, dataTablesJSON(`[]`))
+			}))
+			t.Cleanup(server.Close)
+
+			ctx := contextWithTestClient(t, server.URL)
+			root := &cli.Command{Commands: []*cli.Command{newTradeLevelsCommand()}}
+			err := root.Run(ctx, []string{
+				"app", "levels", "AMD",
+				"--trade-level-count", count,
+			})
+			assertErrContains(t, err, "--trade-level-count must be between 1 and 50 for trade level retrieval")
+			if requestCount != 0 {
+				t.Fatalf("expected invalid trade level count to fail before API query, got %d requests", requestCount)
+			}
+		})
+	}
+}
+
+func TestTradeLevelTouchesRejectsUnsafeLength(t *testing.T) {
+	for _, length := range []string{"-1", "0", "51"} {
+		t.Run(length, func(t *testing.T) {
+			var requestCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
+				fmt.Fprint(w, dataTablesJSON(`[]`))
+			}))
+			t.Cleanup(server.Close)
+
+			ctx := contextWithTestClient(t, server.URL)
+			root := &cli.Command{Commands: []*cli.Command{newTradeLevelTouchesCommand()}}
+			err := root.Run(ctx, []string{
+				"app", "level-touches",
+				"--start-date", "2025-04-21",
+				"--end-date", "2025-04-21",
+				"--length", length,
+			})
+			assertErrContains(t, err, "--length must be between 1 and 50 for trade level touch retrieval")
+			if requestCount != 0 {
+				t.Fatalf("expected invalid trade level touch length to fail before API query, got %d requests", requestCount)
+			}
+		})
 	}
 }
 

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	maxTradeRequestLength       = 50
+	maxTradeLevelRequestLength  = 50
 	tradeListTickerLookbackDays = 365
 )
 
@@ -260,7 +261,7 @@ Dates are optional. Defaults to 1-year lookback ending today. Use --days for sho
 				&cli.IntFlag{Name: "vcd", Value: 0, Usage: "VCD filter"},
 				&cli.IntFlag{Name: "relative-size", Value: 0, Usage: "Relative size threshold"},
 				&cli.IntFlag{Name: "trade-level-rank", Value: -1, Usage: "Trade level rank filter"},
-				&cli.IntFlag{Name: "trade-level-count", Value: 10, Usage: "Number of price levels to return"},
+				&cli.IntFlag{Name: "trade-level-count", Value: 10, Usage: "Number of price levels to return (1-50)"},
 				&cli.StringFlag{Name: "fields", Usage: "Comma-separated trade level fields to include in output"},
 			},
 			outputFormatFlags(),
@@ -288,7 +289,7 @@ volumeleaders-agent trade level-touches --tickers NVDA,AMD --trade-level-rank 5`
 				&cli.IntFlag{Name: "trade-level-rank", Value: 10, Usage: "Trade level rank filter"},
 			},
 			outputFormatFlags(),
-			paginationFlags(100, 0, "desc"),
+			paginationFlags(maxTradeLevelRequestLength, 0, "desc"),
 		),
 		Action: runTradeLevelTouches,
 	}
@@ -428,6 +429,20 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 func validateTradeRequestLength(length int) error {
 	if length < 1 || length > maxTradeRequestLength {
 		return fmt.Errorf("--length must be between 1 and %d for trade retrieval", maxTradeRequestLength)
+	}
+	return nil
+}
+
+func validateTradeLevelCount(count int) error {
+	if count < 1 || count > maxTradeLevelRequestLength {
+		return fmt.Errorf("--trade-level-count must be between 1 and %d for trade level retrieval", maxTradeLevelRequestLength)
+	}
+	return nil
+}
+
+func validateTradeLevelTouchesLength(length int) error {
+	if length < 1 || length > maxTradeLevelRequestLength {
+		return fmt.Errorf("--length must be between 1 and %d for trade level touch retrieval", maxTradeLevelRequestLength)
 	}
 	return nil
 }
@@ -807,9 +822,12 @@ func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
 		tradeLevelRank:  cmd.Int("trade-level-rank"),
 		tradeLevelCount: cmd.Int("trade-level-count"),
 	}
+	if err := validateTradeLevelCount(opts.tradeLevelCount); err != nil {
+		return err
+	}
 	dataOpts := dataTableOptions{
 		start:    0,
-		length:   -1,
+		length:   opts.tradeLevelCount,
 		orderCol: 1,
 		orderDir: "desc",
 		filters:  buildTradeLevelFilters(opts),
@@ -849,6 +867,9 @@ func fetchTradeLevels(ctx context.Context, opts dataTableOptions) ([]models.Trad
 func runTradeLevelTouches(ctx context.Context, cmd *cli.Command) error {
 	startDate, endDate, err := requiredDateRange(cmd)
 	if err != nil {
+		return err
+	}
+	if err := validateTradeLevelTouchesLength(cmd.Int("length")); err != nil {
 		return err
 	}
 	tickers := multiTickerValue(cmd)

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -16,7 +15,10 @@ import (
 	cli "github.com/urfave/cli/v3"
 )
 
-const tradeListTickerLookbackDays = 365
+const (
+	maxTradeRequestLength       = 50
+	tradeListTickerLookbackDays = 365
+)
 
 // --- Option structs ---
 
@@ -148,7 +150,7 @@ Dates are optional. With tickers: defaults to 365-day lookback. Without: default
 				&cli.StringFlag{Name: "group-by", Value: "ticker", Usage: "Summary grouping (requires --summary): ticker, day, or ticker,day"},
 			},
 			outputFormatFlags(),
-			paginationFlags(100, 1, "desc"),
+			paginationFlags(maxTradeRequestLength, 1, "desc"),
 		),
 		Action: runTradeList,
 	}
@@ -306,6 +308,9 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	if err := validateTradeRequestLength(cmd.Int("length")); err != nil {
+		return err
+	}
 
 	// Apply a ticker-scoped default that lets the server sort the wider history
 	// and return only the highest-value rows within the requested page size.
@@ -420,14 +425,17 @@ func runTradeList(ctx context.Context, cmd *cli.Command) error {
 	)
 }
 
+func validateTradeRequestLength(length int) error {
+	if length < 1 || length > maxTradeRequestLength {
+		return fmt.Errorf("--length must be between 1 and %d for trade retrieval", maxTradeRequestLength)
+	}
+	return nil
+}
+
 func runTradeListRows(ctx context.Context, opts dataTableOptions) error {
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
-	}
-
-	if opts.length < 0 {
-		return runPaginatedTradeListRows(ctx, vlClient, opts)
 	}
 
 	request := newDataTablesRequest(datatables.TradeColumns, opts)
@@ -437,39 +445,6 @@ func runTradeListRows(ctx context.Context, opts dataTableOptions) error {
 		return fmt.Errorf("query trades: %w", err)
 	}
 	return printJSON(ctx, models.NewTradeListRows(result))
-}
-
-func runPaginatedTradeListRows(ctx context.Context, vlClient *client.Client, opts dataTableOptions) error {
-	opts.length = paginationPageSize
-	all := make([]models.TradeListRow, 0)
-
-	for {
-		request := newDataTablesRequest(datatables.TradeColumns, opts)
-		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
-		if err != nil {
-			slog.Error("failed to query trades", "error", err)
-			return fmt.Errorf("query trades: %w", err)
-		}
-
-		var page []models.Trade
-		if err := json.Unmarshal(resp.Data, &page); err != nil {
-			slog.Error("failed to decode trades", "error", err)
-			return fmt.Errorf("query trades: decode response: %w", err)
-		}
-		if len(page) == 0 {
-			return printJSON(ctx, all)
-		}
-
-		all = append(all, models.NewTradeListRows(page)...)
-		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
-			return printJSON(ctx, all)
-		}
-		if len(page) < paginationPageSize {
-			return printJSON(ctx, all)
-		}
-
-		opts.start += len(page)
-	}
 }
 
 func runTradeSummary(ctx context.Context, opts dataTableOptions, groupBy, startDate, endDate string) error {
@@ -493,10 +468,6 @@ func fetchTradeList(ctx context.Context, opts dataTableOptions) ([]models.Trade,
 		return nil, err
 	}
 
-	if opts.length < 0 {
-		return fetchAllTradePages(ctx, vlClient, opts)
-	}
-
 	request := newDataTablesRequest(datatables.TradeColumns, opts)
 	var result []models.Trade
 	if err := vlClient.PostDataTables(ctx, "/Trades/GetTrades", request.Encode(), &result); err != nil {
@@ -504,38 +475,6 @@ func fetchTradeList(ctx context.Context, opts dataTableOptions) ([]models.Trade,
 		return nil, fmt.Errorf("query trades: %w", err)
 	}
 	return result, nil
-}
-
-func fetchAllTradePages(ctx context.Context, vlClient *client.Client, opts dataTableOptions) ([]models.Trade, error) {
-	opts.length = paginationPageSize
-	all := make([]models.Trade, 0)
-	for {
-		request := newDataTablesRequest(datatables.TradeColumns, opts)
-		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
-		if err != nil {
-			slog.Error("failed to query trades", "error", err)
-			return nil, fmt.Errorf("query trades: %w", err)
-		}
-
-		var page []models.Trade
-		if err := json.Unmarshal(resp.Data, &page); err != nil {
-			slog.Error("failed to decode trades", "error", err)
-			return nil, fmt.Errorf("query trades: decode response: %w", err)
-		}
-		if len(page) == 0 {
-			return all, nil
-		}
-
-		all = append(all, page...)
-		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
-			return all, nil
-		}
-		if len(page) < paginationPageSize {
-			return all, nil
-		}
-
-		opts.start += len(page)
-	}
 }
 
 type tradeSummaryGroup string
@@ -699,9 +638,13 @@ func runTradeSentiment(ctx context.Context, cmd *cli.Command) error {
 		sector:       "X B",
 	}
 	filters := buildTradeFilters(opts)
-	trades, err := fetchAllTradeSentimentTrades(ctx, dataTableOptions{
+	vlClient, err := newCommandClient(ctx)
+	if err != nil {
+		return err
+	}
+	trades, err := fetchTradeSentimentTrades(ctx, vlClient, dataTableOptions{
 		start:    0,
-		length:   -1,
+		length:   maxTradeRequestLength,
 		orderCol: 1,
 		orderDir: "desc",
 		filters:  filters,
@@ -930,47 +873,14 @@ func runTradeLevelTouches(ctx context.Context, cmd *cli.Command) error {
 		}, cmd.String("format"), "query trade level touches")
 }
 
-func fetchAllTradeSentimentTrades(ctx context.Context, opts dataTableOptions) ([]models.Trade, error) {
-	vlClient, err := newCommandClient(ctx)
-	if err != nil {
-		return nil, err
+func fetchTradeSentimentTrades(ctx context.Context, vlClient *client.Client, opts dataTableOptions) ([]models.Trade, error) {
+	request := newDataTablesRequest(datatables.TradeColumns, opts)
+	var result []models.Trade
+	if err := vlClient.PostDataTables(ctx, "/Trades/GetTrades", request.Encode(), &result); err != nil {
+		slog.Error("failed to query trade sentiment", "error", err)
+		return nil, fmt.Errorf("query trade sentiment: %w", err)
 	}
-	return fetchAllTradeSentimentPages(ctx, vlClient, opts)
-}
-
-func fetchAllTradeSentimentPages(ctx context.Context, vlClient *client.Client, opts dataTableOptions) ([]models.Trade, error) {
-	opts.length = paginationPageSize
-	all := make([]models.Trade, 0)
-
-	for {
-		request := newDataTablesRequest(datatables.TradeColumns, opts)
-		resp, err := vlClient.PostDataTablesPage(ctx, "/Trades/GetTrades", request.Encode())
-		if err != nil {
-			slog.Error("failed to query trade sentiment", "error", err)
-			return nil, fmt.Errorf("query trade sentiment: %w", err)
-		}
-
-		var page []models.Trade
-		if err := json.Unmarshal(resp.Data, &page); err != nil {
-			slog.Error("failed to decode trade sentiment response", "error", err)
-			return nil, fmt.Errorf("query trade sentiment: decode response: %w", err)
-		}
-		if len(page) == 0 {
-			break
-		}
-
-		all = append(all, page...)
-		if resp.RecordsFiltered > 0 && len(all) >= resp.RecordsFiltered {
-			break
-		}
-		if len(page) < paginationPageSize {
-			break
-		}
-
-		opts.start += len(page)
-	}
-
-	return all, nil
+	return result, nil
 }
 
 type tradeSentimentAccumulator struct {

--- a/skills/volumeleaders-agent/SKILL.md
+++ b/skills/volumeleaders-agent/SKILL.md
@@ -72,11 +72,11 @@ This is the entry point. Command details are split by command group:
 ## Global Conventions
 
 - Dates: `YYYY-MM-DD`. Commands with date ranges accept either `--start-date D --end-date D` or `--days N`; `--days` counts backward from today unless `--end-date` is also set, and cannot be combined with `--start-date`.
-- Pagination: `--start` offset, `--length` count, `--length -1` means all rows, `--order-col` sort column index, `--order-dir asc|desc`.
+- Pagination: `--start` offset, `--length` count, `--length -1` means all rows unless the command file documents a stricter endpoint limit, `--order-col` sort column index, `--order-dir asc|desc`.
 - Toggle filters: `-1` all/unfiltered, `0` exclude, `1` include/only.
 - Tickers: `--tickers` is comma-separated, `--ticker` is single-symbol. Commands that take tickers generally accept positional tickers too, for example `trade list XLE XLK` or `chart company AAPL`. Trade and volume ticker filters also accept `--symbol` and `--symbols` aliases.
 - Output formats: list-style commands may support `--format json|csv|tsv`. CSV/TSV include headers, booleans render as `true`/`false`, null/missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless their command file says otherwise.
-- Performance: use explicit dates and tickers when possible. `--length -1` can return large datasets and slow summary aggregation.
+- Performance: use explicit dates and tickers when possible. Individual trade retrieval is capped at 50 trades per request to protect the VolumeLeaders backend.
 
 ## Trade Shared Flags
 

--- a/skills/volumeleaders-agent/SKILL.md
+++ b/skills/volumeleaders-agent/SKILL.md
@@ -76,7 +76,7 @@ This is the entry point. Command details are split by command group:
 - Toggle filters: `-1` all/unfiltered, `0` exclude, `1` include/only.
 - Tickers: `--tickers` is comma-separated, `--ticker` is single-symbol. Commands that take tickers generally accept positional tickers too, for example `trade list XLE XLK` or `chart company AAPL`. Trade and volume ticker filters also accept `--symbol` and `--symbols` aliases.
 - Output formats: list-style commands may support `--format json|csv|tsv`. CSV/TSV include headers, booleans render as `true`/`false`, null/missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless their command file says otherwise.
-- Performance: use explicit dates and tickers when possible. Individual trade retrieval is capped at 50 trades per request to protect the VolumeLeaders backend.
+- Performance: use explicit dates and tickers when possible. Individual trade and trade-level retrieval commands are capped at 50 rows per request to protect the VolumeLeaders backend.
 
 ## Trade Shared Flags
 

--- a/skills/volumeleaders-agent/daily.md
+++ b/skills/volumeleaders-agent/daily.md
@@ -15,7 +15,7 @@ volumeleaders-agent --pretty daily summary --date 2026-04-28 --limit 5
 
 Output sections: `date`, `top_institutional_volume_tickers`, `top_clusters_by_dollars`, `top_clusters_by_multiplier`, `repeated_cluster_tickers`, `sector_totals`, `cluster_bombs`, `level_touches` split by relative size and dollars, `leveraged_etf_sentiment`, `market_exhaustion`.
 
-Data sources: institutional volume, trade clusters, cluster bombs, level touches, leveraged ETF sentiment via `Trades/GetTrades`, and exhaustion scores.
+Data sources: institutional volume, trade clusters, cluster bombs, level touches, leveraged ETF sentiment via one capped 50-row `Trades/GetTrades` request, and exhaustion scores.
 
 Follow up with:
 

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -96,11 +96,11 @@ Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, 
 
 ## Levels and level touches
 
-`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--fields`, `--format`. Defaults to a 1-year lookback when dates are omitted, `--trade-level-count 10`, and non-standard `--relative-size 0`. It does not expose pagination flags, but sends one request with `start=0` and `length=-1` to match the observed VolumeLeaders levels request and return all matching levels.
+`trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--fields`, `--format`. Defaults to a 1-year lookback when dates are omitted, `--trade-level-count 10`, and non-standard `--relative-size 0`. It does not expose pagination flags. Trade level retrieval is capped at 50 rows per request, so `--trade-level-count` must be between 1 and 50.
 
 Default `trade levels` JSON returns compact analysis rows. It keeps level price, dollars, volume, trade count, relative size, cumulative distribution, rank, and min/max dates. Repetitive single-ticker metadata (`Ticker`, `Name`) and the verbose `Dates` list are omitted to reduce tokens. Use `--fields Ticker,Name,Dates` or another explicit field list when those raw API fields are needed. CSV/TSV without `--fields` still use the full raw trade level row columns.
 
-`trade level-touches` finds events where price revisits institutional levels. Required: complete `--start-date`/`--end-date` range or `--days`. Optional: ticker aliases, positional tickers, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--order-col 0`, `--order-dir desc`.
+`trade level-touches` finds events where price revisits institutional levels. Required: complete `--start-date`/`--end-date` range or `--days`. Optional: ticker aliases, positional tickers, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--length 50`, `--order-col 0`, `--order-dir desc`. Level-touch retrieval rejects `--length -1`, `--length 0`, and values above 50.
 
 ```bash
 volumeleaders-agent trade levels AAPL --days 30

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -32,13 +32,15 @@ volumeleaders-agent trade preset-tickers --preset "Megacaps"
 
 Primary individual-print query. Optional flags: `--start-date`, `--end-date`, `--days`, ticker aliases, positional tickers, `--sector`, `--preset`, `--watchlist`, `--fields`, `--format`, `--summary`, `--group-by`, trade shared flags, pagination.
 
+Trade retrieval is capped at 50 rows per request. `trade list` defaults to `--length 50` and rejects `--length -1`, `--length 0`, and values above 50. Use narrower dates, ticker filters, presets, or watchlists instead of asking for more than 50 individual trades.
+
 Default JSON returns compact analysis rows, not the full raw API row. It keeps trade timing, ticker/company context, price/volume/dollar size, rank, relative-size metrics, key boolean traits, frequency windows, trade conditions, and RSI. Repetitive query dates, internal numeric keys, raw bid/ask, redundant volume leaderboard totals, `TotalRows`, and feed metadata are omitted to reduce tokens.
 
 Date defaults: with tickers, 365-day lookback from today. Without tickers, today only. Explicit dates override defaults. `--days N` uses today or explicit `--end-date` as the range end and computes the start date; do not combine `--days` with `--start-date`. Presets and watchlists never supply dates.
 
 Filter precedence: preset baseline, then watchlist merge, then explicit CLI flags override both.
 
-Summary mode: `--summary` returns aggregate JSON instead of rows. Valid `--group-by`: `ticker`, `day`, `ticker,day`. Summary respects pagination, so use `--length -1` for all matching rows. `--fields` and non-JSON `--format` are invalid with `--summary`.
+Summary mode: `--summary` returns aggregate JSON instead of rows. Valid `--group-by`: `ticker`, `day`, `ticker,day`. Summary respects the same 1-50 trade retrieval cap as row output. `--fields` and non-JSON `--format` are invalid with `--summary`.
 
 Fields mode: `--fields FIELD1,FIELD2` limits JSON keys or CSV/TSV columns using raw API field names. Use it to request fields omitted from default compact JSON, such as `TradeID`, `Bid`, `Ask`, `AverageDailyVolume`, or `TotalRows`. Names are case-sensitive and validated before the API query. CSV/TSV without `--fields` still use the full raw trade row columns.
 
@@ -47,7 +49,7 @@ volumeleaders-agent trade list --tickers AAPL --dark-pools 1 --min-dollars 10000
 volumeleaders-agent trade list XLE --days 5
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2026-04-28 --end-date 2026-04-28
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2026-04-01 --end-date 2026-04-28
-volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2026-04-21 --end-date 2026-04-28 --summary --group-by ticker,day --length -1
+volumeleaders-agent trade list --tickers SPY,QQQ --start-date 2026-04-21 --end-date 2026-04-28 --summary --group-by ticker,day --length 50
 volumeleaders-agent trade list --tickers AAPL,MSFT --start-date 2026-04-21 --end-date 2026-04-28 --fields Date,Ticker,Dollars --format csv
 ```
 
@@ -55,7 +57,7 @@ Default JSON row fields: `Date`, `FullDateTime`, `FullTimeString24`, `Ticker`, `
 
 ## trade sentiment
 
-Daily bull/bear leveraged ETF flow. The command always queries the combined leveraged ETF sector filter `SectorIndustry=X B`, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags.
+Daily bull/bear leveraged ETF flow. The command always queries the combined leveraged ETF sector filter `SectorIndustry=X B`, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags. It fetches at most 50 trades from `Trades/GetTrades`.
 
 Required: complete `--start-date`/`--end-date` range or `--days`. Optional: `--format json|csv|tsv`, trade shared flags except ticker/sector filters. Non-standard defaults: `--min-dollars 5000000`, `--vcd 97`; shared `--relative-size 5` still applies.
 


### PR DESCRIPTION
## Summary
- Cap `trade list`, `trade sentiment`, and daily sentiment trade fetches at 50 rows before querying VolumeLeaders.
- Cap `trade levels` and `trade level-touches` retrieval at 50 rows and reject unsafe values.
- Update tests and agent docs so capped endpoints no longer advertise `--length -1` behavior.

## Verification
- `go test ./internal/commands`
- `make test`
- `make lint`
- `make build`