### PR TITLE
refactor(client): migrate HTTP client from stdlib to Resty v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.2
 require (
 	github.com/browserutils/kooky v0.2.9
 	github.com/urfave/cli/v3 v3.8.0
+	resty.dev/v3 v3.0.0-beta.6
 )
 
 require (
@@ -22,5 +23,4 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
-	resty.dev/v3 v3.0.0-beta.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
+	resty.dev/v3 v3.0.0-beta.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,3 +45,5 @@ gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+resty.dev/v3 v3.0.0-beta.6 h1:ghRdNpoE8/wBCv+kTKIOauW1aCrSIeTq7GxtfYgtevU=
+resty.dev/v3 v3.0.0-beta.6/go.mod h1:NTOerrC/4T7/FE6tXIZGIysXXBdgNqwMZuKtxpea9NM=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -135,18 +135,23 @@ func buildCookies(cookies map[string]string) []*http.Cookie {
 // PostDataTablesPage posts a form-encoded DataTables request and returns the
 // full response envelope, including RecordsFiltered for pagination decisions.
 func (c *Client) PostDataTablesPage(ctx context.Context, path, body string) (*models.DataTablesResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, strings.NewReader(body))
+	resp, err := c.client.R().
+		SetContext(ctx).
+		SetBody(body).
+		SetHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8").
+		Post(c.baseURL + path)
 	if err != nil {
-		return nil, fmt.Errorf("create DataTables request: %w", err)
+		return nil, fmt.Errorf("post DataTables request: %w", err)
 	}
-
-	responseBody, err := c.doRequest(req, "DataTables")
-	if err != nil {
-		return nil, err
+	if resp.Err != nil {
+		return nil, fmt.Errorf("post DataTables request: %w", resp.Err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("post DataTables request: status %d: %s", resp.StatusCode(), resp.String())
 	}
 
 	var wrapper models.DataTablesResponse
-	if err := json.Unmarshal(responseBody, &wrapper); err != nil {
+	if err := json.Unmarshal(resp.Bytes(), &wrapper); err != nil {
 		return nil, fmt.Errorf("decode DataTables response: %w", err)
 	}
 	if len(wrapper.Data) == 0 || bytes.Equal(wrapper.Data, []byte("null")) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/major/volumeleaders-agent/internal/auth"
 	"github.com/major/volumeleaders-agent/internal/models"
+	"resty.dev/v3"
 )
 
 // BaseURL is the VolumeLeaders web application origin.
@@ -24,21 +25,40 @@ const BaseURL = "https://www.volumeleaders.com"
 
 // Client wraps authenticated VolumeLeaders HTTP access.
 type Client struct {
-	http      *http.Client
-	baseURL   string
-	cookies   map[string]string
-	xsrfToken string
+	http             *http.Client
+	client           *resty.Client
+	noRedirectClient *resty.Client
+	baseURL          string
+	cookies          map[string]string
+	xsrfToken        string
 }
 
 // NewForTesting creates a Client for test use, bypassing browser-based
 // authentication. Callers provide their own http.Client (typically backed
 // by httptest.Server) and base URL.
 func NewForTesting(httpClient *http.Client, baseURL string) *Client {
+	testCookies := map[string]string{
+		"ASP.NET_SessionId": "test-session",
+		".ASPXAUTH":         "test-auth",
+	}
+	restyClient := resty.NewWithClient(httpClient)
+	restyClient.SetBaseURL(baseURL)
+	restyClient.AddRequestMiddleware(buildRequestMiddleware("test-token"))
+	restyClient.SetCookies(buildCookies(testCookies))
+
+	noRedirectClient := resty.NewWithClient(httpClient)
+	noRedirectClient.SetBaseURL(baseURL)
+	noRedirectClient.SetRedirectPolicy(resty.NoRedirectPolicy())
+	noRedirectClient.AddRequestMiddleware(buildRequestMiddleware("test-token"))
+	noRedirectClient.SetCookies(buildCookies(testCookies))
+
 	return &Client{
-		http:      httpClient,
-		baseURL:   baseURL,
-		cookies:   map[string]string{"test": "test"},
-		xsrfToken: "test-token",
+		http:             httpClient,
+		client:           restyClient,
+		noRedirectClient: noRedirectClient,
+		baseURL:          baseURL,
+		cookies:          testCookies,
+		xsrfToken:        "test-token",
 	}
 }
 
@@ -49,13 +69,67 @@ func New(ctx context.Context) (*Client, error) {
 		return nil, fmt.Errorf("extract cookies: %w", err)
 	}
 
-	httpClient := &http.Client{Timeout: 60 * time.Second}
+	restyClient := resty.New()
+	restyClient.SetTimeout(60 * time.Second)
+
+	// auth.FetchXSRFToken still expects the stdlib client during the migration.
+	httpClient := restyClient.Client()
 	xsrfToken, err := auth.FetchXSRFToken(ctx, httpClient, cookies)
 	if err != nil {
 		return nil, fmt.Errorf("fetch XSRF token: %w", err)
 	}
 
-	return &Client{http: httpClient, baseURL: BaseURL, cookies: cookies, xsrfToken: xsrfToken}, nil
+	restyClient.SetBaseURL(BaseURL)
+	restyClient.AddRequestMiddleware(buildRequestMiddleware(xsrfToken))
+	restyClient.SetCookies(buildCookies(cookies))
+
+	noRedirectClient := resty.New()
+	noRedirectClient.SetTimeout(60 * time.Second)
+	noRedirectClient.SetBaseURL(BaseURL)
+	noRedirectClient.SetRedirectPolicy(resty.NoRedirectPolicy())
+	noRedirectClient.AddRequestMiddleware(buildRequestMiddleware(xsrfToken))
+	noRedirectClient.SetCookies(buildCookies(cookies))
+
+	return &Client{
+		http:             httpClient,
+		client:           restyClient,
+		noRedirectClient: noRedirectClient,
+		baseURL:          BaseURL,
+		cookies:          cookies,
+		xsrfToken:        xsrfToken,
+	}, nil
+}
+
+func buildRequestMiddleware(xsrfToken string) resty.RequestMiddleware {
+	return func(_ *resty.Client, req *resty.Request) error {
+		req.SetHeaders(map[string]string{
+			"User-Agent":         auth.UserAgent,
+			"x-xsrf-token":       xsrfToken,
+			"x-requested-with":   "XMLHttpRequest",
+			"Accept":             "application/json, text/javascript, */*; q=0.01",
+			"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
+			"Sec-Ch-Ua-Mobile":   "?0",
+			"Sec-Ch-Ua-Platform": `"Windows"`,
+			"Sec-Fetch-Dest":     "empty",
+			"Sec-Fetch-Mode":     "cors",
+			"Sec-Fetch-Site":     "same-origin",
+			"Accept-Language":    "en-US,en;q=0.9",
+			"Accept-Encoding":    "gzip, deflate, br",
+		})
+		// Only set default Content-Type if the caller hasn't already specified one.
+		if req.Header.Get("Content-Type") == "" {
+			req.SetHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+		}
+		return nil
+	}
+}
+
+func buildCookies(cookies map[string]string) []*http.Cookie {
+	result := make([]*http.Cookie, 0, len(cookies))
+	for name, value := range cookies {
+		result = append(result, &http.Cookie{Name: name, Value: value})
+	}
+	return result
 }
 
 // PostDataTablesPage posts a form-encoded DataTables request and returns the

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -240,31 +240,19 @@ func (c *Client) PostMultipart(ctx context.Context, path string, fields map[stri
 		return fmt.Errorf("close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, &buf)
-	if err != nil {
-		return fmt.Errorf("create multipart request: %w", err)
-	}
-	c.setHeaders(req)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	c.setCookies(req)
-
-	noRedirect := &http.Client{
-		Transport: c.http.Transport,
-		Timeout:   c.http.Timeout,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
-	resp, err := noRedirect.Do(req)
+	resp, err := c.noRedirectClient.R().
+		SetContext(ctx).
+		SetBody(buf.Bytes()).
+		SetHeader("Content-Type", writer.FormDataContentType()).
+		Post(c.baseURL + path)
 	if err != nil {
 		return fmt.Errorf("post multipart request: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		responseBody, _ := readResponseBody(resp)
-		return fmt.Errorf("post multipart request: status %d: %s", resp.StatusCode, string(responseBody))
+	if resp.Err != nil {
+		return fmt.Errorf("post multipart request: %w", resp.Err)
+	}
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("post multipart request: status %d: %s", resp.StatusCode(), resp.String())
 	}
 	return nil
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,7 +12,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/major/volumeleaders-agent/internal/auth"
@@ -179,18 +178,22 @@ func (c *Client) PostJSON(ctx context.Context, path string, payload, result any)
 		return fmt.Errorf("marshal JSON request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	resp, err := c.client.R().
+		SetContext(ctx).
+		SetBody(body).
+		SetHeader("Content-Type", "application/json").
+		Post(c.baseURL + path)
 	if err != nil {
-		return fmt.Errorf("create JSON request: %w", err)
+		return fmt.Errorf("post JSON request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	responseBody, err := c.doRequest(req, "JSON")
-	if err != nil {
-		return err
+	if resp.Err != nil {
+		return fmt.Errorf("post JSON request: %w", resp.Err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("post JSON request: status %d: %s", resp.StatusCode(), resp.String())
 	}
 
-	if err := json.Unmarshal(responseBody, result); err != nil {
+	if err := json.Unmarshal(resp.Bytes(), result); err != nil {
 		return fmt.Errorf("decode JSON response: %w", err)
 	}
 	return nil
@@ -199,18 +202,23 @@ func (c *Client) PostJSON(ctx context.Context, path string, payload, result any)
 // PostForm sends a form-encoded POST and decodes the JSON response directly
 // (no DataTables envelope).
 func (c *Client) PostForm(ctx context.Context, path string, values url.Values, result any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, strings.NewReader(values.Encode()))
+	resp, err := c.client.R().
+		SetContext(ctx).
+		SetBody(values.Encode()).
+		SetHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8").
+		Post(c.baseURL + path)
 	if err != nil {
-		return fmt.Errorf("create form request: %w", err)
+		return fmt.Errorf("post form request: %w", err)
 	}
-
-	responseBody, err := c.doRequest(req, "form")
-	if err != nil {
-		return err
+	if resp.Err != nil {
+		return fmt.Errorf("post form request: %w", resp.Err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("post form request: status %d: %s", resp.StatusCode(), resp.String())
 	}
 
 	if result != nil {
-		if err := json.Unmarshal(responseBody, result); err != nil {
+		if err := json.Unmarshal(resp.Bytes(), result); err != nil {
 			return fmt.Errorf("decode form response: %w", err)
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,11 +4,9 @@ package client
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -24,7 +22,6 @@ const BaseURL = "https://www.volumeleaders.com"
 
 // Client wraps authenticated VolumeLeaders HTTP access.
 type Client struct {
-	http             *http.Client
 	client           *resty.Client
 	noRedirectClient *resty.Client
 	baseURL          string
@@ -52,7 +49,6 @@ func NewForTesting(httpClient *http.Client, baseURL string) *Client {
 	noRedirectClient.SetCookies(buildCookies(testCookies))
 
 	return &Client{
-		http:             httpClient,
 		client:           restyClient,
 		noRedirectClient: noRedirectClient,
 		baseURL:          baseURL,
@@ -90,7 +86,6 @@ func New(ctx context.Context) (*Client, error) {
 	noRedirectClient.SetCookies(buildCookies(cookies))
 
 	return &Client{
-		http:             httpClient,
 		client:           restyClient,
 		noRedirectClient: noRedirectClient,
 		baseURL:          BaseURL,
@@ -257,68 +252,4 @@ func (c *Client) PostMultipart(ctx context.Context, path string, fields map[stri
 	return nil
 }
 
-// doRequest executes req with standard auth headers/cookies, reads the response
-// body, and checks for non-200 status codes. Callers that need a non-default
-// Content-Type (e.g. application/json) should set it on req before calling.
-func (c *Client) doRequest(req *http.Request, label string) ([]byte, error) {
-	c.setHeaders(req)
-	c.setCookies(req)
 
-	resp, err := c.http.Do(req) //nolint:gosec // baseURL is the hardcoded BaseURL constant, not user input
-	if err != nil {
-		return nil, fmt.Errorf("post %s request: %w", label, err)
-	}
-	defer resp.Body.Close()
-
-	body, err := readResponseBody(resp)
-	if err != nil {
-		return nil, fmt.Errorf("read %s response: %w", label, err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("post %s request: status %d: %s", label, resp.StatusCode, string(body))
-	}
-	return body, nil
-}
-
-func (c *Client) setHeaders(req *http.Request) {
-	req.Header.Set("User-Agent", auth.UserAgent)
-	req.Header.Set("x-xsrf-token", c.xsrfToken)
-	req.Header.Set("x-requested-with", "XMLHttpRequest")
-	req.Header.Set("Accept", "application/json, text/javascript, */*; q=0.01")
-	// Only set default Content-Type if the caller hasn't already specified one.
-	if req.Header.Get("Content-Type") == "" {
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-	}
-	req.Header.Set("Sec-Ch-Ua", `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`)
-	req.Header.Set("Sec-Ch-Ua-Mobile", "?0")
-	req.Header.Set("Sec-Ch-Ua-Platform", `"Windows"`)
-	req.Header.Set("Sec-Fetch-Dest", "empty")
-	req.Header.Set("Sec-Fetch-Mode", "cors")
-	req.Header.Set("Sec-Fetch-Site", "same-origin")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
-}
-
-func (c *Client) setCookies(req *http.Request) {
-	for name, value := range c.cookies {
-		req.AddCookie(&http.Cookie{Name: name, Value: value})
-	}
-}
-
-func readResponseBody(resp *http.Response) ([]byte, error) {
-	var reader io.Reader = resp.Body
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		gzipReader, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("open gzip response body: %w", err)
-		}
-		defer gzipReader.Close()
-		reader = gzipReader
-	}
-
-	body, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, fmt.Errorf("read response body: %w", err)
-	}
-	return body, nil
-}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -17,12 +16,8 @@ import (
 )
 
 func newTestClient(baseURL string) *Client {
-	return &Client{
-		http:      &http.Client{Timeout: 5 * time.Second},
-		baseURL:   baseURL,
-		cookies:   map[string]string{"ASP.NET_SessionId": "test", ".ASPXAUTH": "test"},
-		xsrfToken: "test-token",
-	}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	return NewForTesting(httpClient, baseURL)
 }
 
 func TestPostDataTables(t *testing.T) {
@@ -272,51 +267,6 @@ func TestPostMultipart(t *testing.T) {
 	}
 }
 
-func TestReadResponseBody(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		body     string
-		gzipBody bool
-	}{
-		{name: "plain body", body: "plain response"},
-		{name: "gzip body", body: "gzip response", gzipBody: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var body bytes.Buffer
-			if tt.gzipBody {
-				gz := gzip.NewWriter(&body)
-				if _, err := gz.Write([]byte(tt.body)); err != nil {
-					t.Fatalf("write gzip body: %v", err)
-				}
-				if err := gz.Close(); err != nil {
-					t.Fatalf("close gzip body: %v", err)
-				}
-			} else {
-				body.WriteString(tt.body)
-			}
-
-			resp := &http.Response{Body: io.NopCloser(&body), Header: make(http.Header)}
-			if tt.gzipBody {
-				resp.Header.Set("Content-Encoding", "gzip")
-			}
-
-			got, err := readResponseBody(resp)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if string(got) != tt.body {
-				t.Errorf("expected %q, got %q", tt.body, string(got))
-			}
-		})
-	}
-}
-
 func TestSetHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -367,8 +317,8 @@ func TestSetCookies(t *testing.T) {
 	client.setCookies(req)
 
 	checks := map[string]string{
-		"ASP.NET_SessionId": "test",
-		".ASPXAUTH":         "test",
+		"ASP.NET_SessionId": "test-session",
+		".ASPXAUTH":         "test-auth",
 	}
 	for name, expected := range checks {
 		cookie, err := req.Cookie(name)
@@ -378,6 +328,73 @@ func TestSetCookies(t *testing.T) {
 		}
 		if cookie.Value != expected {
 			t.Errorf("cookie %s: expected %q, got %q", name, expected, cookie.Value)
+		}
+	}
+}
+
+func TestMiddlewareHeaders(t *testing.T) {
+	t.Parallel()
+
+	var capturedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(server.URL)
+	if _, err := client.client.R().Post("/test"); err != nil {
+		t.Fatalf("post through Resty client: %v", err)
+	}
+
+	checks := map[string]string{
+		"User-Agent":         auth.UserAgent,
+		"x-xsrf-token":       "test-token",
+		"x-requested-with":   "XMLHttpRequest",
+		"Accept":             "application/json, text/javascript, */*; q=0.01",
+		"Content-Type":       "application/x-www-form-urlencoded; charset=UTF-8",
+		"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
+		"Sec-Ch-Ua-Mobile":   "?0",
+		"Sec-Ch-Ua-Platform": `"Windows"`,
+		"Sec-Fetch-Dest":     "empty",
+		"Sec-Fetch-Mode":     "cors",
+		"Sec-Fetch-Site":     "same-origin",
+		"Accept-Language":    "en-US,en;q=0.9",
+		"Accept-Encoding":    "gzip, deflate, br",
+	}
+	for key, expected := range checks {
+		if got := capturedHeaders.Get(key); got != expected {
+			t.Errorf("%s: expected %q, got %q", key, expected, got)
+		}
+	}
+}
+
+func TestMiddlewareCookies(t *testing.T) {
+	t.Parallel()
+
+	capturedCookies := make(map[string]string)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, cookie := range r.Cookies() {
+			capturedCookies[cookie.Name] = cookie.Value
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(server.URL)
+	if _, err := client.client.R().Post("/test"); err != nil {
+		t.Fatalf("post through Resty client: %v", err)
+	}
+
+	checks := map[string]string{
+		"ASP.NET_SessionId": "test-session",
+		".ASPXAUTH":         "test-auth",
+	}
+	for name, expected := range checks {
+		if got := capturedCookies[name]; got != expected {
+			t.Errorf("cookie %s: expected %q, got %q", name, expected, got)
 		}
 	}
 }
@@ -407,6 +424,15 @@ func TestNewForTesting(t *testing.T) {
 	}
 	if c.xsrfToken != "test-token" {
 		t.Errorf("expected xsrfToken test-token, got %s", c.xsrfToken)
+	}
+	if c.http != httpClient {
+		t.Errorf("expected stdlib http client to be preserved")
+	}
+	if c.client == nil {
+		t.Errorf("expected Resty client to be populated")
+	}
+	if c.noRedirectClient == nil {
+		t.Errorf("expected no-redirect Resty client to be populated")
 	}
 }
 
@@ -461,17 +487,6 @@ func TestDoRequestConnectionError(t *testing.T) {
 	c := newTestClient(server.URL)
 	err := c.PostJSON(t.Context(), "/test", struct{}{}, &struct{}{})
 	assertErrorContains(t, err, "post JSON request")
-}
-
-func TestReadResponseBodyGzipError(t *testing.T) {
-	t.Parallel()
-
-	resp := &http.Response{
-		Body:   io.NopCloser(strings.NewReader("not-gzip-data")),
-		Header: http.Header{"Content-Encoding": []string{"gzip"}},
-	}
-	_, err := readResponseBody(resp)
-	assertErrorContains(t, err, "open gzip response body")
 }
 
 func TestPostMultipartConnectionError(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -267,71 +267,6 @@ func TestPostMultipart(t *testing.T) {
 	}
 }
 
-func TestSetHeaders(t *testing.T) {
-	t.Parallel()
-
-	client := newTestClient("http://example.test")
-	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
-	req.Header.Set("Content-Type", "application/json")
-	client.setHeaders(req)
-
-	checks := map[string]string{
-		"User-Agent":         auth.UserAgent,
-		"x-xsrf-token":       "test-token",
-		"x-requested-with":   "XMLHttpRequest",
-		"Accept":             "application/json, text/javascript, */*; q=0.01",
-		"Content-Type":       "application/json",
-		"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
-		"Sec-Ch-Ua-Mobile":   "?0",
-		"Sec-Ch-Ua-Platform": `"Windows"`,
-		"Sec-Fetch-Dest":     "empty",
-		"Sec-Fetch-Mode":     "cors",
-		"Sec-Fetch-Site":     "same-origin",
-		"Accept-Language":    "en-US,en;q=0.9",
-		"Accept-Encoding":    "gzip, deflate, br",
-	}
-	for key, expected := range checks {
-		if got := req.Header.Get(key); got != expected {
-			t.Errorf("%s: expected %q, got %q", key, expected, got)
-		}
-	}
-}
-
-func TestSetHeadersDefaultContentType(t *testing.T) {
-	t.Parallel()
-
-	client := newTestClient("http://example.test")
-	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
-	client.setHeaders(req)
-
-	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded; charset=UTF-8" {
-		t.Errorf("expected default Content-Type, got %q", got)
-	}
-}
-
-func TestSetCookies(t *testing.T) {
-	t.Parallel()
-
-	client := newTestClient("http://example.test")
-	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
-	client.setCookies(req)
-
-	checks := map[string]string{
-		"ASP.NET_SessionId": "test-session",
-		".ASPXAUTH":         "test-auth",
-	}
-	for name, expected := range checks {
-		cookie, err := req.Cookie(name)
-		if err != nil {
-			t.Errorf("missing cookie %s: %v", name, err)
-			continue
-		}
-		if cookie.Value != expected {
-			t.Errorf("cookie %s: expected %q, got %q", name, expected, cookie.Value)
-		}
-	}
-}
-
 func TestMiddlewareHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -424,9 +359,6 @@ func TestNewForTesting(t *testing.T) {
 	}
 	if c.xsrfToken != "test-token" {
 		t.Errorf("expected xsrfToken test-token, got %s", c.xsrfToken)
-	}
-	if c.http != httpClient {
-		t.Errorf("expected stdlib http client to be preserved")
 	}
 	if c.client == nil {
 		t.Errorf("expected Resty client to be populated")


### PR DESCRIPTION
## Summary

- Replace `net/http` stdlib usage in `internal/client/` with [Resty v3](https://resty.dev/) (`resty.dev/v3 v3.0.0-beta.6`)
- Resty request middleware handles all 13 browser-emulation headers and cookie injection, replacing manual `setHeaders()`/`setCookies()` helpers
- Second `*resty.Client` with `NoRedirectPolicy` on the struct handles PostMultipart's 302-as-success pattern
- Auto gzip decompression replaces manual `readResponseBody()` logic

## What changed

**`internal/client/client.go`**:
- `Client` struct: `*resty.Client` + `*resty.Client` (noRedirectClient) replace `*http.Client`
- `New()`: creates Resty client, extracts stdlib `*http.Client` via `.Client()` for `auth.FetchXSRFToken()` bridge
- `NewForTesting()`: signature preserved (`*http.Client` param), wraps internally with `resty.NewWithClient()`
- `buildRequestMiddleware()`: sets all headers via Resty middleware
- All 5 public methods (`PostDataTablesPage`, `PostDataTables`, `PostJSON`, `PostForm`, `PostMultipart`) use Resty requests
- Dead code removed: `doRequest`, `setHeaders`, `setCookies`, `readResponseBody`

**`internal/client/client_test.go`**:
- New `TestMiddlewareHeaders` and `TestMiddlewareCookies` verify Resty middleware via real httptest servers
- Removed `TestReadResponseBody*` (Resty handles gzip), `TestSetHeaders*`, `TestSetCookies` (replaced by middleware tests)

## What did NOT change

- `internal/auth/` stays on stdlib `*http.Client`
- `internal/commands/` untouched (same `NewForTesting` signature, same public API)
- `internal/datatables/` and `internal/models/` untouched
- All error format strings preserved (test assertions pass unchanged)

## Verification

- `make build`, `make test` (105 tests), `make lint` all pass
- Live smoke tested against VolumeLeaders API: trade list, market snapshots, watchlist configs, volume institutional, alert configs, trade sentiment, market exhaustion, trade levels