### PR TITLE
Complete resty v3 migration: auth, Close(), constructor cleanup

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -33,6 +33,19 @@ var requiredCookieNames = []string{"ASP.NET_SessionId", ".ASPXAUTH"}
 
 var xsrfTokenPattern = regexp.MustCompile(`<input\s+name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"`)
 
+// BrowserHeaders contains the 9 browser-fingerprint headers that mimic Chrome 147 on Windows.
+var BrowserHeaders = map[string]string{
+	"User-Agent":         UserAgent,
+	"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
+	"Sec-Ch-Ua-Mobile":   "?0",
+	"Sec-Ch-Ua-Platform": `"Windows"`,
+	"Sec-Fetch-Dest":     "empty",
+	"Sec-Fetch-Mode":     "cors",
+	"Sec-Fetch-Site":     "same-origin",
+	"Accept-Language":    "en-US,en;q=0.9",
+	"Accept-Encoding":    "gzip, deflate, br",
+}
+
 type sessionExpiredError struct {
 	redirectPath string
 }
@@ -210,13 +223,7 @@ func normalizeRedirectPath(redirectPath string) string {
 }
 
 func setBrowserHeaders(req *http.Request) {
-	req.Header.Set("User-Agent", UserAgent)
-	req.Header.Set("Sec-Ch-Ua", `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`)
-	req.Header.Set("Sec-Ch-Ua-Mobile", "?0")
-	req.Header.Set("Sec-Ch-Ua-Platform", `"Windows"`)
-	req.Header.Set("Sec-Fetch-Dest", "empty")
-	req.Header.Set("Sec-Fetch-Mode", "cors")
-	req.Header.Set("Sec-Fetch-Site", "same-origin")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	for k, v := range BrowserHeaders {
+		req.Header.Set(k, v)
+	}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -3,11 +3,9 @@
 package auth
 
 import (
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"path"
 	"regexp"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/browserutils/kooky"
 	_ "github.com/browserutils/kooky/browser/all"
+	"resty.dev/v3"
 )
 
 // UserAgent mimics Chrome 147 on Windows for authenticated requests.
@@ -87,47 +86,21 @@ func ExtractCookies(ctx context.Context) (map[string]string, error) {
 }
 
 // FetchXSRFToken retrieves the hidden request verification token from ExecutiveSummary.
-func FetchXSRFToken(ctx context.Context, httpClient *http.Client, cookies map[string]string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.volumeleaders.com/ExecutiveSummary", http.NoBody)
-	if err != nil {
-		return "", fmt.Errorf("create XSRF token request: %w", err)
-	}
-	setBrowserHeaders(req)
-	for name, value := range cookies {
-		req.AddCookie(&http.Cookie{Name: name, Value: value})
-	}
-
-	resp, err := httpClient.Do(req)
+func FetchXSRFToken(ctx context.Context, client *resty.Client) (string, error) {
+	resp, err := client.R().SetContext(ctx).SetHeaders(BrowserHeaders).Get("https://www.volumeleaders.com/ExecutiveSummary")
 	if err != nil {
 		return "", fmt.Errorf("fetch XSRF token page: %w", err)
 	}
-	defer resp.Body.Close()
 
-	redirectPath := safeRedirectPath(resp)
+	redirectPath := safeRedirectPath(resp.RawResponse)
 	if normalizeRedirectPath(redirectPath) == "/login" {
 		return "", sessionExpiredError{redirectPath: redirectPath}
 	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("fetch XSRF token page: status %d", resp.StatusCode)
+	if resp.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("fetch XSRF token page: status %d", resp.StatusCode())
 	}
 
-	// When Accept-Encoding is set explicitly, Go's net/http does not
-	// auto-decompress. Handle gzip manually.
-	var bodyReader io.Reader = resp.Body
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		gr, gzErr := gzip.NewReader(resp.Body)
-		if gzErr != nil {
-			return "", fmt.Errorf("decompress XSRF token page: %w", gzErr)
-		}
-		defer gr.Close()
-		bodyReader = gr
-	}
-
-	body, err := io.ReadAll(bodyReader)
-	if err != nil {
-		return "", fmt.Errorf("read XSRF token page: %w", err)
-	}
-	matches := xsrfTokenPattern.FindSubmatch(body)
+	matches := xsrfTokenPattern.FindSubmatch(resp.Bytes())
 	if matches == nil {
 		return "", fmt.Errorf("XSRF token not found in HTML")
 	}
@@ -220,10 +193,4 @@ func normalizeRedirectPath(redirectPath string) string {
 		redirectPath = "/" + redirectPath
 	}
 	return strings.ToLower(path.Clean(redirectPath))
-}
-
-func setBrowserHeaders(req *http.Request) {
-	for k, v := range BrowserHeaders {
-		req.Header.Set(k, v)
-	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/browserutils/kooky"
+	"resty.dev/v3"
 )
 
 func TestXSRFTokenPattern(t *testing.T) {
@@ -141,11 +142,13 @@ func TestFetchXSRFToken(t *testing.T) {
 
 			client := server.Client()
 			client.Transport = rewriteHostTransport{base: client.Transport, target: server.URL}
-
-			token, err := FetchXSRFToken(t.Context(), client, map[string]string{
-				"ASP.NET_SessionId": "session-cookie",
-				".ASPXAUTH":         "auth-cookie",
+			restyClient := resty.NewWithClient(client)
+			restyClient.SetCookies([]*http.Cookie{
+				{Name: "ASP.NET_SessionId", Value: "session-cookie"},
+				{Name: ".ASPXAUTH", Value: "auth-cookie"},
 			})
+
+			token, err := FetchXSRFToken(t.Context(), restyClient)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q", tt.wantErr)
@@ -307,14 +310,16 @@ func TestFetchXSRFToken_CanceledContext(t *testing.T) {
 
 	client := server.Client()
 	client.Transport = rewriteHostTransport{base: client.Transport, target: server.URL}
+	restyClient := resty.NewWithClient(client)
+	restyClient.SetCookies([]*http.Cookie{
+		{Name: "ASP.NET_SessionId", Value: "session-cookie"},
+		{Name: ".ASPXAUTH", Value: "auth-cookie"},
+	})
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
-	_, err := FetchXSRFToken(ctx, client, map[string]string{
-		"ASP.NET_SessionId": "session-cookie",
-		".ASPXAUTH":         "auth-cookie",
-	})
+	_, err := FetchXSRFToken(ctx, restyClient)
 	if err == nil {
 		t.Fatal("expected error from canceled context")
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -342,18 +342,7 @@ func (t rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, erro
 func assertBrowserHeaders(t *testing.T, r *http.Request) {
 	t.Helper()
 
-	checks := map[string]string{
-		"User-Agent":         UserAgent,
-		"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
-		"Sec-Ch-Ua-Mobile":   "?0",
-		"Sec-Ch-Ua-Platform": `"Windows"`,
-		"Sec-Fetch-Dest":     "empty",
-		"Sec-Fetch-Mode":     "cors",
-		"Sec-Fetch-Site":     "same-origin",
-		"Accept-Language":    "en-US,en;q=0.9",
-		"Accept-Encoding":    "gzip, deflate, br",
-	}
-	for key, expected := range checks {
+	for key, expected := range BrowserHeaders {
 		if got := r.Header.Get(key); got != expected {
 			t.Errorf("%s: expected %q, got %q", key, expected, got)
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -69,17 +69,15 @@ func New(ctx context.Context) (*Client, error) {
 
 	restyClient := resty.New()
 	restyClient.SetTimeout(60 * time.Second)
+	restyClient.SetCookies(buildCookies(cookies))
 
-	// auth.FetchXSRFToken still expects the stdlib client during the migration.
-	httpClient := restyClient.Client()
-	xsrfToken, err := auth.FetchXSRFToken(ctx, httpClient, cookies)
+	xsrfToken, err := auth.FetchXSRFToken(ctx, restyClient)
 	if err != nil {
 		return nil, fmt.Errorf("fetch XSRF token: %w", err)
 	}
 
 	restyClient.SetBaseURL(BaseURL)
 	restyClient.AddRequestMiddleware(buildRequestMiddleware(xsrfToken))
-	restyClient.SetCookies(buildCookies(cookies))
 
 	noRedirectClient := resty.New()
 	noRedirectClient.SetTimeout(60 * time.Second)
@@ -258,5 +256,3 @@ func (c *Client) PostMultipart(ctx context.Context, path string, fields map[stri
 	}
 	return nil
 }
-
-

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/major/volumeleaders-agent/internal/auth"
@@ -27,6 +29,7 @@ type Client struct {
 	baseURL          string
 	cookies          map[string]string
 	xsrfToken        string
+	closeOnce        sync.Once
 }
 
 // NewForTesting creates a Client for test use, bypassing browser-based
@@ -92,6 +95,16 @@ func New(ctx context.Context) (*Client, error) {
 		cookies:          cookies,
 		xsrfToken:        xsrfToken,
 	}, nil
+}
+
+// Close releases resources held by both resty clients.
+// It is safe to call Close more than once.
+func (c *Client) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		err = errors.Join(c.client.Close(), c.noRedirectClient.Close())
+	})
+	return err
 }
 
 func buildRequestMiddleware(xsrfToken string) resty.RequestMiddleware {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -96,20 +96,14 @@ func New(ctx context.Context) (*Client, error) {
 
 func buildRequestMiddleware(xsrfToken string) resty.RequestMiddleware {
 	return func(_ *resty.Client, req *resty.Request) error {
-		req.SetHeaders(map[string]string{
-			"User-Agent":         auth.UserAgent,
-			"x-xsrf-token":       xsrfToken,
-			"x-requested-with":   "XMLHttpRequest",
-			"Accept":             "application/json, text/javascript, */*; q=0.01",
-			"Sec-Ch-Ua":          `"Chromium";v="147", "Not A(Brand";v="24", "Google Chrome";v="147"`,
-			"Sec-Ch-Ua-Mobile":   "?0",
-			"Sec-Ch-Ua-Platform": `"Windows"`,
-			"Sec-Fetch-Dest":     "empty",
-			"Sec-Fetch-Mode":     "cors",
-			"Sec-Fetch-Site":     "same-origin",
-			"Accept-Language":    "en-US,en;q=0.9",
-			"Accept-Encoding":    "gzip, deflate, br",
-		})
+		// Set shared browser headers
+		for k, v := range auth.BrowserHeaders {
+			req.SetHeader(k, v)
+		}
+		// Set API-specific headers
+		req.SetHeader("x-xsrf-token", xsrfToken)
+		req.SetHeader("x-requested-with", "XMLHttpRequest")
+		req.SetHeader("Accept", "application/json, text/javascript, */*; q=0.01")
 		// Only set default Content-Type if the caller hasn't already specified one.
 		if req.Header.Get("Content-Type") == "" {
 			req.SetHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -41,14 +41,12 @@ func NewForTesting(httpClient *http.Client, baseURL string) *Client {
 		".ASPXAUTH":         "test-auth",
 	}
 	restyClient := resty.NewWithClient(httpClient)
-	restyClient.SetBaseURL(baseURL)
-	restyClient.AddRequestMiddleware(buildRequestMiddleware("test-token"))
+	configureClient(restyClient, baseURL, "test-token")
 	restyClient.SetCookies(buildCookies(testCookies))
 
 	noRedirectClient := resty.NewWithClient(httpClient)
-	noRedirectClient.SetBaseURL(baseURL)
+	configureClient(noRedirectClient, baseURL, "test-token")
 	noRedirectClient.SetRedirectPolicy(resty.NoRedirectPolicy())
-	noRedirectClient.AddRequestMiddleware(buildRequestMiddleware("test-token"))
 	noRedirectClient.SetCookies(buildCookies(testCookies))
 
 	return &Client{
@@ -76,14 +74,12 @@ func New(ctx context.Context) (*Client, error) {
 		return nil, fmt.Errorf("fetch XSRF token: %w", err)
 	}
 
-	restyClient.SetBaseURL(BaseURL)
-	restyClient.AddRequestMiddleware(buildRequestMiddleware(xsrfToken))
+	configureClient(restyClient, BaseURL, xsrfToken)
 
 	noRedirectClient := resty.New()
 	noRedirectClient.SetTimeout(60 * time.Second)
-	noRedirectClient.SetBaseURL(BaseURL)
+	configureClient(noRedirectClient, BaseURL, xsrfToken)
 	noRedirectClient.SetRedirectPolicy(resty.NoRedirectPolicy())
-	noRedirectClient.AddRequestMiddleware(buildRequestMiddleware(xsrfToken))
 	noRedirectClient.SetCookies(buildCookies(cookies))
 
 	return &Client{
@@ -103,6 +99,14 @@ func (c *Client) Close() error {
 		err = errors.Join(c.client.Close(), c.noRedirectClient.Close())
 	})
 	return err
+}
+
+// configureClient applies the base URL and request middleware shared by all
+// resty clients. Cookies are set separately by each constructor to avoid
+// duplicate appends (resty's SetCookies appends rather than replaces).
+func configureClient(c *resty.Client, baseURL, xsrfToken string) {
+	c.SetBaseURL(baseURL)
+	c.AddRequestMiddleware(buildRequestMiddleware(xsrfToken))
 }
 
 func buildRequestMiddleware(xsrfToken string) resty.RequestMiddleware {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	cookies          map[string]string
 	xsrfToken        string
 	closeOnce        sync.Once
+	closeErr         error
 }
 
 // NewForTesting creates a Client for test use, bypassing browser-based
@@ -94,11 +95,10 @@ func New(ctx context.Context) (*Client, error) {
 // Close releases resources held by both resty clients.
 // It is safe to call Close more than once.
 func (c *Client) Close() error {
-	var err error
 	c.closeOnce.Do(func() {
-		err = errors.Join(c.client.Close(), c.noRedirectClient.Close())
+		c.closeErr = errors.Join(c.client.Close(), c.noRedirectClient.Close())
 	})
-	return err
+	return c.closeErr
 }
 
 // configureClient applies the base URL and request middleware shared by all

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -448,3 +448,49 @@ func assertErrorContains(t *testing.T, err error, want string) {
 		t.Fatalf("expected error containing %q, got %v", want, err)
 	}
 }
+
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		calls   int
+		wantErr bool
+	}{
+		{
+			name:    "single close returns nil",
+			calls:   1,
+			wantErr: false,
+		},
+		{
+			name:    "double close does not panic",
+			calls:   2,
+			wantErr: false,
+		},
+		{
+			name:    "triple close does not panic",
+			calls:   3,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := newTestClient("http://localhost")
+
+			var lastErr error
+			for i := 0; i < tt.calls; i++ {
+				lastErr = client.Close()
+			}
+
+			if tt.wantErr && lastErr == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tt.wantErr && lastErr != nil {
+				t.Errorf("expected nil, got error: %v", lastErr)
+			}
+		})
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -480,16 +480,27 @@ func TestClose(t *testing.T) {
 
 			client := newTestClient("http://localhost")
 
-			var lastErr error
+			var firstErr error
 			for i := 0; i < tt.calls; i++ {
-				lastErr = client.Close()
+				err := client.Close()
+				if i == 0 {
+					firstErr = err
+				} else {
+					// Verify all calls return the same error value (proving closeErr caching works)
+					if (err == nil && firstErr != nil) || (err != nil && firstErr == nil) {
+						t.Errorf("Close() call %d: got %v, want %v", i+1, err, firstErr)
+					}
+					if err != nil && firstErr != nil && err.Error() != firstErr.Error() {
+						t.Errorf("Close() call %d: got %v, want %v", i+1, err, firstErr)
+					}
+				}
 			}
 
-			if tt.wantErr && lastErr == nil {
+			if tt.wantErr && firstErr == nil {
 				t.Errorf("expected error, got nil")
 			}
-			if !tt.wantErr && lastErr != nil {
-				t.Errorf("expected nil, got error: %v", lastErr)
+			if !tt.wantErr && firstErr != nil {
+				t.Errorf("expected nil, got error: %v", firstErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Completes the deferred items from the resty v3 migration (#60): migrates `FetchXSRFToken` from stdlib to resty, adds `Client.Close()` lifecycle management, and consolidates duplicated constructor/header logic.

- Extract shared `BrowserHeaders` constant used by both auth and client packages, eliminating 9-header duplication between `setBrowserHeaders` and `buildRequestMiddleware`
- Add `Client.Close()` with `sync.Once` double-close protection and `errors.Join` for both resty clients, caching the error for idempotent return
- Migrate `FetchXSRFToken` from `*http.Client` to `*resty.Client`, removing manual gzip decompression (resty auto-decompresses) and the stdlib bridge in `New()`
- Consolidate constructor setup into `configureClient` helper used by both `New()` and `NewForTesting()`
- Remove stale migration comment and `setBrowserHeaders` function

## Changes

| File | What changed |
|------|-------------|
| `internal/auth/auth.go` | `BrowserHeaders` exported map, `FetchXSRFToken` takes `*resty.Client`, `setBrowserHeaders` deleted, manual gzip removed |
| `internal/auth/auth_test.go` | Tests updated for new `FetchXSRFToken(ctx, restyClient)` signature |
| `internal/client/client.go` | `Close()` method, `configureClient` helper, `buildRequestMiddleware` uses `auth.BrowserHeaders` |
| `internal/client/client_test.go` | `TestClose` with idempotent error caching verification |

## Testing

- All existing tests pass (`make test`, `make lint`, `go vet ./...`)
- Live smoke tests against VolumeLeaders API: `volume institutional`, `market earnings`, `trade list`, `trade sentiment`, `watchlist configs`