### PR TITLE
feat(trade): default clusters and levels to compact fields

### DIFF
--- a/internal/commands/chart.go
+++ b/internal/commands/chart.go
@@ -155,7 +155,7 @@ volumeleaders-agent chart price-data --ticker NVDA --start-date 2025-01-01 --end
 			if err != nil {
 				return err
 			}
-			fields, err := chartFields[models.PriceBar](cmd.String("fields"), chartPriceDataDefaultFields)
+			fields, err := outputFields[models.PriceBar](cmd.String("fields"), chartPriceDataDefaultFields)
 			if err != nil {
 				return fmt.Errorf("parsing fields flag: %w", err)
 			}
@@ -238,7 +238,7 @@ volumeleaders-agent chart levels --ticker TSLA --start-date 2025-01-01 --levels 
 			if err != nil {
 				return err
 			}
-			fields, err := chartFields[models.TradeLevel](cmd.String("fields"), chartLevelDefaultFields)
+			fields, err := outputFields[models.TradeLevel](cmd.String("fields"), chartLevelDefaultFields)
 			if err != nil {
 				return fmt.Errorf("parsing fields flag: %w", err)
 			}
@@ -269,7 +269,7 @@ func newCompanyCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			fields, err := chartFields[models.Company](cmd.String("fields"), chartCompanyDefaultFields)
+			fields, err := outputFields[models.Company](cmd.String("fields"), chartCompanyDefaultFields)
 			if err != nil {
 				return fmt.Errorf("parsing fields flag: %w", err)
 			}
@@ -369,7 +369,7 @@ func runChartLevels(ctx context.Context, opts *chartLevelsOptions) error {
 			length:   -1,
 			orderCol: 0,
 			orderDir: "desc",
-			fields:   chartFieldsOrDefault(opts.fields, chartLevelDefaultFields),
+			fields:   outputFieldsOrDefault(opts.fields, chartLevelDefaultFields),
 			filters: map[string]string{
 				"StartDate": opts.startDate,
 				"EndDate":   opts.endDate,
@@ -394,24 +394,7 @@ func runCompany(ctx context.Context, ticker string, fields []string) error {
 		return fmt.Errorf("query company: %w", err)
 	}
 
-	return printSelectedJSON(ctx, company, chartFieldsOrDefault(fields, chartCompanyDefaultFields))
-}
-
-func chartFields[T any](value string, defaultFields []string) ([]string, error) {
-	if value == "" {
-		return defaultFields, nil
-	}
-	if value == "all" {
-		return jsonFieldNamesInOrder[T](), nil
-	}
-	return parseJSONFieldList[T](value)
-}
-
-func chartFieldsOrDefault(fields, defaultFields []string) []string {
-	if len(fields) == 0 {
-		return defaultFields
-	}
-	return fields
+	return printSelectedJSON(ctx, company, outputFieldsOrDefault(fields, chartCompanyDefaultFields))
 }
 
 func printSelectedJSON[T any](ctx context.Context, item T, fields []string) error {

--- a/internal/commands/chart_test.go
+++ b/internal/commands/chart_test.go
@@ -255,7 +255,7 @@ func TestRunCompanyFieldsAllIncludesFullModel(t *testing.T) {
 
 	ctx := contextWithTestClient(t, server.URL)
 	output := captureStdout(t, func() {
-		fields, err := chartFields[models.Company]("all", chartCompanyDefaultFields)
+		fields, err := outputFields[models.Company]("all", chartCompanyDefaultFields)
 		if err != nil {
 			t.Fatalf("unexpected field parse error: %v", err)
 		}

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -217,6 +217,23 @@ func parseJSONFieldList[T any](value string) ([]string, error) {
 	return fields, nil
 }
 
+func outputFields[T any](value string, defaultFields []string) ([]string, error) {
+	if value == "" {
+		return defaultFields, nil
+	}
+	if value == "all" {
+		return jsonFieldNamesInOrder[T](), nil
+	}
+	return parseJSONFieldList[T](value)
+}
+
+func outputFieldsOrDefault(fields, defaultFields []string) []string {
+	if len(fields) == 0 {
+		return defaultFields
+	}
+	return fields
+}
+
 func jsonFieldNames[T any]() []string {
 	fields := jsonFieldNamesInOrder[T]()
 	slices.Sort(fields)

--- a/internal/commands/run_trade_test.go
+++ b/internal/commands/run_trade_test.go
@@ -968,6 +968,121 @@ func TestTradeListFieldsRejectsInvalidField(t *testing.T) {
 	assertErrContains(t, err, "Ticker")
 }
 
+func TestTradeClustersDefaultFieldsCompactOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/TradeClusters/GetTradeClusters" {
+			t.Errorf("expected path /TradeClusters/GetTradeClusters, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[{"Date":"/Date(1745193600000)/","DateKey":20250421,"SecurityKey":123,"Ticker":"APH","Sector":"Technology","Industry":"Hardware","Name":"Amphenol","MinFullDateTime":"2025-04-21T09:30:00","MaxFullDateTime":"2025-04-21T15:55:00","Price":88.5,"Dollars":25000000,"Volume":300000,"TradeCount":4,"DollarsMultiplier":8.2,"CumulativeDistribution":0.94,"TradeClusterRank":3,"TotalRows":71,"ExternalFeed":true}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeClustersCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "clusters",
+			"--tickers", "APH",
+			"--start-date", "2025-04-01",
+			"--end-date", "2025-04-28",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal cluster output: %v", err)
+	}
+	for _, field := range []string{"Date", "Ticker", "Price", "Dollars", "Volume", "TradeCount", "DollarsMultiplier", "CumulativeDistribution", "TradeClusterRank", "MinFullDateTime", "MaxFullDateTime"} {
+		if _, ok := got[0][field]; !ok {
+			t.Errorf("expected compact cluster field %q", field)
+		}
+	}
+	for _, field := range []string{"DateKey", "SecurityKey", "Sector", "Industry", "Name", "TotalRows", "ExternalFeed"} {
+		if _, ok := got[0][field]; ok {
+			t.Errorf("did not expect noisy cluster field %q", field)
+		}
+	}
+}
+
+func TestTradeClustersFieldsAllIncludesFullModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"APH","Name":"Amphenol","Price":88.5,"TotalRows":71}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeClustersCommand()}}
+		if err := root.Run(ctx, []string{
+			"app", "clusters",
+			"--start-date", "2025-04-01",
+			"--end-date", "2025-04-28",
+			"--fields", "all",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal cluster all-fields output: %v", err)
+	}
+	for _, field := range []string{"Ticker", "Name", "TotalRows"} {
+		if _, ok := got[0][field]; !ok {
+			t.Errorf("expected all-fields cluster output to include %q", field)
+		}
+	}
+}
+
+func TestTradeLevelsFieldsAllIncludesFullModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, dataTablesJSON(`[{"Ticker":"AAPL","Name":"Apple Inc.","Price":195.5,"MinDate":"/Date(1743465600000)/","MaxDate":"/Date(1745798400000)/"}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		root := &cli.Command{Commands: []*cli.Command{newTradeLevelsCommand()}}
+		if err := root.Run(ctx, []string{"app", "levels", "AAPL", "--days", "30", "--fields", "all"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("unmarshal level all-fields output: %v", err)
+	}
+	for _, field := range []string{"Ticker", "Name", "Price", "MinDate", "MaxDate"} {
+		if _, ok := got[0][field]; !ok {
+			t.Errorf("expected all-fields level output to include %q", field)
+		}
+	}
+}
+
+func TestTradeFieldsRejectInvalidBeforeAPI(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := contextWithTestClient(t, server.URL)
+	root := &cli.Command{Commands: []*cli.Command{newTradeClustersCommand()}}
+	err := root.Run(ctx, []string{
+		"app", "clusters",
+		"--start-date", "2025-04-01",
+		"--end-date", "2025-04-28",
+		"--fields", "Ticker,NotAField",
+	})
+	assertErrContains(t, err, "invalid field \"NotAField\"")
+	if calls != 0 {
+		t.Fatalf("expected invalid fields to fail before API call, got %d calls", calls)
+	}
+}
+
 func TestTradeListSummaryDefaultsToTickerGrouping(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/Trades/GetTrades" {

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -812,10 +812,6 @@ func runTradeClusterAlerts(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
-	fields, err := parseJSONFieldList[models.TradeLevel](cmd.String("fields"))
-	if err != nil {
-		return fmt.Errorf("parsing fields flag: %w", err)
-	}
 	format, err := parseOutputFormat(cmd.String("format"))
 	if err != nil {
 		return err

--- a/internal/commands/trade.go
+++ b/internal/commands/trade.go
@@ -21,6 +21,20 @@ const (
 	tradeListTickerLookbackDays = 365
 )
 
+var tradeClusterDefaultFields = []string{
+	"Date",
+	"Ticker",
+	"Price",
+	"Dollars",
+	"Volume",
+	"TradeCount",
+	"DollarsMultiplier",
+	"CumulativeDistribution",
+	"TradeClusterRank",
+	"MinFullDateTime",
+	"MaxFullDateTime",
+}
+
 // --- Option structs ---
 
 type tradesOptions struct {
@@ -163,7 +177,8 @@ func newTradeClustersCommand() *cli.Command {
 		Usage: "Query aggregated trade clusters",
 		UsageText: `volumeleaders-agent trade clusters AAPL --days 7
 volumeleaders-agent trade clusters --tickers AAPL --start-date 2025-01-01 --end-date 2025-01-31
-volumeleaders-agent trade clusters --min-dollars 50000000 --vcd 1`,
+volumeleaders-agent trade clusters --min-dollars 50000000 --vcd 1
+volumeleaders-agent trade clusters AAPL --days 30 --fields Date,Ticker,Price,Dollars`,
 		Flags: slices.Concat(
 			dateRangeFlags(),
 			volumeRangeFlags(),
@@ -176,6 +191,7 @@ volumeleaders-agent trade clusters --min-dollars 50000000 --vcd 1`,
 				&cli.IntFlag{Name: "relative-size", Value: 5, Usage: "Relative size threshold"},
 				&cli.IntFlag{Name: "trade-cluster-rank", Value: -1, Usage: "Trade cluster rank filter"},
 				&cli.StringFlag{Name: "sector", Usage: "Sector/Industry filter"},
+				&cli.StringFlag{Name: "fields", Usage: "Comma-separated TradeCluster fields to include in output, or 'all' for every field"},
 			},
 			outputFormatFlags(),
 			paginationFlags(1000, 1, "desc"),
@@ -249,6 +265,7 @@ func newTradeLevelsCommand() *cli.Command {
 		UsageText: `volumeleaders-agent trade levels AAPL
 volumeleaders-agent trade levels --ticker AAPL
 volumeleaders-agent trade levels --ticker MSFT --trade-level-count 20 --min-dollars 1000000
+volumeleaders-agent trade levels AAPL --fields all
 
 Dates are optional. Defaults to 1-year lookback ending today. Use --days for shorter lookbacks.`,
 		Flags: slices.Concat(
@@ -262,7 +279,7 @@ Dates are optional. Defaults to 1-year lookback ending today. Use --days for sho
 				&cli.IntFlag{Name: "relative-size", Value: 0, Usage: "Relative size threshold"},
 				&cli.IntFlag{Name: "trade-level-rank", Value: -1, Usage: "Trade level rank filter"},
 				&cli.IntFlag{Name: "trade-level-count", Value: 10, Usage: "Number of price levels to return (1-50)"},
-				&cli.StringFlag{Name: "fields", Usage: "Comma-separated trade level fields to include in output"},
+				&cli.StringFlag{Name: "fields", Usage: "Comma-separated TradeLevel fields to include in output, or 'all' for every field"},
 			},
 			outputFormatFlags(),
 		),
@@ -720,11 +737,16 @@ func runTradeClusters(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	fields, err := outputFields[models.TradeCluster](cmd.String("fields"), tradeClusterDefaultFields)
+	if err != nil {
+		return fmt.Errorf("parsing fields flag: %w", err)
+	}
 	tickers := multiTickerValue(cmd)
 	return runDataTablesCommand[models.TradeCluster](ctx, "/TradeClusters/GetTradeClusters", datatables.TradeClusterColumns,
 		dataTableOptions{
 			start: cmd.Int("start"), length: cmd.Int("length"),
 			orderCol: cmd.Int("order-col"), orderDir: cmd.String("order-dir"),
+			fields: fields,
 			filters: map[string]string{
 				"Tickers":          tickers,
 				"StartDate":        startDate,
@@ -802,6 +824,10 @@ func runTradeLevels(ctx context.Context, cmd *cli.Command) error {
 	startDate, endDate, err := optionalDateRange(cmd, 365)
 	if err != nil {
 		return err
+	}
+	fields, err := outputFields[models.TradeLevel](cmd.String("fields"), nil)
+	if err != nil {
+		return fmt.Errorf("parsing fields flag: %w", err)
 	}
 	ticker, err := singleTickerValue(cmd)
 	if err != nil {

--- a/skills/volumeleaders-agent/trade.md
+++ b/skills/volumeleaders-agent/trade.md
@@ -71,13 +71,16 @@ JSON: `dateRange`, `daily`, `totals`. Daily rows include `date`, `bear`, `bull`,
 
 ## Clusters and cluster bombs
 
-`trade clusters` finds multiple institutional trades converging at similar prices. Requires a complete date range or `--days`. Defaults: `--min-dollars 10000000`, `--length 1000`, `--order-col 1`, `--order-dir desc`. Optional filters: ticker aliases, positional tickers, `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank`, format, pagination.
+`trade clusters` finds multiple institutional trades converging at similar prices. Requires a complete date range or `--days`. Defaults: `--min-dollars 10000000`, `--length 1000`, `--order-col 1`, `--order-dir desc`. Optional filters: ticker aliases, positional tickers, `--sector`, volume/price/dollar ranges, `--vcd`, `--security-type`, `--relative-size`, `--trade-cluster-rank`, `--fields`, format, pagination.
+
+Cluster output defaults to compact agent-friendly fields: `Date`, `Ticker`, `Price`, `Dollars`, `Volume`, `TradeCount`, `DollarsMultiplier`, `CumulativeDistribution`, `TradeClusterRank`, `MinFullDateTime`, `MaxFullDateTime`. Use `--fields all` for the full API model, or `--fields FIELD1,FIELD2` for a custom validated field list.
 
 `trade cluster-bombs` finds sudden, aggressive bursts tightly grouped in time and price. Requires a complete date range or `--days`. Defaults: `--min-dollars 0`, `--security-type 0`, `--relative-size 0`, `--length 100`. It accepts ticker aliases and positional tickers, has no price range filters, and uses `--trade-cluster-bomb-rank`.
 
 ```bash
 volumeleaders-agent trade clusters --start-date 2026-04-01 --end-date 2026-04-28 --min-dollars 50000000
 volumeleaders-agent trade clusters AAPL MSFT --days 5
+volumeleaders-agent trade clusters APH --start-date 2026-01-01 --end-date 2026-04-29 --fields all
 volumeleaders-agent trade cluster-bombs --start-date 2026-04-28 --end-date 2026-04-28
 ```
 
@@ -92,18 +95,19 @@ volumeleaders-agent trade alerts --date 2026-04-28
 volumeleaders-agent trade cluster-alerts --date 2026-04-28 --format tsv
 ```
 
-Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, `VolumeCumulativeDistribution`, `DollarsMultiplier`, `Volume`, `Dollars`, booleans, `FullDateTime`, `InProcess`, `Complete`. Cluster alert fields match `trade clusters`.
+Trade alert fields include `Ticker`, `Name`, `AlertType`, `Price`, `TradeRank`, `VolumeCumulativeDistribution`, `DollarsMultiplier`, `Volume`, `Dollars`, booleans, `FullDateTime`, `InProcess`, `Complete`. Cluster alert fields use the full cluster-shaped model rather than the compact default from `trade clusters`.
 
 ## Levels and level touches
 
 `trade levels` finds significant institutional prices for one ticker. Required: `--ticker` (aliases accepted) or one positional ticker. Optional: `--start-date`, `--end-date`, `--days`, shared ranges, `--vcd`, `--trade-level-rank`, `--trade-level-count`, `--fields`, `--format`. Defaults to a 1-year lookback when dates are omitted, `--trade-level-count 10`, and non-standard `--relative-size 0`. It does not expose pagination flags. Trade level retrieval is capped at 50 rows per request, so `--trade-level-count` must be between 1 and 50.
 
-Default `trade levels` JSON returns compact analysis rows. It keeps level price, dollars, volume, trade count, relative size, cumulative distribution, rank, and min/max dates. Repetitive single-ticker metadata (`Ticker`, `Name`) and the verbose `Dates` list are omitted to reduce tokens. Use `--fields Ticker,Name,Dates` or another explicit field list when those raw API fields are needed. CSV/TSV without `--fields` still use the full raw trade level row columns.
+Default `trade levels` JSON returns compact analysis rows. It keeps level price, dollars, volume, trade count, relative size, cumulative distribution, rank, and min/max dates. Repetitive single-ticker metadata (`Ticker`, `Name`) and the verbose `Dates` list are omitted to reduce tokens. Use `--fields all`, `--fields Ticker,Name,Dates`, or another explicit field list when raw API fields are needed. CSV/TSV without `--fields` still use the full raw trade level row columns.
 
 `trade level-touches` finds events where price revisits institutional levels. Required: complete `--start-date`/`--end-date` range or `--days`. Optional: ticker aliases, positional tickers, volume/price/dollar ranges, `--vcd`, `--trade-level-rank`, format, pagination. Defaults: `--relative-size 0`, `--trade-level-rank 10`, `--length 50`, `--order-col 0`, `--order-dir desc`. Level-touch retrieval rejects `--length -1`, `--length 0`, and values above 50.
 
 ```bash
 volumeleaders-agent trade levels AAPL --days 30
+volumeleaders-agent trade levels AAPL --days 30 --fields all
 volumeleaders-agent trade level-touches XLE --days 5
 ```
 


### PR DESCRIPTION
## Summary
- Default `trade clusters` and `trade levels` to compact, agent-friendly JSON fields while keeping `--fields all` for the full API model.
- Reuse the chart field-selection helper so custom field validation works consistently across commands and formats.
- Document the new trade field defaults in the VolumeLeaders skill docs.

Closes #41.

## Verification
- `go test ./internal/commands -run 'Test(Trade|RunChart|Chart|ParseJSONFieldList)'`
- `make test`
- `make build`
- Oracle review completed, no blockers found.