### PR TITLE
feat: compact alert and chart outputs

### DIFF
--- a/internal/commands/alert.go
+++ b/internal/commands/alert.go
@@ -6,11 +6,24 @@ import (
 	"log/slog"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/major/volumeleaders-agent/internal/datatables"
 	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
+
+var alertConfigDefaultFields = []string{
+	"AlertConfigKey",
+	"Name",
+	"Tickers",
+	"TradeConditions",
+	"ClosingTradeConditions",
+	"DarkPool",
+	"Sweep",
+	"OffsettingPrint",
+	"PhantomPrint",
+}
 
 // NewAlertCommand returns the "alert" command group with all subcommands.
 func NewAlertCommand() *cli.Command {
@@ -22,9 +35,14 @@ func NewAlertCommand() *cli.Command {
 				Name:      "configs",
 				Usage:     "List saved alert configurations",
 				UsageText: "volumeleaders-agent alert configs",
-				Flags:     outputFormatFlags(),
+				Flags: slices.Concat(
+					[]cli.Flag{
+						&cli.StringFlag{Name: "fields", Usage: "Comma-separated fields to include (use 'all' for every field)"},
+					},
+					outputFormatFlags(),
+				),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return runAlertConfigs(ctx, cmd.String("format"))
+					return runAlertConfigs(ctx, cmd.String("fields"), cmd.String("format"))
 				},
 			},
 			{
@@ -165,8 +183,13 @@ func buildAlertConfigFields(cmd *cli.Command, key int) map[string]string {
 
 // --- Action handlers ---
 
-func runAlertConfigs(ctx context.Context, formatValue string) error {
+func runAlertConfigs(ctx context.Context, fieldsValue, formatValue string) error {
 	format, err := parseOutputFormat(formatValue)
+	if err != nil {
+		return err
+	}
+
+	fields, err := alertConfigFields(fieldsValue)
 	if err != nil {
 		return err
 	}
@@ -183,7 +206,23 @@ func runAlertConfigs(ctx context.Context, formatValue string) error {
 		return fmt.Errorf("query alert configs: %w", err)
 	}
 
-	return printDataTablesResult(ctx, configs, nil, format)
+	return printDataTablesResult(ctx, configs, fields, format)
+}
+
+func alertConfigFields(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return alertConfigDefaultFields, nil
+	}
+	if strings.EqualFold(value, "all") {
+		return nil, nil
+	}
+
+	fields, err := parseJSONFieldList[models.AlertConfig](value)
+	if err != nil {
+		return nil, fmt.Errorf("parse alert config fields: %w", err)
+	}
+	return fields, nil
 }
 
 func runAlertDelete(ctx context.Context, key int) error {

--- a/internal/commands/alert_test.go
+++ b/internal/commands/alert_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,8 +9,43 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
+
+const alertConfigFixture = `[{
+	"AlertConfigKey": 1,
+	"UserKey": 99,
+	"Name": "Big sweeps",
+	"Tickers": "AAPL,MSFT",
+	"TradeRankLTE": 5,
+	"TradeVCDGTE": null,
+	"TradeMultGTE": null,
+	"TradeVolumeGTE": 1000000,
+	"TradeDollarsGTE": null,
+	"TradeConditions": "OBH",
+	"TradeClusterRankLTE": null,
+	"TradeClusterVCDGTE": null,
+	"TradeClusterMultGTE": null,
+	"TradeClusterVolumeGTE": null,
+	"TradeClusterDollarsGTE": null,
+	"TotalRankLTE": null,
+	"TotalVolumeGTE": null,
+	"TotalDollarsGTE": null,
+	"AHRankLTE": null,
+	"AHVolumeGTE": null,
+	"AHDollarsGTE": null,
+	"ClosingTradeRankLTE": null,
+	"ClosingTradeVCDGTE": null,
+	"ClosingTradeMultGTE": null,
+	"ClosingTradeVolumeGTE": null,
+	"ClosingTradeDollarsGTE": null,
+	"ClosingTradeConditions": "OSH",
+	"OffsettingPrint": false,
+	"PhantomPrint": false,
+	"Sweep": true,
+	"DarkPool": true
+}]`
 
 func TestRunAlertConfigs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -22,10 +58,93 @@ func TestRunAlertConfigs(t *testing.T) {
 
 	ctx := contextWithTestClient(t, server.URL)
 	captureStdout(t, func() {
-		if err := runAlertConfigs(ctx, "json"); err != nil {
+		if err := runAlertConfigs(ctx, "", "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestRunAlertConfigsDefaultFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(alertConfigFixture))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		if err := runAlertConfigs(ctx, "", "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	rows := decodeAlertConfigRows(t, output)
+	assertAlertConfigFields(t, rows[0], alertConfigDefaultFields)
+	if rows[0]["AlertConfigKey"] != float64(1) {
+		t.Fatalf("expected AlertConfigKey 1, got %#v", rows[0]["AlertConfigKey"])
+	}
+}
+
+func TestRunAlertConfigsAllFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(alertConfigFixture))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		if err := runAlertConfigs(ctx, "all", "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	rows := decodeAlertConfigRows(t, output)
+	allFields := jsonFieldNamesInOrder[models.AlertConfig]()
+	assertAlertConfigFields(t, rows[0], allFields)
+	if rows[0]["UserKey"] != float64(99) {
+		t.Fatalf("expected UserKey 99 in full output, got %#v", rows[0]["UserKey"])
+	}
+}
+
+func TestRunAlertConfigsExplicitFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(alertConfigFixture))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		if err := runAlertConfigs(ctx, "AlertConfigKey,Name", "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	rows := decodeAlertConfigRows(t, output)
+	assertAlertConfigFields(t, rows[0], []string{"AlertConfigKey", "Name"})
+}
+
+func TestRunAlertConfigsInvalidFields(t *testing.T) {
+	ctx := contextWithTestClient(t, "http://example.invalid")
+	err := runAlertConfigs(ctx, "BadField", "json")
+	assertErrContains(t, err, "invalid field")
+}
+
+func TestRunAlertConfigsCSVDefaultFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(alertConfigFixture))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		if err := runAlertConfigs(ctx, "", "csv"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	wantHeader := strings.Join(alertConfigDefaultFields, ",") + "\n"
+	if !strings.HasPrefix(output, wantHeader) {
+		t.Fatalf("expected CSV header %q, got %q", wantHeader, output)
+	}
 }
 
 func TestRunAlertConfigsServerError(t *testing.T) {
@@ -35,7 +154,7 @@ func TestRunAlertConfigsServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	err := runAlertConfigs(ctx, "json")
+	err := runAlertConfigs(ctx, "", "json")
 	assertErrContains(t, err, "query alert configs")
 }
 
@@ -54,6 +173,32 @@ func TestRunAlertDelete(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func decodeAlertConfigRows(t *testing.T, output string) []map[string]any {
+	t.Helper()
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(output), &rows); err != nil {
+		t.Fatalf("decode alert config output: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 alert config row, got %d", len(rows))
+	}
+	return rows
+}
+
+func assertAlertConfigFields(t *testing.T, row map[string]any, fields []string) {
+	t.Helper()
+
+	if len(row) != len(fields) {
+		t.Fatalf("expected %d fields, got %d: %#v", len(fields), len(row), row)
+	}
+	for _, field := range fields {
+		if _, ok := row[field]; !ok {
+			t.Fatalf("expected field %q in %#v", field, row)
+		}
+	}
 }
 
 func TestRunAlertDeleteServerError(t *testing.T) {

--- a/internal/commands/chart.go
+++ b/internal/commands/chart.go
@@ -17,6 +17,7 @@ import (
 type priceDataOptions struct {
 	ticker, format                 string
 	startDate, endDate             string
+	fields                         []string
 	volumeProfile, levels          int
 	minVolume, maxVolume           int
 	vcd, tradeCount                int
@@ -33,7 +34,65 @@ type priceDataOptions struct {
 
 type chartLevelsOptions struct {
 	ticker, startDate, endDate, format string
+	fields                             []string
 	levels                             int
+}
+
+var chartPriceDataDefaultFields = []string{
+	"DateKey",
+	"TimeKey",
+	"FullDateTime",
+	"OpenPrice",
+	"HighPrice",
+	"LowPrice",
+	"ClosePrice",
+	"Volume",
+	"Dollars",
+	"Trades",
+	"CumulativeDistribution",
+	"TradeRank",
+	"TradeRankSnapshot",
+	"TradeLevelRank",
+	"DollarsMultiplier",
+	"RelativeSize",
+	"DarkPoolTrade",
+	"LatePrint",
+	"OpeningTrade",
+	"ClosingTrade",
+	"SignaturePrint",
+	"PhantomPrint",
+	"Sweep",
+}
+
+var chartLevelDefaultFields = []string{
+	"Price",
+	"Dollars",
+	"Volume",
+	"Trades",
+	"RelativeSize",
+	"CumulativeDistribution",
+	"TradeLevelRank",
+	"Dates",
+}
+
+var chartCompanyDefaultFields = []string{
+	"Name",
+	"Ticker",
+	"Sector",
+	"Industry",
+	"MarketCap",
+	"CurrentPrice",
+	"OptionsEnabled",
+	"IPODate",
+	"AverageBlockSizeDollars",
+	"AverageDailyVolume",
+	"AverageTradeShares",
+	"AverageDailyRangePct",
+	"AverageClusterSizeDollars",
+	"AverageLevelSizeDollars",
+	"TotalTrades",
+	"FirstTradeDate",
+	"MaxDate",
 }
 
 // NewChartCommand returns the "chart" command group with all subcommands.
@@ -83,6 +142,7 @@ volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end
 				&cli.IntFlag{Name: "include-closing", Value: 1, Usage: "Include closing trades (0/1)"},
 				&cli.IntFlag{Name: "include-phantom", Value: 1, Usage: "Include phantom prints (0/1)"},
 				&cli.IntFlag{Name: "include-offsetting", Value: 1, Usage: "Include offsetting trades (0/1)"},
+				&cli.StringFlag{Name: "fields", Usage: "Comma-separated PriceBar fields to include in output, or 'all' for every field"},
 			},
 			outputFormatFlags(),
 		),
@@ -95,11 +155,16 @@ volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end
 			if err != nil {
 				return err
 			}
+			fields, err := chartFields[models.PriceBar](cmd.String("fields"), chartPriceDataDefaultFields)
+			if err != nil {
+				return fmt.Errorf("parsing fields flag: %w", err)
+			}
 			opts := priceDataOptions{
 				ticker:            ticker,
 				format:            cmd.String("format"),
 				startDate:         startDate,
 				endDate:           endDate,
+				fields:            fields,
 				volumeProfile:     cmd.Int("volume-profile"),
 				levels:            cmd.Int("levels"),
 				minVolume:         cmd.Int("min-volume"),
@@ -160,6 +225,7 @@ volumeleaders-agent chart levels --ticker TSLA --start-date 2025-01-01 --levels 
 			[]cli.Flag{
 				&cli.StringFlag{Name: "ticker", Usage: "Ticker symbol"},
 				&cli.IntFlag{Name: "levels", Value: 5, Usage: "Number of trade levels"},
+				&cli.StringFlag{Name: "fields", Usage: "Comma-separated TradeLevel fields to include in output, or 'all' for every field"},
 			},
 			outputFormatFlags(),
 		),
@@ -172,14 +238,19 @@ volumeleaders-agent chart levels --ticker TSLA --start-date 2025-01-01 --levels 
 			if err != nil {
 				return err
 			}
+			fields, err := chartFields[models.TradeLevel](cmd.String("fields"), chartLevelDefaultFields)
+			if err != nil {
+				return fmt.Errorf("parsing fields flag: %w", err)
+			}
 			opts := chartLevelsOptions{
 				ticker:    ticker,
 				startDate: startDate,
 				endDate:   endDate,
+				fields:    fields,
 				levels:    cmd.Int("levels"),
 				format:    cmd.String("format"),
 			}
-			return runChartLevels(ctx, opts)
+			return runChartLevels(ctx, &opts)
 		},
 	}
 }
@@ -191,13 +262,18 @@ func newCompanyCommand() *cli.Command {
 		UsageText: "volumeleaders-agent chart company AAPL",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "ticker", Usage: "Ticker symbol"},
+			&cli.StringFlag{Name: "fields", Usage: "Comma-separated Company fields to include in output, or 'all' for every field"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			ticker, err := singleTickerValue(cmd)
 			if err != nil {
 				return err
 			}
-			return runCompany(ctx, ticker)
+			fields, err := chartFields[models.Company](cmd.String("fields"), chartCompanyDefaultFields)
+			if err != nil {
+				return fmt.Errorf("parsing fields flag: %w", err)
+			}
+			return runCompany(ctx, ticker, fields)
 		},
 	}
 }
@@ -259,7 +335,11 @@ func runPriceData(ctx context.Context, opts *priceDataOptions) error {
 		}
 	}
 
-	return printDataTablesResult(ctx, bars, nil, format)
+	fields := opts.fields
+	if len(fields) == 0 {
+		fields = chartPriceDataDefaultFields
+	}
+	return printDataTablesResult(ctx, bars, fields, format)
 }
 
 func runChartSnapshot(ctx context.Context, ticker, dateKey string) error {
@@ -282,13 +362,14 @@ func runChartSnapshot(ctx context.Context, ticker, dateKey string) error {
 	return printJSON(ctx, resp.Snapshot)
 }
 
-func runChartLevels(ctx context.Context, opts chartLevelsOptions) error {
+func runChartLevels(ctx context.Context, opts *chartLevelsOptions) error {
 	return runDataTablesCommand[models.TradeLevel](ctx, "/Chart0/GetTradeLevels", datatables.TradeLevelColumns,
 		dataTableOptions{
 			start:    0,
 			length:   -1,
 			orderCol: 0,
 			orderDir: "desc",
+			fields:   chartFieldsOrDefault(opts.fields, chartLevelDefaultFields),
 			filters: map[string]string{
 				"StartDate": opts.startDate,
 				"EndDate":   opts.endDate,
@@ -300,7 +381,7 @@ func runChartLevels(ctx context.Context, opts chartLevelsOptions) error {
 		"query chart levels")
 }
 
-func runCompany(ctx context.Context, ticker string) error {
+func runCompany(ctx context.Context, ticker string, fields []string) error {
 	vlClient, err := newCommandClient(ctx)
 	if err != nil {
 		return err
@@ -313,5 +394,30 @@ func runCompany(ctx context.Context, ticker string) error {
 		return fmt.Errorf("query company: %w", err)
 	}
 
-	return printJSON(ctx, company)
+	return printSelectedJSON(ctx, company, chartFieldsOrDefault(fields, chartCompanyDefaultFields))
+}
+
+func chartFields[T any](value string, defaultFields []string) ([]string, error) {
+	if value == "" {
+		return defaultFields, nil
+	}
+	if value == "all" {
+		return jsonFieldNamesInOrder[T](), nil
+	}
+	return parseJSONFieldList[T](value)
+}
+
+func chartFieldsOrDefault(fields, defaultFields []string) []string {
+	if len(fields) == 0 {
+		return defaultFields
+	}
+	return fields
+}
+
+func printSelectedJSON[T any](ctx context.Context, item T, fields []string) error {
+	selected, err := selectJSONFields([]T{item}, fields)
+	if err != nil {
+		return err
+	}
+	return printJSON(ctx, selected[0])
 }

--- a/internal/commands/chart_test.go
+++ b/internal/commands/chart_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -19,12 +20,12 @@ func TestRunPriceData(t *testing.T) {
 			t.Errorf("expected path /Chart0/GetAllPriceVolumeTradeData, got %s", r.URL.Path)
 		}
 		// API returns nested array: [[PriceBar, ...], ...]
-		fmt.Fprint(w, `[[{}]]`)
+		fmt.Fprint(w, `[[{"DateKey":20250428,"TimeKey":945,"SecurityKey":123,"Ticker":"AAPL","FullDateTime":"2025-04-28T09:45:00","OpenPrice":100,"HighPrice":101,"LowPrice":99,"ClosePrice":100.5,"Volume":100000,"Dollars":10050000,"Trades":4,"FrequencyLast30TD":9}]]`)
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	captureStdout(t, func() {
+	output := captureStdout(t, func() {
 		opts := &priceDataOptions{
 			ticker:    "AAPL",
 			startDate: "2025-01-15",
@@ -34,6 +35,23 @@ func TestRunPriceData(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &rows); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	for _, field := range []string{"DateKey", "FullDateTime", "OpenPrice", "Volume", "Dollars", "Trades"} {
+		if _, ok := rows[0][field]; !ok {
+			t.Errorf("expected compact default field %q in output", field)
+		}
+	}
+	for _, field := range []string{"SecurityKey", "Ticker", "FrequencyLast30TD"} {
+		if _, ok := rows[0][field]; ok {
+			t.Errorf("did not expect noisy field %q in compact default output", field)
+		}
+	}
 }
 
 func TestRunPriceDataEmptyResponse(t *testing.T) {
@@ -49,8 +67,64 @@ func TestRunPriceDataEmptyResponse(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
-	if !strings.Contains(output, "null") {
-		t.Errorf("expected null output for empty response, got: %s", output)
+	if strings.TrimSpace(output) != "[]" {
+		t.Errorf("expected empty array output for empty response, got: %s", output)
+	}
+}
+
+func TestRunPriceDataFieldsSelectsRequestedOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[[{"DateKey":20250428,"SecurityKey":123,"Ticker":"AAPL","Volume":100000}]]`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		opts := &priceDataOptions{
+			ticker:    "AAPL",
+			startDate: "2025-01-15",
+			endDate:   "2025-01-15",
+			fields:    []string{"Ticker", "SecurityKey"},
+		}
+		if err := runPriceData(ctx, opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &rows); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(rows[0]) != 2 {
+		t.Fatalf("expected 2 selected fields, got %#v", rows[0])
+	}
+	for _, field := range []string{"Ticker", "SecurityKey"} {
+		if _, ok := rows[0][field]; !ok {
+			t.Errorf("expected selected field %q in output", field)
+		}
+	}
+	if _, ok := rows[0]["Volume"]; ok {
+		t.Errorf("did not expect unselected field Volume in output")
+	}
+}
+
+func TestChartPriceDataFieldsRejectsInvalidField(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		fmt.Fprint(w, `[[{}]]`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	root := &cli.Command{Commands: []*cli.Command{NewChartCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "chart", "price-data", "--ticker", "AAPL", "--start-date", "2025-01-15", "--end-date", "2025-01-15",
+		"--fields", "Ticker,NotAField",
+	})
+	assertErrContains(t, err, "invalid field \"NotAField\"")
+	if calls != 0 {
+		t.Errorf("expected invalid fields to fail before API call, got %d calls", calls)
 	}
 }
 
@@ -99,22 +173,36 @@ func TestRunChartLevels(t *testing.T) {
 		if r.URL.Path != "/Chart0/GetTradeLevels" {
 			t.Errorf("expected path /Chart0/GetTradeLevels, got %s", r.URL.Path)
 		}
-		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"AAPL","Name":"Apple Inc.","Price":195.5,"Dollars":25000000,"Volume":125000,"Trades":5,"RelativeSize":8.5,"CumulativeDistribution":0.94,"TradeLevelRank":2,"Dates":"2025-01-01 - 2025-01-31"}]`))
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	captureStdout(t, func() {
+	output := captureStdout(t, func() {
 		opts := chartLevelsOptions{
 			ticker:    "AAPL",
 			startDate: "2025-01-01",
 			endDate:   "2025-01-31",
 			levels:    5,
 		}
-		if err := runChartLevels(ctx, opts); err != nil {
+		if err := runChartLevels(ctx, &opts); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &rows); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	for _, field := range []string{"Price", "Dollars", "Volume", "Dates"} {
+		if _, ok := rows[0][field]; !ok {
+			t.Errorf("expected compact default field %q in output", field)
+		}
+	}
+	for _, field := range []string{"Ticker", "Name", "MinDate", "MaxDate"} {
+		if _, ok := rows[0][field]; ok {
+			t.Errorf("did not expect noisy field %q in compact default output", field)
+		}
+	}
 }
 
 func TestRunCompany(t *testing.T) {
@@ -122,16 +210,30 @@ func TestRunCompany(t *testing.T) {
 		if r.URL.Path != "/Chart0/GetCompany" {
 			t.Errorf("expected path /Chart0/GetCompany, got %s", r.URL.Path)
 		}
-		fmt.Fprint(w, `{}`)
+		fmt.Fprint(w, `{"SecurityKey":123,"Name":"Apple Inc.","Ticker":"AAPL","Sector":"Technology","Industry":"Consumer Electronics","Description":"long company description","AverageBlockSizeDollars":2500000,"AverageBlockSizeDollars30Days":3000000,"AverageDailyVolume":65000000,"CurrentPrice":195.5,"MarketCap":3000000000000,"OptionsEnabled":true,"News":"long news payload"}`)
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	captureStdout(t, func() {
-		if err := runCompany(ctx, "AAPL"); err != nil {
+	output := captureStdout(t, func() {
+		if err := runCompany(ctx, "AAPL", nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+	var row map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &row); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	for _, field := range []string{"Name", "Ticker", "Sector", "Industry", "MarketCap", "CurrentPrice"} {
+		if _, ok := row[field]; !ok {
+			t.Errorf("expected compact default field %q in output", field)
+		}
+	}
+	for _, field := range []string{"SecurityKey", "Description", "AverageBlockSizeDollars30Days", "News"} {
+		if _, ok := row[field]; ok {
+			t.Errorf("did not expect noisy field %q in compact default output", field)
+		}
+	}
 }
 
 func TestRunCompanyServerError(t *testing.T) {
@@ -141,8 +243,36 @@ func TestRunCompanyServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	err := runCompany(ctx, "INVALID")
+	err := runCompany(ctx, "INVALID", nil)
 	assertErrContains(t, err, "query company")
+}
+
+func TestRunCompanyFieldsAllIncludesFullModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"SecurityKey":123,"Name":"Apple Inc.","Ticker":"AAPL","Description":"long company description"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		fields, err := chartFields[models.Company]("all", chartCompanyDefaultFields)
+		if err != nil {
+			t.Fatalf("unexpected field parse error: %v", err)
+		}
+		if err := runCompany(ctx, "AAPL", fields); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var row map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &row); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	for _, field := range []string{"SecurityKey", "Description", "AverageBlockSizeDollars30Days"} {
+		if _, ok := row[field]; !ok {
+			t.Errorf("expected all-fields output to include %q", field)
+		}
+	}
 }
 
 func TestRunPriceDataDecodeError(t *testing.T) {

--- a/skills/volumeleaders-agent/alert.md
+++ b/skills/volumeleaders-agent/alert.md
@@ -4,19 +4,22 @@ Manage saved alert configurations. Alerts trigger when trades or clusters match 
 
 | Command | Use when | Required | Output |
 |---|---|---|---|
-| `alert configs` | List alert configs | none | JSON, CSV, TSV |
+| `alert configs` | List alert configs | optional `--fields` | JSON, CSV, TSV |
 | `alert delete` | Delete a config | `--key` | JSON |
 | `alert create` | Create a config | `--name` | JSON |
 | `alert edit` | Replace/update a config | `--key` | JSON |
 
 ```bash
 volumeleaders-agent alert configs --format csv
+volumeleaders-agent alert configs --fields all --format csv
 volumeleaders-agent alert create --name "Top Trades" --tickers "AAPL,MSFT" --trade-rank-lte 5
 volumeleaders-agent alert edit --key 12345 --trade-rank-lte 3
 volumeleaders-agent alert delete --key 12345
 ```
 
-`alert configs` fields include `AlertConfigKey` for edit/delete, `Name`, `Tickers`, and threshold fields. Threshold names follow `{Category}{Metric}{LTE|GTE}` where LTE is maximum rank and GTE is minimum value.
+`alert configs` defaults to a compact LLM-friendly field set: `AlertConfigKey`, `Name`, `Tickers`, `TradeConditions`, `ClosingTradeConditions`, `DarkPool`, `Sweep`, `OffsettingPrint`, and `PhantomPrint`. Use `--fields FieldA,FieldB` to request specific JSON fields, or `--fields all` for the full alert model with every threshold. CSV/TSV headers follow the same field selection.
+
+Full `alert configs` fields include `AlertConfigKey` for edit/delete, `UserKey`, `Name`, `Tickers`, and threshold fields. Threshold names follow `{Category}{Metric}{LTE|GTE}` where LTE is maximum rank and GTE is minimum value.
 
 Create/edit options: `--name` max 50 chars, `--ticker-group AllTickers|SelectedTickers`, `--tickers` comma-separated and auto-selects `SelectedTickers`.
 

--- a/skills/volumeleaders-agent/chart.md
+++ b/skills/volumeleaders-agent/chart.md
@@ -8,7 +8,7 @@ Chart filter names differ from trade commands: use `--signature-prints` not `--s
 
 One-minute OHLCV bars with institutional trade overlays.
 
-Required: ticker flag or positional ticker, plus a complete `--start-date`/`--end-date` range or `--days`. Supports `--format json|csv|tsv`.
+Required: ticker flag or positional ticker, plus a complete `--start-date`/`--end-date` range or `--days`. Supports `--format json|csv|tsv` and `--fields` for custom output fields.
 
 Important options: `--volume-profile 0|1`, `--levels 5`, `--trade-count 3`, volume/price/dollar ranges, `--dark-pools`, `--sweeps`, `--late-prints`, `--signature-prints`, `--vcd`, `--trade-rank`, `--trade-rank-snapshot`, include-session flags.
 
@@ -16,9 +16,13 @@ Important options: `--volume-profile 0|1`, `--levels 5`, `--trade-count 3`, volu
 volumeleaders-agent chart price-data --ticker AAPL --start-date 2026-04-28 --end-date 2026-04-28
 volumeleaders-agent chart price-data AAPL --days 2
 volumeleaders-agent chart price-data --ticker AAPL --start-date 2026-04-28 --end-date 2026-04-28 --format tsv
+volumeleaders-agent chart price-data AAPL --days 1 --fields FullDateTime,ClosePrice,Volume,Dollars
+volumeleaders-agent chart price-data AAPL --days 1 --fields all
 ```
 
-Key fields: `DateKey`, `TimeKey`, `Date`, `FullDateTime`, `OpenPrice`, `ClosePrice`, `HighPrice`, `LowPrice`, `Volume`, `Dollars`, `Trades`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `TradeLevelRank`, `DollarsMultiplier`, `RelativeSize`, `DarkPoolTrade`, `LatePrint`, `OpeningTrade`, `ClosingTrade`, `SignaturePrint`, `PhantomPrint`, `Sweep`, frequency fields.
+Default output is compact for LLM context windows. It keeps analytical bar and overlay fields: `DateKey`, `TimeKey`, `FullDateTime`, `OpenPrice`, `HighPrice`, `LowPrice`, `ClosePrice`, `Volume`, `Dollars`, `Trades`, `CumulativeDistribution`, `TradeRank`, `TradeRankSnapshot`, `TradeLevelRank`, `DollarsMultiplier`, `RelativeSize`, `DarkPoolTrade`, `LatePrint`, `OpeningTrade`, `ClosingTrade`, `SignaturePrint`, `PhantomPrint`, `Sweep`.
+
+Use `--fields FieldA,FieldB` to select explicit `PriceBar` fields, or `--fields all` to include the full API model. Full-model fields include repeated or verbose values such as `SecurityKey`, `TradeID`, `Ticker`, duplicate date strings, `TradeConditions`, `Dates`, comparison dates, and frequency fields that are omitted by default.
 
 ## chart snapshot
 
@@ -36,23 +40,28 @@ Fields: `ticker`, `lastQuote`, `lastTrade`, `todaysChange`, `todaysChangePerc`. 
 
 Chart-ready institutional price levels with fewer filters than `trade levels`.
 
-Required: ticker flag or positional ticker, plus a complete `--start-date`/`--end-date` range or `--days`. Optional: `--levels` default `5`, `--format json|csv|tsv`.
+Required: ticker flag or positional ticker, plus a complete `--start-date`/`--end-date` range or `--days`. Optional: `--levels` default `5`, `--format json|csv|tsv`, `--fields`.
 
 ```bash
 volumeleaders-agent chart levels --ticker AAPL --start-date 2026-01-01 --end-date 2026-04-28 --levels 10
 volumeleaders-agent chart levels AAPL --days 30 --levels 10
+volumeleaders-agent chart levels AAPL --days 30 --fields Price,Dollars,TradeLevelRank
 ```
 
-Fields: same TradeLevel model as `trade levels`.
+Default fields: `Price`, `Dollars`, `Volume`, `Trades`, `RelativeSize`, `CumulativeDistribution`, `TradeLevelRank`, `Dates`. Use `--fields all` for the full `TradeLevel` model, including repeated `Ticker`/`Name` and separate `MinDate`/`MaxDate` fields.
 
 ## chart company
 
 Company metadata, fundamentals, sector/industry, and trading averages. JSON-only single object.
 
-Required: ticker flag or positional ticker.
+Required: ticker flag or positional ticker. Optional: `--fields`.
 
 ```bash
 volumeleaders-agent chart company AAPL
+volumeleaders-agent chart company AAPL --fields Name,Ticker,MarketCap,CurrentPrice
+volumeleaders-agent chart company AAPL --fields all
 ```
 
-Key fields: `SecurityKey`, `Name`, `Ticker`, `Sector`, `Industry`, `Description`, `HomePageURL`, `MarketCap`, `CurrentPrice`, `OptionsEnabled`, `IPODate`, all-time/30-day/90-day average block, volume, trade-share, range, closing-trade, cluster-size, and level-size fields.
+Default output is compact company context: `Name`, `Ticker`, `Sector`, `Industry`, `MarketCap`, `CurrentPrice`, `OptionsEnabled`, `IPODate`, `AverageBlockSizeDollars`, `AverageDailyVolume`, `AverageTradeShares`, `AverageDailyRangePct`, `AverageClusterSizeDollars`, `AverageLevelSizeDollars`, `TotalTrades`, `FirstTradeDate`, `MaxDate`.
+
+Use `--fields all` when you need the full company model, including keys, status flags, long text fields (`Description`, `News`, `Financials`, `Splits`), homepage URL, previous ticker data, and duplicate 30-day/90-day averages.


### PR DESCRIPTION
## Summary
- Default alert config output to a compact field set, with `--fields all` still available for full records.
- Default chart price data output to compact fields and document the updated output behavior.

## Verification
- `make test`