### PR TITLE
feat(market): compact default output

### DIFF
--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -11,6 +11,15 @@ import (
 	cli "github.com/urfave/cli/v3"
 )
 
+var marketEarningsDefaultFields = []string{
+	"Ticker",
+	"EarningsDate",
+	"AfterMarketClose",
+	"TradeCount",
+	"TradeClusterCount",
+	"TradeClusterBombCount",
+}
+
 // NewMarketCommand returns the "market" command group with all subcommands.
 func NewMarketCommand() *cli.Command {
 	return &cli.Command{
@@ -42,13 +51,22 @@ func newEarningsCommand() *cli.Command {
 		Name:      "earnings",
 		Usage:     "Query earnings calendar within a date range",
 		UsageText: "volumeleaders-agent market earnings --days 5",
-		Flags:     slices.Concat(dateRangeFlags(), outputFormatFlags()),
+		Flags: slices.Concat(dateRangeFlags(), outputFormatFlags(), []cli.Flag{
+			&cli.StringFlag{
+				Name:  "fields",
+				Usage: "Comma-separated fields to include (use 'all' for every field)",
+			},
+		}),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			startDate, endDate, err := requiredDateRange(cmd)
 			if err != nil {
 				return err
 			}
-			return runEarnings(ctx, startDate, endDate, cmd.String("format"))
+			fields, err := outputFields[models.Earnings](cmd.String("fields"), marketEarningsDefaultFields)
+			if err != nil {
+				return err
+			}
+			return runEarnings(ctx, startDate, endDate, fields, cmd.String("format"))
 		},
 	}
 }
@@ -85,13 +103,14 @@ func runSnapshots(ctx context.Context) error {
 	return printJSON(ctx, snapshots)
 }
 
-func runEarnings(ctx context.Context, startDate, endDate, format string) error {
+func runEarnings(ctx context.Context, startDate, endDate string, fields []string, format string) error {
 	return runDataTablesCommand[models.Earnings](ctx, "/Earnings/GetEarnings", datatables.EarningsColumns,
 		dataTableOptions{
 			start:    0,
 			length:   -1,
 			orderCol: 0,
 			orderDir: "asc",
+			fields:   fields,
 			filters: map[string]string{
 				"StartDate": startDate,
 				"EndDate":   endDate,
@@ -114,5 +133,15 @@ func runExhaustion(ctx context.Context, date string) error {
 		return fmt.Errorf("query exhaustion scores: %w", err)
 	}
 
-	return printJSON(ctx, score)
+	return printJSON(ctx, summarizeMarketExhaustion(score))
+}
+
+func summarizeMarketExhaustion(score models.ExhaustionScore) models.MarketExhaustion {
+	return models.MarketExhaustion{
+		DateKey:  score.DateKey,
+		Rank:     score.ExhaustionScoreRank,
+		Rank30D:  score.ExhaustionScoreRank30Day,
+		Rank90D:  score.ExhaustionScoreRank90Day,
+		Rank365D: score.ExhaustionScoreRank365Day,
+	}
 }

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/major/volumeleaders-agent/internal/models"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -49,16 +51,80 @@ func TestRunEarnings(t *testing.T) {
 		if r.URL.Path != "/Earnings/GetEarnings" {
 			t.Errorf("expected path /Earnings/GetEarnings, got %s", r.URL.Path)
 		}
-		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+		fmt.Fprint(w, dataTablesJSON(`[{
+			"Ticker":"AAPL",
+			"Name":"Apple Inc.",
+			"Sector":"Technology",
+			"Industry":"Consumer Electronics",
+			"EarningsDate":"/Date(1761091200000)/",
+			"AfterMarketClose":true,
+			"TradeCount":12,
+			"TradeClusterCount":3,
+			"TradeClusterBombCount":1
+		}]`))
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	captureStdout(t, func() {
-		if err := runEarnings(ctx, "2025-01-20", "2025-01-24", "json"); err != nil {
+	output := captureStdout(t, func() {
+		if err := runEarnings(ctx, "2025-01-20", "2025-01-24", marketEarningsDefaultFields, "json"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	rows := decodeJSONRows(t, output)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 earnings row, got %d", len(rows))
+	}
+	assertJSONFields(t, rows[0], marketEarningsDefaultFields, []string{"Name", "Sector", "Industry"})
+}
+
+func TestRunEarningsAllFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Earnings/GetEarnings" {
+			t.Errorf("expected path /Earnings/GetEarnings, got %s", r.URL.Path)
+		}
+		fmt.Fprint(w, dataTablesJSON(`[{
+			"Ticker":"MSFT",
+			"Name":"Microsoft Corporation",
+			"Sector":"Technology",
+			"Industry":"Software",
+			"EarningsDate":"/Date(1761091200000)/",
+			"AfterMarketClose":false,
+			"TradeCount":8,
+			"TradeClusterCount":2,
+			"TradeClusterBombCount":0
+		}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	fields, err := outputFields[models.Earnings]("all", marketEarningsDefaultFields)
+	if err != nil {
+		t.Fatalf("unexpected fields error: %v", err)
+	}
+
+	ctx := contextWithTestClient(t, server.URL)
+	output := captureStdout(t, func() {
+		if err := runEarnings(ctx, "2025-01-20", "2025-01-24", fields, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	rows := decodeJSONRows(t, output)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 earnings row, got %d", len(rows))
+	}
+	assertJSONFields(t, rows[0], []string{
+		"Ticker",
+		"Name",
+		"Sector",
+		"Industry",
+		"EarningsDate",
+		"AfterMarketClose",
+		"TradeCount",
+		"TradeClusterCount",
+		"TradeClusterBombCount",
+	}, nil)
 }
 
 func TestRunEarningsServerError(t *testing.T) {
@@ -68,7 +134,7 @@ func TestRunEarningsServerError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	err := runEarnings(ctx, "2025-01-20", "2025-01-24", "json")
+	err := runEarnings(ctx, "2025-01-20", "2025-01-24", marketEarningsDefaultFields, "json")
 	assertErrContains(t, err, "query earnings")
 }
 
@@ -77,16 +143,37 @@ func TestRunExhaustion(t *testing.T) {
 		if r.URL.Path != "/ExecutiveSummary/GetExhaustionScores" {
 			t.Errorf("expected path /ExecutiveSummary/GetExhaustionScores, got %s", r.URL.Path)
 		}
-		fmt.Fprint(w, `{}`)
+		fmt.Fprint(w, `{
+			"DateKey":20250115,
+			"ExhaustionScoreRank":4,
+			"ExhaustionScoreRank30Day":8,
+			"ExhaustionScoreRank90Day":13,
+			"ExhaustionScoreRank365Day":21
+		}`)
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	captureStdout(t, func() {
+	output := captureStdout(t, func() {
 		if err := runExhaustion(ctx, "2025-01-15"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	var score map[string]int
+	if err := json.Unmarshal([]byte(output), &score); err != nil {
+		t.Fatalf("decode exhaustion output: %v", err)
+	}
+	for _, field := range []string{"date_key", "rank", "rank_30d", "rank_90d", "rank_365d"} {
+		if _, ok := score[field]; !ok {
+			t.Errorf("expected compact exhaustion field %q in output %s", field, output)
+		}
+	}
+	for _, field := range []string{"DateKey", "ExhaustionScoreRank", "ExhaustionScoreRank30Day", "ExhaustionScoreRank90Day", "ExhaustionScoreRank365Day"} {
+		if _, ok := score[field]; ok {
+			t.Errorf("expected raw exhaustion field %q to be omitted from output %s", field, output)
+		}
+	}
 }
 
 func TestRunExhaustionServerError(t *testing.T) {
@@ -126,17 +213,41 @@ func TestMarketEarningsCLI(t *testing.T) {
 		if r.URL.Path != "/Earnings/GetEarnings" {
 			t.Errorf("expected path /Earnings/GetEarnings, got %s", r.URL.Path)
 		}
-		fmt.Fprint(w, dataTablesJSON(`[{}]`))
+		fmt.Fprint(w, dataTablesJSON(`[{
+			"Ticker":"AAPL",
+			"Name":"Apple Inc.",
+			"Sector":"Technology",
+			"Industry":"Consumer Electronics",
+			"EarningsDate":"/Date(1761091200000)/",
+			"AfterMarketClose":true,
+			"TradeCount":12,
+			"TradeClusterCount":3,
+			"TradeClusterBombCount":1
+		}]`))
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := contextWithTestClient(t, server.URL)
-	captureStdout(t, func() {
+	output := captureStdout(t, func() {
 		root := &cli.Command{Commands: []*cli.Command{NewMarketCommand()}}
-		if err := root.Run(ctx, []string{"app", "market", "earnings", "--start-date", "2025-01-20", "--end-date", "2025-01-24"}); err != nil {
+		args := []string{
+			"app",
+			"market",
+			"earnings",
+			"--start-date",
+			"2025-01-20",
+			"--end-date",
+			"2025-01-24",
+			"--fields",
+			"all",
+		}
+		if err := root.Run(ctx, args); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+	if !strings.Contains(output, "Name") {
+		t.Errorf("expected --fields all output to contain Name, got: %s", output)
+	}
 }
 
 func TestMarketExhaustionCLI(t *testing.T) {
@@ -155,4 +266,29 @@ func TestMarketExhaustionCLI(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func decodeJSONRows(t *testing.T, output string) []map[string]json.RawMessage {
+	t.Helper()
+
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &rows); err != nil {
+		t.Fatalf("decode JSON rows: %v", err)
+	}
+	return rows
+}
+
+func assertJSONFields(t *testing.T, row map[string]json.RawMessage, included, omitted []string) {
+	t.Helper()
+
+	for _, field := range included {
+		if _, ok := row[field]; !ok {
+			t.Errorf("expected field %q in row %#v", field, row)
+		}
+	}
+	for _, field := range omitted {
+		if _, ok := row[field]; ok {
+			t.Errorf("expected field %q to be omitted from row %#v", field, row)
+		}
+	}
 }

--- a/internal/models/exhaustion.go
+++ b/internal/models/exhaustion.go
@@ -2,9 +2,18 @@ package models
 
 // ExhaustionScore represents exhaustion score rank values for a specific trading day.
 type ExhaustionScore struct {
-	DateKey                      int `json:"DateKey"`
-	ExhaustionScoreRank          int `json:"ExhaustionScoreRank"`
-	ExhaustionScoreRank30Day     int `json:"ExhaustionScoreRank30Day"`
-	ExhaustionScoreRank90Day     int `json:"ExhaustionScoreRank90Day"`
-	ExhaustionScoreRank365Day    int `json:"ExhaustionScoreRank365Day"`
+	DateKey                   int `json:"DateKey"`
+	ExhaustionScoreRank       int `json:"ExhaustionScoreRank"`
+	ExhaustionScoreRank30Day  int `json:"ExhaustionScoreRank30Day"`
+	ExhaustionScoreRank90Day  int `json:"ExhaustionScoreRank90Day"`
+	ExhaustionScoreRank365Day int `json:"ExhaustionScoreRank365Day"`
+}
+
+// MarketExhaustion is the compact CLI projection for market exhaustion ranks.
+type MarketExhaustion struct {
+	DateKey  int `json:"date_key"`
+	Rank     int `json:"rank"`
+	Rank30D  int `json:"rank_30d"`
+	Rank90D  int `json:"rank_90d"`
+	Rank365D int `json:"rank_365d"`
 }

--- a/skills/volumeleaders-agent/market.md
+++ b/skills/volumeleaders-agent/market.md
@@ -12,9 +12,10 @@ Market-wide prices, earnings calendar, and exhaustion scores.
 volumeleaders-agent market snapshots
 volumeleaders-agent market earnings --start-date 2026-04-21 --end-date 2026-04-28 --format csv
 volumeleaders-agent market earnings --days 7
+volumeleaders-agent market earnings --days 7 --fields all
 volumeleaders-agent market exhaustion --date 2026-04-28
 ```
 
-`market earnings` fields: `Ticker`, `Name`, `Sector`, `Industry`, `EarningsDate`, `AfterMarketClose`, `TradeCount`, `TradeClusterCount`, `TradeClusterBombCount`.
+`market earnings` defaults to compact LLM-focused rows with: `Ticker`, `EarningsDate`, `AfterMarketClose`, `TradeCount`, `TradeClusterCount`, `TradeClusterBombCount`. Repetitive company descriptors (`Name`, `Sector`, `Industry`) are omitted by default to reduce tokens. Use `--fields all` for every raw field, or `--fields Ticker,Name,EarningsDate` for a custom subset. Raw fields are: `Ticker`, `Name`, `Sector`, `Industry`, `EarningsDate`, `AfterMarketClose`, `TradeCount`, `TradeClusterCount`, `TradeClusterBombCount`.
 
-`market exhaustion` optional flag: `--date`, omitted for current day. Fields: `DateKey`, `ExhaustionScoreRank`, `ExhaustionScoreRank30Day`, `ExhaustionScoreRank90Day`, `ExhaustionScoreRank365Day`. Lower rank = stronger exhaustion signal. Multiple low ranks across timeframes reinforce reversal risk.
+`market exhaustion` optional flag: `--date`, omitted for current day. Compact fields: `date_key`, `rank`, `rank_30d`, `rank_90d`, `rank_365d`. Lower rank = stronger exhaustion signal. Multiple low ranks across timeframes reinforce reversal risk.


### PR DESCRIPTION
## Summary
- Compact `market earnings` defaults to the fields most useful for LLM workflows, with `--fields all` preserving access to the full raw field set.
- Return compact `market exhaustion` rank keys while keeping raw API models unchanged.
- Update market command tests and skill docs for the new output behavior.

## Verification
- LSP diagnostics on modified Go files
- `go test ./internal/commands -run 'TestRunEarnings|TestRunExhaustion|TestMarketEarnings|TestMarketExhaustion'`
- `go test ./internal/commands ./internal/models`
- `make test`
- `make lint`
- `make build`