### PR TITLE
Compact daily summary output

### DIFF
--- a/internal/commands/daily.go
+++ b/internal/commands/daily.go
@@ -34,7 +34,7 @@ func newDailySummaryCommand() *cli.Command {
 		UsageText: "volumeleaders-agent daily summary --date 2026-04-28 --limit 10",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "date", Required: true, Usage: "Date YYYY-MM-DD"},
-			&cli.IntFlag{Name: "limit", Value: 10, Usage: "Maximum rows per summary section"},
+			&cli.IntFlag{Name: "limit", Value: 10, Usage: "Rows considered per daily summary ranking"},
 		},
 		Action: runDailySummary,
 	}
@@ -78,16 +78,13 @@ func runDailySummary(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	summary := models.DailySummary{
-		Date:                          date,
-		TopInstitutionalVolumeTickers: summarizeDailyInstitutionalVolume(institutional, limit),
-		TopClustersByDollars:          summarizeDailyClustersByDollars(clusters, limit),
-		TopClustersByMultiplier:       summarizeDailyClustersByMultiplier(clusters, limit),
-		RepeatedClusterTickers:        summarizeRepeatedClusterTickers(clusters, limit),
-		SectorTotals:                  summarizeDailySectorTotals(institutional, clusters, clusterBombs, levelTouches, limit),
-		ClusterBombs:                  summarizeDailyClusterBombs(clusterBombs, limit),
-		LevelTouches:                  summarizeDailyLevelTouches(levelTouches, limit),
-		LeveragedETFSentiment:         summarizeDailyLeveragedETFSentiment(sentimentTrades, date),
-		MarketExhaustion:              exhaustion,
+		Date:                  date,
+		InstitutionalVolume:   summarizeDailyInstitutionalVolume(institutional, limit),
+		Clusters:              summarizeDailyClusters(clusters, limit),
+		ClusterBombs:          summarizeDailyClusterBombs(clusterBombs, limit),
+		LevelTouches:          summarizeDailyLevelTouches(levelTouches, limit),
+		LeveragedETFSentiment: summarizeDailyLeveragedETFSentiment(sentimentTrades, date),
+		MarketExhaustion:      summarizeDailyMarketExhaustion(exhaustion),
 	}
 	return printJSON(ctx, summary)
 }
@@ -249,7 +246,7 @@ func fetchDailyDataTables[T any](ctx context.Context, vlClient *client.Client, p
 	return nil, fmt.Errorf("%s: pagination exceeded %d pages", label, maxDailySummaryPages)
 }
 
-func summarizeDailyInstitutionalVolume(trades []models.Trade, limit int) []models.DailyInstitutionalVolumeRow {
+func summarizeDailyInstitutionalVolume(trades []models.Trade, limit int) []models.DailyInstitutionalVolume {
 	sorted := slices.Clone(trades)
 	sort.Slice(sorted, func(i, j int) bool {
 		if sorted[i].TotalInstitutionalDollars == sorted[j].TotalInstitutionalDollars {
@@ -257,59 +254,88 @@ func summarizeDailyInstitutionalVolume(trades []models.Trade, limit int) []model
 		}
 		return sorted[i].TotalInstitutionalDollars > sorted[j].TotalInstitutionalDollars
 	})
-	rows := make([]models.DailyInstitutionalVolumeRow, 0, min(limit, len(sorted)))
+	rows := make([]models.DailyInstitutionalVolume, 0, min(limit, len(sorted)))
 	for i := range min(limit, len(sorted)) {
 		trade := &sorted[i]
-		rows = append(rows, models.DailyInstitutionalVolumeRow{
-			Ticker:                       trade.Ticker,
-			Sector:                       trade.Sector,
-			Price:                        trade.Price,
-			Volume:                       trade.Volume,
-			TotalInstitutionalDollars:    trade.TotalInstitutionalDollars,
-			TotalInstitutionalDollarRank: trade.TotalInstitutionalDollarsRank,
+		rows = append(rows, models.DailyInstitutionalVolume{
+			Ticker:               trade.Ticker,
+			Sector:               trade.Sector,
+			Price:                trade.Price,
+			InstitutionalDollars: trade.TotalInstitutionalDollars,
+			Rank:                 trade.TotalInstitutionalDollarsRank,
 		})
 	}
 	return rows
 }
 
-func summarizeDailyClustersByDollars(clusters []models.TradeCluster, limit int) []models.DailyClusterRow {
-	sorted := slices.Clone(clusters)
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Dollars == sorted[j].Dollars {
-			return sorted[i].Ticker < sorted[j].Ticker
+func summarizeDailyClusters(clusters []models.TradeCluster, limit int) models.DailyClusterSummary {
+	byDollars := slices.Clone(clusters)
+	sort.Slice(byDollars, func(i, j int) bool {
+		if byDollars[i].Dollars == byDollars[j].Dollars {
+			return byDollars[i].Ticker < byDollars[j].Ticker
 		}
-		return sorted[i].Dollars > sorted[j].Dollars
+		return byDollars[i].Dollars > byDollars[j].Dollars
 	})
-	return dailyClusterRows(sorted, limit)
+
+	byMultiplier := slices.Clone(clusters)
+	sort.Slice(byMultiplier, func(i, j int) bool {
+		if byMultiplier[i].DollarsMultiplier == byMultiplier[j].DollarsMultiplier {
+			return byMultiplier[i].Ticker < byMultiplier[j].Ticker
+		}
+		return byMultiplier[i].DollarsMultiplier > byMultiplier[j].DollarsMultiplier
+	})
+
+	return models.DailyClusterSummary{
+		Top:             dailyClusterRows(byDollars, byMultiplier, limit),
+		RepeatedTickers: summarizeRepeatedClusterTickers(clusters, limit),
+	}
 }
 
-func summarizeDailyClustersByMultiplier(clusters []models.TradeCluster, limit int) []models.DailyClusterRow {
-	sorted := slices.Clone(clusters)
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].DollarsMultiplier == sorted[j].DollarsMultiplier {
-			return sorted[i].Ticker < sorted[j].Ticker
-		}
-		return sorted[i].DollarsMultiplier > sorted[j].DollarsMultiplier
-	})
-	return dailyClusterRows(sorted, limit)
+func dailyClusterRows(byDollars, byMultiplier []models.TradeCluster, limit int) []models.DailyCluster {
+	rowsByKey := make(map[string]models.DailyCluster)
+	keys := make([]string, 0, min(limit, len(byDollars))+min(limit, len(byMultiplier)))
+
+	addDailyClusterRows(rowsByKey, &keys, byDollars, limit, "dollars")
+	addDailyClusterRows(rowsByKey, &keys, byMultiplier, limit, "multiplier")
+
+	rows := make([]models.DailyCluster, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, rowsByKey[key])
+	}
+	return rows
 }
 
-func dailyClusterRows(clusters []models.TradeCluster, limit int) []models.DailyClusterRow {
-	rows := make([]models.DailyClusterRow, 0, min(limit, len(clusters)))
+func addDailyClusterRows(rowsByKey map[string]models.DailyCluster, keys *[]string, clusters []models.TradeCluster, limit int, topBy string) {
 	for i := range min(limit, len(clusters)) {
 		cluster := &clusters[i]
-		rows = append(rows, models.DailyClusterRow{
-			Ticker:                 cluster.Ticker,
-			Sector:                 cluster.Sector,
-			Dollars:                cluster.Dollars,
-			DollarsMultiplier:      cluster.DollarsMultiplier,
-			Volume:                 cluster.Volume,
-			TradeCount:             cluster.TradeCount,
-			TradeClusterRank:       cluster.TradeClusterRank,
-			CumulativeDistribution: cluster.CumulativeDistribution,
-		})
+		key := dailyClusterKey(cluster)
+		row, ok := rowsByKey[key]
+		if !ok {
+			row = models.DailyCluster{
+				Ticker:                 cluster.Ticker,
+				Sector:                 cluster.Sector,
+				Dollars:                cluster.Dollars,
+				DollarsMultiplier:      cluster.DollarsMultiplier,
+				TradeCount:             cluster.TradeCount,
+				Rank:                   cluster.TradeClusterRank,
+				CumulativeDistribution: cluster.CumulativeDistribution,
+			}
+			*keys = append(*keys, key)
+		}
+		row.TopBy = appendUniqueDailyTopBy(row.TopBy, topBy)
+		rowsByKey[key] = row
 	}
-	return rows
+}
+
+func dailyClusterKey(cluster *models.TradeCluster) string {
+	return fmt.Sprintf("%s|%.6f|%d|%d", cluster.Ticker, cluster.Dollars, cluster.TradeCount, cluster.TradeClusterRank)
+}
+
+func appendUniqueDailyTopBy(topBy []string, value string) []string {
+	if slices.Contains(topBy, value) {
+		return topBy
+	}
+	return append(topBy, value)
 }
 
 type dailyRepeatedClusterAccumulator struct {
@@ -318,6 +344,7 @@ type dailyRepeatedClusterAccumulator struct {
 	dollars       float64
 	tradeCount    int
 	maxMultiplier float64
+	bestRank      int
 }
 
 func summarizeRepeatedClusterTickers(clusters []models.TradeCluster, limit int) []models.DailyRepeatedClusterTicker {
@@ -330,6 +357,9 @@ func summarizeRepeatedClusterTickers(clusters []models.TradeCluster, limit int) 
 		acc.dollars += cluster.Dollars
 		acc.tradeCount += cluster.TradeCount
 		acc.maxMultiplier = max(acc.maxMultiplier, cluster.DollarsMultiplier)
+		if acc.bestRank == 0 || cluster.TradeClusterRank < acc.bestRank {
+			acc.bestRank = cluster.TradeClusterRank
+		}
 		byTicker[cluster.Ticker] = acc
 	}
 
@@ -345,6 +375,7 @@ func summarizeRepeatedClusterTickers(clusters []models.TradeCluster, limit int) 
 			Dollars:       acc.dollars,
 			TradeCount:    acc.tradeCount,
 			MaxMultiplier: acc.maxMultiplier,
+			BestRank:      acc.bestRank,
 		})
 	}
 	sort.Slice(rows, func(i, j int) bool {
@@ -359,93 +390,7 @@ func summarizeRepeatedClusterTickers(clusters []models.TradeCluster, limit int) 
 	return rows[:min(limit, len(rows))]
 }
 
-type dailySectorAccumulator struct {
-	tickers    map[string]struct{}
-	trades     int
-	dollars    float64
-	volume     int
-	tradeCount int
-}
-
-func summarizeDailySectorTotals(trades []models.Trade, clusters []models.TradeCluster, bombs []models.TradeClusterBomb, touches []models.TradeLevelTouch, limit int) []models.DailySectorTotal {
-	bySector := make(map[string]dailySectorAccumulator)
-	for i := range trades {
-		trade := &trades[i]
-		acc := sectorAccumulator(bySector, trade.Sector)
-		acc.tickers[trade.Ticker] = struct{}{}
-		acc.trades++
-		acc.dollars += trade.TotalInstitutionalDollars
-		acc.volume += trade.Volume
-		bySector[sectorName(trade.Sector)] = acc
-	}
-	for i := range clusters {
-		cluster := &clusters[i]
-		acc := sectorAccumulator(bySector, cluster.Sector)
-		acc.tickers[cluster.Ticker] = struct{}{}
-		acc.dollars += cluster.Dollars
-		acc.volume += cluster.Volume
-		acc.tradeCount += cluster.TradeCount
-		bySector[sectorName(cluster.Sector)] = acc
-	}
-	for i := range bombs {
-		bomb := &bombs[i]
-		acc := sectorAccumulator(bySector, bomb.Sector)
-		acc.tickers[bomb.Ticker] = struct{}{}
-		acc.dollars += bomb.Dollars
-		acc.volume += bomb.Volume
-		acc.tradeCount += bomb.TradeCount
-		bySector[sectorName(bomb.Sector)] = acc
-	}
-	for i := range touches {
-		touch := &touches[i]
-		sector := ""
-		if touch.Sector != nil {
-			sector = *touch.Sector
-		}
-		acc := sectorAccumulator(bySector, sector)
-		acc.tickers[touch.Ticker] = struct{}{}
-		acc.dollars += touch.Dollars
-		acc.volume += touch.Volume
-		acc.tradeCount += touch.Trades
-		bySector[sectorName(sector)] = acc
-	}
-
-	rows := make([]models.DailySectorTotal, 0, len(bySector))
-	for sector, acc := range bySector {
-		rows = append(rows, models.DailySectorTotal{
-			Sector:     sector,
-			Tickers:    len(acc.tickers),
-			Trades:     acc.trades,
-			Dollars:    acc.dollars,
-			Volume:     acc.volume,
-			TradeCount: acc.tradeCount,
-		})
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].Dollars == rows[j].Dollars {
-			return rows[i].Sector < rows[j].Sector
-		}
-		return rows[i].Dollars > rows[j].Dollars
-	})
-	return rows[:min(limit, len(rows))]
-}
-
-func sectorAccumulator(items map[string]dailySectorAccumulator, sector string) dailySectorAccumulator {
-	acc := items[sectorName(sector)]
-	if acc.tickers == nil {
-		acc.tickers = make(map[string]struct{})
-	}
-	return acc
-}
-
-func sectorName(sector string) string {
-	if sector == "" {
-		return "unknown"
-	}
-	return sector
-}
-
-func summarizeDailyClusterBombs(bombs []models.TradeClusterBomb, limit int) []models.DailyClusterBombRow {
+func summarizeDailyClusterBombs(bombs []models.TradeClusterBomb, limit int) []models.DailyClusterBomb {
 	sorted := slices.Clone(bombs)
 	sort.Slice(sorted, func(i, j int) bool {
 		if sorted[i].Dollars == sorted[j].Dollars {
@@ -453,24 +398,23 @@ func summarizeDailyClusterBombs(bombs []models.TradeClusterBomb, limit int) []mo
 		}
 		return sorted[i].Dollars > sorted[j].Dollars
 	})
-	rows := make([]models.DailyClusterBombRow, 0, min(limit, len(sorted)))
+	rows := make([]models.DailyClusterBomb, 0, min(limit, len(sorted)))
 	for i := range min(limit, len(sorted)) {
 		bomb := &sorted[i]
-		rows = append(rows, models.DailyClusterBombRow{
+		rows = append(rows, models.DailyClusterBomb{
 			Ticker:                 bomb.Ticker,
 			Sector:                 bomb.Sector,
 			Dollars:                bomb.Dollars,
 			DollarsMultiplier:      bomb.DollarsMultiplier,
-			Volume:                 bomb.Volume,
 			TradeCount:             bomb.TradeCount,
-			TradeClusterBombRank:   bomb.TradeClusterBombRank,
+			Rank:                   bomb.TradeClusterBombRank,
 			CumulativeDistribution: bomb.CumulativeDistribution,
 		})
 	}
 	return rows
 }
 
-func summarizeDailyLevelTouches(touches []models.TradeLevelTouch, limit int) models.DailyLevelTouchSummary {
+func summarizeDailyLevelTouches(touches []models.TradeLevelTouch, limit int) []models.DailyLevelTouch {
 	byRelativeSize := slices.Clone(touches)
 	sort.Slice(byRelativeSize, func(i, j int) bool {
 		if byRelativeSize[i].RelativeSize == byRelativeSize[j].RelativeSize {
@@ -487,41 +431,78 @@ func summarizeDailyLevelTouches(touches []models.TradeLevelTouch, limit int) mod
 		return byDollars[i].Dollars > byDollars[j].Dollars
 	})
 
-	return models.DailyLevelTouchSummary{
-		ByRelativeSize: dailyLevelTouchRows(byRelativeSize, limit),
-		ByDollars:      dailyLevelTouchRows(byDollars, limit),
+	return dailyLevelTouchRows(byRelativeSize, byDollars, limit)
+}
+
+func dailyLevelTouchRows(byRelativeSize, byDollars []models.TradeLevelTouch, limit int) []models.DailyLevelTouch {
+	rowsByKey := make(map[string]models.DailyLevelTouch)
+	keys := make([]string, 0, min(limit, len(byRelativeSize))+min(limit, len(byDollars)))
+
+	addDailyLevelTouchRows(rowsByKey, &keys, byRelativeSize, limit, "relative_size")
+	addDailyLevelTouchRows(rowsByKey, &keys, byDollars, limit, "dollars")
+
+	rows := make([]models.DailyLevelTouch, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, rowsByKey[key])
+	}
+	return rows
+}
+
+func addDailyLevelTouchRows(rowsByKey map[string]models.DailyLevelTouch, keys *[]string, touches []models.TradeLevelTouch, limit int, topBy string) {
+	for i := range min(limit, len(touches)) {
+		touch := &touches[i]
+		key := dailyLevelTouchKey(touch)
+		row, ok := rowsByKey[key]
+		if !ok {
+			row = dailyLevelTouchRow(touch)
+			*keys = append(*keys, key)
+		}
+		row.TopBy = appendUniqueDailyTopBy(row.TopBy, topBy)
+		rowsByKey[key] = row
 	}
 }
 
-func dailyLevelTouchRows(touches []models.TradeLevelTouch, limit int) []models.DailyLevelTouchRow {
-	rows := make([]models.DailyLevelTouchRow, 0, min(limit, len(touches)))
-	for i := range min(limit, len(touches)) {
-		touch := &touches[i]
-		sector := ""
-		if touch.Sector != nil {
-			sector = *touch.Sector
-		}
-		rows = append(rows, models.DailyLevelTouchRow{
-			Ticker:            touch.Ticker,
-			Sector:            sector,
-			Price:             touch.Price,
-			Dollars:           touch.Dollars,
-			RelativeSize:      touch.RelativeSize,
-			Volume:            touch.Volume,
-			Trades:            touch.Trades,
-			TradeLevelRank:    touch.TradeLevelRank,
-			TradeLevelTouches: touch.TradeLevelTouches,
-		})
+func dailyLevelTouchRow(touch *models.TradeLevelTouch) models.DailyLevelTouch {
+	sector := ""
+	if touch.Sector != nil {
+		sector = *touch.Sector
 	}
-	return rows
+	return models.DailyLevelTouch{
+		Ticker:                 touch.Ticker,
+		Sector:                 sector,
+		Price:                  touch.Price,
+		Dollars:                touch.Dollars,
+		RelativeSize:           touch.RelativeSize,
+		Trades:                 touch.Trades,
+		Rank:                   touch.TradeLevelRank,
+		Touches:                touch.TradeLevelTouches,
+		CumulativeDistribution: touch.CumulativeDistribution,
+	}
+}
+
+func dailyLevelTouchKey(touch *models.TradeLevelTouch) string {
+	return fmt.Sprintf("%s|%.6f|%.6f|%d", touch.Ticker, touch.Price, touch.Dollars, touch.TradeLevelRank)
 }
 
 func summarizeDailyLeveragedETFSentiment(trades []models.Trade, date string) models.DailyLeveragedETFSentiment {
 	sentiment := summarizeTradeSentiment(trades, date, date)
 	return models.DailyLeveragedETFSentiment{
-		Bear:   sentiment.Totals.Bear,
-		Bull:   sentiment.Totals.Bull,
-		Ratio:  sentiment.Totals.Ratio,
-		Signal: sentiment.Totals.Signal,
+		Signal:      sentiment.Totals.Signal,
+		Ratio:       sentiment.Totals.Ratio,
+		BullDollars: sentiment.Totals.Bull.Dollars,
+		BearDollars: sentiment.Totals.Bear.Dollars,
+		BullTrades:  sentiment.Totals.Bull.Trades,
+		BearTrades:  sentiment.Totals.Bear.Trades,
+		BullTickers: sentiment.Totals.Bull.TopTickers,
+		BearTickers: sentiment.Totals.Bear.TopTickers,
+	}
+}
+
+func summarizeDailyMarketExhaustion(exhaustion models.ExhaustionScore) models.DailyMarketExhaustion {
+	return models.DailyMarketExhaustion{
+		Rank:     exhaustion.ExhaustionScoreRank,
+		Rank30D:  exhaustion.ExhaustionScoreRank30Day,
+		Rank90D:  exhaustion.ExhaustionScoreRank90Day,
+		Rank365D: exhaustion.ExhaustionScoreRank365Day,
 	}
 }

--- a/internal/commands/daily_test.go
+++ b/internal/commands/daily_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
@@ -85,22 +86,31 @@ func TestDailySummaryAggregatesInstitutionalActivity(t *testing.T) {
 	if got.Date != "2026-04-28" {
 		t.Fatalf("date = %q, want 2026-04-28", got.Date)
 	}
-	if got.TopInstitutionalVolumeTickers[0].Ticker != "NVDA" {
-		t.Fatalf("expected NVDA top institutional volume, got %#v", got.TopInstitutionalVolumeTickers)
+	if got.InstitutionalVolume[0].Ticker != "NVDA" || got.InstitutionalVolume[0].InstitutionalDollars != 500000000 {
+		t.Fatalf("expected NVDA top institutional volume, got %#v", got.InstitutionalVolume)
 	}
-	if got.TopClustersByMultiplier[0].Ticker != "NVDA" || got.TopClustersByMultiplier[0].DollarsMultiplier != 8 {
-		t.Fatalf("unexpected top multiplier clusters: %#v", got.TopClustersByMultiplier)
+	if len(got.Clusters.Top) != 3 {
+		t.Fatalf("expected deduped cluster union with 3 rows, got %#v", got.Clusters.Top)
 	}
-	if len(got.RepeatedClusterTickers) != 1 || got.RepeatedClusterTickers[0].Ticker != "NVDA" {
-		t.Fatalf("unexpected repeated clusters: %#v", got.RepeatedClusterTickers)
+	if got.Clusters.Top[0].Ticker != "NVDA" || !slices.Contains(got.Clusters.Top[0].TopBy, "dollars") || !slices.Contains(got.Clusters.Top[0].TopBy, "multiplier") {
+		t.Fatalf("unexpected top dollar clusters: %#v", got.Clusters.Top)
 	}
-	if got.LevelTouches.ByRelativeSize[0].Ticker != "AMD" || got.LevelTouches.ByDollars[0].Ticker != "SPY" {
+	if got.Clusters.Top[2].Ticker != "NVDA" || got.Clusters.Top[2].DollarsMultiplier != 8 || got.Clusters.Top[2].TopBy[0] != "multiplier" {
+		t.Fatalf("unexpected top multiplier cluster union: %#v", got.Clusters.Top)
+	}
+	if len(got.Clusters.RepeatedTickers) != 1 || got.Clusters.RepeatedTickers[0].Ticker != "NVDA" || got.Clusters.RepeatedTickers[0].BestRank != 1 {
+		t.Fatalf("unexpected repeated clusters: %#v", got.Clusters.RepeatedTickers)
+	}
+	if len(got.LevelTouches) != 2 || got.LevelTouches[0].Ticker != "AMD" || got.LevelTouches[1].Ticker != "SPY" {
 		t.Fatalf("unexpected level touches: %#v", got.LevelTouches)
 	}
-	if got.LeveragedETFSentiment.Ratio == nil || *got.LeveragedETFSentiment.Ratio != 2 {
+	if !slices.Contains(got.LevelTouches[0].TopBy, "relative_size") || !slices.Contains(got.LevelTouches[0].TopBy, "dollars") || !slices.Contains(got.LevelTouches[1].TopBy, "relative_size") || !slices.Contains(got.LevelTouches[1].TopBy, "dollars") || got.LevelTouches[1].Touches != 2 {
+		t.Fatalf("unexpected level touch top_by metadata: %#v", got.LevelTouches)
+	}
+	if got.LeveragedETFSentiment.Ratio == nil || *got.LeveragedETFSentiment.Ratio != 2 || got.LeveragedETFSentiment.BullDollars != 200000000 {
 		t.Fatalf("unexpected leveraged ETF sentiment: %#v", got.LeveragedETFSentiment)
 	}
-	if got.MarketExhaustion.DateKey != 20260428 {
+	if got.MarketExhaustion.Rank != 4 || got.MarketExhaustion.Rank365D != 20 {
 		t.Fatalf("unexpected exhaustion score: %#v", got.MarketExhaustion)
 	}
 }
@@ -131,11 +141,9 @@ func TestDailySummaryOutputUsesRequestedSectionNames(t *testing.T) {
 	})
 
 	for _, field := range []string{
-		"top_institutional_volume_tickers",
-		"top_clusters_by_dollars",
-		"top_clusters_by_multiplier",
-		"repeated_cluster_tickers",
-		"sector_totals",
+		"institutional_volume",
+		"clusters",
+		"repeated_tickers",
 		"cluster_bombs",
 		"level_touches",
 		"leveraged_etf_sentiment",
@@ -143,6 +151,17 @@ func TestDailySummaryOutputUsesRequestedSectionNames(t *testing.T) {
 	} {
 		if !strings.Contains(output, field) {
 			t.Fatalf("expected output to contain %q, got %s", field, output)
+		}
+	}
+	for _, field := range []string{
+		"top_clusters_by_dollars",
+		"top_clusters_by_multiplier",
+		"sector_totals",
+		"by_relative_size",
+		"by_dollars",
+	} {
+		if strings.Contains(output, field) {
+			t.Fatalf("expected compact output to omit %q, got %s", field, output)
 		}
 	}
 }

--- a/internal/models/daily.go
+++ b/internal/models/daily.go
@@ -2,38 +2,40 @@ package models
 
 // DailySummary is a compact cross-endpoint snapshot for one trading day.
 type DailySummary struct {
-	Date                          string                        `json:"date"`
-	TopInstitutionalVolumeTickers []DailyInstitutionalVolumeRow `json:"top_institutional_volume_tickers"`
-	TopClustersByDollars          []DailyClusterRow             `json:"top_clusters_by_dollars"`
-	TopClustersByMultiplier       []DailyClusterRow             `json:"top_clusters_by_multiplier"`
-	RepeatedClusterTickers        []DailyRepeatedClusterTicker  `json:"repeated_cluster_tickers"`
-	SectorTotals                  []DailySectorTotal            `json:"sector_totals"`
-	ClusterBombs                  []DailyClusterBombRow         `json:"cluster_bombs"`
-	LevelTouches                  DailyLevelTouchSummary        `json:"level_touches"`
-	LeveragedETFSentiment         DailyLeveragedETFSentiment    `json:"leveraged_etf_sentiment"`
-	MarketExhaustion              ExhaustionScore               `json:"market_exhaustion"`
+	Date                  string                     `json:"date"`
+	InstitutionalVolume   []DailyInstitutionalVolume `json:"institutional_volume"`
+	Clusters              DailyClusterSummary        `json:"clusters"`
+	ClusterBombs          []DailyClusterBomb         `json:"cluster_bombs"`
+	LevelTouches          []DailyLevelTouch          `json:"level_touches"`
+	LeveragedETFSentiment DailyLeveragedETFSentiment `json:"leveraged_etf_sentiment"`
+	MarketExhaustion      DailyMarketExhaustion      `json:"market_exhaustion"`
 }
 
-// DailyInstitutionalVolumeRow summarizes high institutional volume tickers.
-type DailyInstitutionalVolumeRow struct {
-	Ticker                       string  `json:"ticker"`
-	Sector                       string  `json:"sector,omitempty"`
-	Price                        float64 `json:"price"`
-	Volume                       int     `json:"volume"`
-	TotalInstitutionalDollars    float64 `json:"total_institutional_dollars"`
-	TotalInstitutionalDollarRank int     `json:"total_institutional_dollar_rank"`
+// DailyInstitutionalVolume summarizes high institutional volume tickers.
+type DailyInstitutionalVolume struct {
+	Ticker               string  `json:"ticker"`
+	Sector               string  `json:"sector,omitempty"`
+	Price                float64 `json:"price"`
+	InstitutionalDollars float64 `json:"institutional_dollars"`
+	Rank                 int     `json:"rank"`
 }
 
-// DailyClusterRow summarizes one trade cluster in daily leaderboards.
-type DailyClusterRow struct {
-	Ticker                 string  `json:"ticker"`
-	Sector                 string  `json:"sector,omitempty"`
-	Dollars                float64 `json:"dollars"`
-	DollarsMultiplier      float64 `json:"dollars_multiplier"`
-	Volume                 int     `json:"volume"`
-	TradeCount             int     `json:"trade_count"`
-	TradeClusterRank       int     `json:"trade_cluster_rank"`
-	CumulativeDistribution float64 `json:"cumulative_distribution"`
+// DailyClusterSummary contains compact cluster signals for the day.
+type DailyClusterSummary struct {
+	Top             []DailyCluster               `json:"top"`
+	RepeatedTickers []DailyRepeatedClusterTicker `json:"repeated_tickers"`
+}
+
+// DailyCluster summarizes one notable trade cluster.
+type DailyCluster struct {
+	Ticker                 string   `json:"ticker"`
+	Sector                 string   `json:"sector,omitempty"`
+	TopBy                  []string `json:"top_by"`
+	Dollars                float64  `json:"dollars"`
+	DollarsMultiplier      float64  `json:"dollars_multiplier"`
+	TradeCount             int      `json:"trade_count"`
+	Rank                   int      `json:"rank"`
+	CumulativeDistribution float64  `json:"cumulative_distribution"`
 }
 
 // DailyRepeatedClusterTicker records tickers with multiple clusters in the day.
@@ -44,53 +46,50 @@ type DailyRepeatedClusterTicker struct {
 	Dollars       float64 `json:"dollars"`
 	TradeCount    int     `json:"trade_count"`
 	MaxMultiplier float64 `json:"max_multiplier"`
+	BestRank      int     `json:"best_rank"`
 }
 
-// DailySectorTotal aggregates institutional activity by sector.
-type DailySectorTotal struct {
-	Sector     string  `json:"sector"`
-	Tickers    int     `json:"tickers"`
-	Trades     int     `json:"trades"`
-	Dollars    float64 `json:"dollars"`
-	Volume     int     `json:"volume"`
-	TradeCount int     `json:"trade_count"`
-}
-
-// DailyClusterBombRow summarizes high-priority cluster bomb entries.
-type DailyClusterBombRow struct {
+// DailyClusterBomb summarizes high-priority cluster bomb entries.
+type DailyClusterBomb struct {
 	Ticker                 string  `json:"ticker"`
 	Sector                 string  `json:"sector,omitempty"`
 	Dollars                float64 `json:"dollars"`
 	DollarsMultiplier      float64 `json:"dollars_multiplier"`
-	Volume                 int     `json:"volume"`
 	TradeCount             int     `json:"trade_count"`
-	TradeClusterBombRank   int     `json:"trade_cluster_bomb_rank"`
+	Rank                   int     `json:"rank"`
 	CumulativeDistribution float64 `json:"cumulative_distribution"`
 }
 
-// DailyLevelTouchSummary contains level-touch leaderboards using two sort keys.
-type DailyLevelTouchSummary struct {
-	ByRelativeSize []DailyLevelTouchRow `json:"by_relative_size"`
-	ByDollars      []DailyLevelTouchRow `json:"by_dollars"`
+// DailyLevelTouch summarizes one notable level-touch event.
+type DailyLevelTouch struct {
+	Ticker                 string   `json:"ticker"`
+	Sector                 string   `json:"sector,omitempty"`
+	TopBy                  []string `json:"top_by"`
+	Price                  float64  `json:"price"`
+	Dollars                float64  `json:"dollars"`
+	RelativeSize           float64  `json:"relative_size"`
+	Trades                 int      `json:"trades"`
+	Rank                   int      `json:"rank"`
+	Touches                int      `json:"touches"`
+	CumulativeDistribution float64  `json:"cumulative_distribution"`
 }
 
-// DailyLevelTouchRow summarizes one notable level-touch event.
-type DailyLevelTouchRow struct {
-	Ticker            string  `json:"ticker"`
-	Sector            string  `json:"sector,omitempty"`
-	Price             float64 `json:"price"`
-	Dollars           float64 `json:"dollars"`
-	RelativeSize      float64 `json:"relative_size"`
-	Volume            int     `json:"volume"`
-	Trades            int     `json:"trades"`
-	TradeLevelRank    int     `json:"trade_level_rank"`
-	TradeLevelTouches int     `json:"trade_level_touches"`
-}
-
-// DailyLeveragedETFSentiment summarizes daily leveraged ETF directional flow.
+// DailyLeveragedETFSentiment summarizes daily leveraged ETF directional proxy flow.
 type DailyLeveragedETFSentiment struct {
-	Bear   TradeSentimentSide   `json:"bear"`
-	Bull   TradeSentimentSide   `json:"bull"`
-	Ratio  *float64             `json:"ratio"`
-	Signal TradeSentimentSignal `json:"signal"`
+	Signal      TradeSentimentSignal `json:"signal"`
+	Ratio       *float64             `json:"ratio"`
+	BullDollars float64              `json:"bull_dollars"`
+	BearDollars float64              `json:"bear_dollars"`
+	BullTrades  int                  `json:"bull_trades"`
+	BearTrades  int                  `json:"bear_trades"`
+	BullTickers []string             `json:"bull_tickers"`
+	BearTickers []string             `json:"bear_tickers"`
+}
+
+// DailyMarketExhaustion keeps only the daily exhaustion ranks useful for decisions.
+type DailyMarketExhaustion struct {
+	Rank     int `json:"rank"`
+	Rank30D  int `json:"rank_30d"`
+	Rank90D  int `json:"rank_90d"`
+	Rank365D int `json:"rank_365d"`
 }

--- a/skills/volumeleaders-agent/daily.md
+++ b/skills/volumeleaders-agent/daily.md
@@ -4,16 +4,26 @@ Use `daily summary` first when the user wants a fast market-wide institutional a
 
 ## daily summary
 
-Nested JSON-only summary for one trading day.
+Compact nested JSON-only summary for one trading day. The schema is optimized for LLM stock-analysis workflows by removing duplicate leaderboards and retaining why each signal was included.
 
-Required: `--date`. Optional: `--limit` leaderboard row limit, default `10`.
+Required: `--date`. Optional: `--limit` rows considered per ranking, default `10`. Merged sections such as `clusters.top` and `level_touches` can return more than `--limit` rows when different rankings select different signals.
 
 ```bash
 volumeleaders-agent daily summary --date 2026-04-28
 volumeleaders-agent --pretty daily summary --date 2026-04-28 --limit 5
 ```
 
-Output sections: `date`, `top_institutional_volume_tickers`, `top_clusters_by_dollars`, `top_clusters_by_multiplier`, `repeated_cluster_tickers`, `sector_totals`, `cluster_bombs`, `level_touches` split by relative size and dollars, `leveraged_etf_sentiment`, `market_exhaustion`.
+Output sections: `date`, `institutional_volume`, `clusters`, `cluster_bombs`, `level_touches`, `leveraged_etf_sentiment`, `market_exhaustion`.
+
+- `institutional_volume` lists top tickers by institutional dollars with `ticker`, optional `sector`, `price`, `institutional_dollars`, and `rank`.
+- `clusters.top` is a deduped union of top clusters by dollars and multiplier. Check `top_by` for why a row was selected, usually `dollars`, `multiplier`, or both.
+- `clusters.repeated_tickers` groups tickers with multiple clusters and includes total cluster dollars, trade count, max multiplier, and best rank.
+- `cluster_bombs` keeps sudden burst signals with dollars, multiplier, trade count, rank, and cumulative distribution.
+- `level_touches` is a deduped union of top touches by relative size and dollars. Check `top_by` for the ranking reason. Rows include price, dollars, relative size, trades, rank, touches, and cumulative distribution.
+- `leveraged_etf_sentiment` is flattened to signal, ratio, bull/bear dollars, bull/bear trades, and top bull/bear tickers. Treat it as leveraged ETF proxy flow, not signed buy/sell flow.
+- `market_exhaustion` returns compact exhaustion ranks as `rank`, `rank_30d`, `rank_90d`, and `rank_365d`. Lower ranks indicate stronger exhaustion or reversal signal.
+
+The summary intentionally omits mixed sector totals because combining dollars and volume across endpoint summaries can double count the same underlying activity.
 
 Data sources: institutional volume, trade clusters, cluster bombs, level touches, leveraged ETF sentiment via one capped 50-row `Trades/GetTrades` request, and exhaustion scores.
 


### PR DESCRIPTION
## Summary
- Rework `daily summary` into compact LLM-focused JSON sections with deduped cluster and level-touch leaderboards.
- Remove mixed `sector_totals` to avoid double-counting endpoint summaries.
- Update daily skill docs and tests for the new output contract.

## Verification
- `go test -v ./internal/commands -run TestDaily`
- `go test ./...`
- `make lint`
- `make build`
- LSP diagnostics on modified Go files

## Notes
- Breaking JSON output change for `daily summary`.
- Local CodeRabbit review skipped by request.