### PR TITLE
feat(cli): add Cobra best-practice metadata to all commands

### DIFF
--- a/internal/cli/alert/alert.go
+++ b/internal/cli/alert/alert.go
@@ -28,9 +28,11 @@ var alertConfigDefaultFields = []string{
 // NewAlertCommand returns the "alert" command group with all subcommands.
 func NewAlertCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:      "alert",
-		Short:    "Alert configuration commands",
-		GroupID:  "alerts",
+		Use:     "alert",
+		Short:   "Alert configuration commands",
+		Long:    "alert contains subcommands for managing saved alert configurations that notify on institutional trade activity matching your criteria. Use create to define new alerts, edit to update existing ones, delete to remove them, and configs to list all saved configurations.",
+		GroupID: "alerts",
+		Args:    cobra.NoArgs,
 	}
 	cmd.AddCommand(
 		newConfigsCmd(),
@@ -44,9 +46,13 @@ func NewAlertCommand() *cobra.Command {
 // newConfigsCmd returns the "configs" subcommand.
 func newConfigsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "configs",
-		Short:   "List saved alert configurations",
-		Example: "volumeleaders-agent alert configs",
+		Use:        "configs",
+		Short:      "List saved alert configurations",
+		Long:       "List all saved alert configurations with their keys, names, ticker filters, trade conditions, and notification settings. Outputs compact JSON or CSV/TSV with --format. Use --fields to select specific output fields.",
+		Example:    "volumeleaders-agent alert configs",
+		Args:       cobra.NoArgs,
+		Aliases:    []string{"ls"},
+		SuggestFor: []string{"config", "cfg"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			fieldsValue, _ := cmd.Flags().GetString("fields")
 			fields, err := common.OutputFields[models.AlertConfig](fieldsValue, alertConfigDefaultFields)
@@ -76,9 +82,13 @@ func newConfigsCmd() *cobra.Command {
 // newDeleteCmd returns the "delete" subcommand.
 func newDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "delete",
-		Short:   "Delete an alert configuration",
-		Example: "volumeleaders-agent alert delete --key 42",
+		Use:        "delete",
+		Short:      "Delete an alert configuration",
+		Long:       "Remove a saved alert configuration by its numeric key. Requires --key with the alert config key (visible in configs output). The deletion is permanent and cannot be undone.",
+		Example:    "volumeleaders-agent alert delete --key 42",
+		Args:       cobra.NoArgs,
+		Aliases:    []string{"rm"},
+		SuggestFor: []string{"del", "remove"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key, _ := cmd.Flags().GetInt("key")
 			ctx := cmd.Context()
@@ -108,8 +118,12 @@ func newCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new alert configuration",
+		Long:  "Create a new alert configuration with a name and filter settings for institutional trade activity. Requires --name. Specify filters such as trade rank, dollar thresholds, dark pool and sweep conditions, and ticker scope. Returns a success response with the new configuration key.",
 		Example: `volumeleaders-agent alert create --name "Big trades" --tickers AAPL,MSFT --trade-rank-lte 5
 volumeleaders-agent alert create --name "Dark pool sweeps" --sweep --dark-pool --trade-volume-gte 1000000`,
+		Args:       cobra.NoArgs,
+		Aliases:    []string{"new"},
+		SuggestFor: []string{"crate", "creat"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAlertCreateEdit(cmd, 0)
 		},
@@ -122,9 +136,12 @@ volumeleaders-agent alert create --name "Dark pool sweeps" --sweep --dark-pool -
 // newEditCmd returns the "edit" subcommand.
 func newEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "edit",
-		Short:   "Edit an existing alert configuration",
-		Example: `volumeleaders-agent alert edit --key 42 --name "Updated alert" --trade-rank-lte 3`,
+		Use:        "edit",
+		Short:      "Edit an existing alert configuration",
+		Long:       "Modify an existing alert configuration identified by its numeric key. Requires --key with the alert config key. Specify only the fields you want to change; unspecified fields retain their current values.",
+		Example:    `volumeleaders-agent alert edit --key 42 --name "Updated alert" --trade-rank-lte 3`,
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"edt", "modify"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key, _ := cmd.Flags().GetInt("key")
 			return runAlertCreateEdit(cmd, key)

--- a/internal/cli/alert/alert.go
+++ b/internal/cli/alert/alert.go
@@ -28,8 +28,9 @@ var alertConfigDefaultFields = []string{
 // NewAlertCommand returns the "alert" command group with all subcommands.
 func NewAlertCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "alert",
-		Short: "Alert configuration commands",
+		Use:      "alert",
+		Short:    "Alert configuration commands",
+		GroupID:  "alerts",
 	}
 	cmd.AddCommand(
 		newConfigsCmd(),

--- a/internal/cli/market/market.go
+++ b/internal/cli/market/market.go
@@ -24,9 +24,11 @@ var marketEarningsDefaultFields = []string{
 // NewMarketCommand returns the "market" command group with all subcommands.
 func NewMarketCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:      "market",
-		Short:    "Market-wide data commands",
-		GroupID:  "market",
+		Use:     "market",
+		Short:   "Market-wide data commands",
+		GroupID: "market",
+		Args:    cobra.NoArgs,
+		Long:    "market contains subcommands for querying market-wide data from VolumeLeaders, including price snapshots, earnings calendars, and exhaustion signals. None of the subcommands accept positional arguments; all filtering is done via flags.",
 	}
 	cmd.AddCommand(
 		newSnapshotsCmd(),
@@ -39,9 +41,12 @@ func NewMarketCommand() *cobra.Command {
 // newSnapshotsCmd returns the "snapshots" subcommand.
 func newSnapshotsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "snapshots",
-		Short:   "Get current price snapshots for all symbols",
-		Example: "volumeleaders-agent market snapshots",
+		Use:        "snapshots",
+		Short:      "Get current price snapshots for all symbols",
+		Example:    "volumeleaders-agent market snapshots",
+		Args:       cobra.NoArgs,
+		Long:       "Retrieve current price snapshot data for all symbols tracked by VolumeLeaders, returning the latest available price and volume data. No date filtering is available; always returns the most recent data. Outputs compact JSON by default.",
+		SuggestFor: []string{"snapshot", "snaps"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			vlClient, err := common.NewCommandClient(ctx)
@@ -64,9 +69,12 @@ func newSnapshotsCmd() *cobra.Command {
 // newEarningsCmd returns the "earnings" subcommand.
 func newEarningsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "earnings",
-		Short:   "Query earnings calendar within a date range",
-		Example: "volumeleaders-agent market earnings --days 5",
+		Use:        "earnings",
+		Short:      "Query earnings calendar within a date range",
+		Example:    "volumeleaders-agent market earnings --days 5",
+		Args:       cobra.NoArgs,
+		Long:       "Query the earnings calendar for a date range, showing tickers with earnings dates and associated trade activity counts. Requires --start-date and --end-date (or --days). Outputs compact JSON or CSV/TSV with --format.",
+		SuggestFor: []string{"earning", "earings"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			startDate, endDate, err := common.RequiredDateRange(cmd)
 			if err != nil {
@@ -104,9 +112,12 @@ func newEarningsCmd() *cobra.Command {
 // newExhaustionCmd returns the "exhaustion" subcommand.
 func newExhaustionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "exhaustion",
-		Short:   "Query exhaustion scores for a date",
-		Example: "volumeleaders-agent market exhaustion --date 2025-01-15",
+		Use:        "exhaustion",
+		Short:      "Query exhaustion scores for a date",
+		Example:    "volumeleaders-agent market exhaustion --date 2025-01-15",
+		Args:       cobra.NoArgs,
+		Long:       "Query exhaustion scores that indicate overbought or oversold market conditions based on institutional trade clustering patterns. Omit --date to query the current trading day. Outputs compact JSON with rank metrics at different lookback periods.",
+		SuggestFor: []string{"exhaust", "exhastion"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			date, _ := cmd.Flags().GetString("date")

--- a/internal/cli/market/market.go
+++ b/internal/cli/market/market.go
@@ -24,8 +24,9 @@ var marketEarningsDefaultFields = []string{
 // NewMarketCommand returns the "market" command group with all subcommands.
 func NewMarketCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "market",
-		Short: "Market-wide data commands",
+		Use:      "market",
+		Short:    "Market-wide data commands",
+		GroupID:  "market",
 	}
 	cmd.AddCommand(
 		newSnapshotsCmd(),

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,11 +18,14 @@ import (
 // NewRootCmd returns the root cobra command for volumeleaders-agent.
 func NewRootCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "volumeleaders-agent",
-		Short:         "CLI tool for querying VolumeLeaders institutional trade data",
-		Version:       version,
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Use:              "volumeleaders-agent",
+		Short:            "CLI tool for querying VolumeLeaders institutional trade data",
+		Long:             "volumeleaders-agent queries institutional trade data from VolumeLeaders, providing access to trades, volume leaderboards, market snapshots, alert configurations, and watchlists. All commands output compact JSON to stdout by default; use --pretty for indented output or --format csv/tsv where supported. Authenticate via browser cookie extraction (see documentation for setup).",
+		Version:          version,
+		SilenceErrors:    true,
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		Args:             cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			prettyFlag, _ := cmd.Flags().GetBool("pretty")
 			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
@@ -31,6 +34,13 @@ func NewRootCmd(version string) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().Bool("pretty", false, "Pretty-print JSON output with indentation")
+	cmd.AddGroup(
+		&cobra.Group{ID: "trading", Title: "Trading Commands:"},
+		&cobra.Group{ID: "volume", Title: "Volume Commands:"},
+		&cobra.Group{ID: "market", Title: "Market Commands:"},
+		&cobra.Group{ID: "alerts", Title: "Alert Commands:"},
+		&cobra.Group{ID: "watchlists", Title: "Watchlist Commands:"},
+	)
 	cmd.AddCommand(
 		trade.NewCmd(),
 		volume.NewVolumeCommand(),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -69,5 +70,230 @@ func TestRootSilenceUsagePreventsUsageOutputOnError(t *testing.T) {
 	combinedOutput := stdout + stderr
 	if strings.Contains(combinedOutput, "Usage:") {
 		t.Fatalf("expected no usage output, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+// walkCommands recursively visits cmd and all of its subcommands, calling fn
+// on each one. This lets structural tests assert properties across the entire
+// command tree without duplicating the traversal logic.
+func walkCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, sub := range cmd.Commands() {
+		walkCommands(sub, fn)
+	}
+}
+
+func TestRootTraverseChildrenEnabled(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+	if !cmd.TraverseChildren {
+		t.Fatal("expected TraverseChildren = true on root command")
+	}
+}
+
+func TestRootHasCommandGroups(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+
+	groups := cmd.Groups()
+	if len(groups) != 5 {
+		t.Fatalf("expected 5 command groups, got %d", len(groups))
+	}
+
+	expectedGroups := []struct {
+		id string
+	}{
+		{"trading"},
+		{"volume"},
+		{"market"},
+		{"alerts"},
+		{"watchlists"},
+	}
+	for _, tt := range expectedGroups {
+		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
+			var found bool
+			for _, g := range groups {
+				if g.ID == tt.id {
+					found = true
+					if g.Title == "" {
+						t.Fatalf("group %q has empty Title", tt.id)
+					}
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected group %q not found", tt.id)
+			}
+		})
+	}
+}
+
+func TestAllTopLevelCommandsHaveGroupID(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+
+	validGroups := []string{"trading", "volume", "market", "alerts", "watchlists"}
+	builtins := []string{"help", "completion"}
+
+	for _, sub := range cmd.Commands() {
+		t.Run(sub.Name(), func(t *testing.T) {
+			t.Parallel()
+			if slices.Contains(builtins, sub.Name()) {
+				return
+			}
+			if sub.GroupID == "" {
+				t.Fatalf("command %q has empty GroupID", sub.Name())
+			}
+			if !slices.Contains(validGroups, sub.GroupID) {
+				t.Fatalf("command %q has unexpected GroupID %q", sub.Name(), sub.GroupID)
+			}
+		})
+	}
+}
+
+func TestAllCommandsHaveArgsValidator(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+
+	walkCommands(cmd, func(c *cobra.Command) {
+		t.Run(c.CommandPath(), func(t *testing.T) {
+			t.Parallel()
+			if c.Args == nil {
+				t.Fatalf("command %q has nil Args validator", c.CommandPath())
+			}
+		})
+	})
+}
+
+func TestAllCommandsHaveLongDescription(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+
+	builtins := []string{"help", "completion"}
+
+	walkCommands(cmd, func(c *cobra.Command) {
+		t.Run(c.CommandPath(), func(t *testing.T) {
+			t.Parallel()
+			if slices.Contains(builtins, c.Name()) {
+				return
+			}
+			if c.Long == "" {
+				t.Fatalf("command %q has empty Long description", c.CommandPath())
+			}
+			if c.Long == c.Short {
+				t.Fatalf("command %q Long equals Short; Long must add value", c.CommandPath())
+			}
+			for _, ch := range []string{"#", "`", "[", "]"} {
+				if strings.Contains(c.Long, ch) {
+					t.Fatalf("command %q Long contains Markdown character %q", c.CommandPath(), ch)
+				}
+			}
+		})
+	})
+}
+
+func TestNoAliasConflictsWithinParentScope(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+
+	walkCommands(cmd, func(parent *cobra.Command) {
+		children := parent.Commands()
+		if len(children) == 0 {
+			return
+		}
+		t.Run(parent.CommandPath(), func(t *testing.T) {
+			t.Parallel()
+			seen := make(map[string]string) // name/alias -> owning command
+			for _, child := range children {
+				name := child.Name()
+				if owner, ok := seen[name]; ok {
+					t.Fatalf("duplicate name %q: used by both %q and %q", name, owner, child.CommandPath())
+				}
+				seen[name] = child.CommandPath()
+
+				for _, alias := range child.Aliases {
+					if owner, ok := seen[alias]; ok {
+						t.Fatalf("alias %q of %q conflicts with %q", alias, child.CommandPath(), owner)
+					}
+					seen[alias] = child.CommandPath()
+				}
+			}
+		})
+	})
+}
+
+func TestNoArgsCommandsRejectPositionalArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"trade sentiment", []string{"trade", "sentiment", "bogus"}},
+		{"trade presets", []string{"trade", "presets", "bogus"}},
+		{"trade preset-tickers", []string{"trade", "preset-tickers", "bogus"}},
+		{"trade alerts", []string{"trade", "alerts", "--date", "2025-01-01", "bogus"}},
+		{"trade cluster-alerts", []string{"trade", "cluster-alerts", "--date", "2025-01-01", "bogus"}},
+		{"market snapshots", []string{"market", "snapshots", "bogus"}},
+		{"market earnings", []string{"market", "earnings", "bogus"}},
+		{"market exhaustion", []string{"market", "exhaustion", "bogus"}},
+		{"alert configs", []string{"alert", "configs", "bogus"}},
+		{"alert delete", []string{"alert", "delete", "bogus"}},
+		{"alert create", []string{"alert", "create", "bogus"}},
+		{"alert edit", []string{"alert", "edit", "bogus"}},
+		{"watchlist configs", []string{"watchlist", "configs", "bogus"}},
+		{"watchlist tickers", []string{"watchlist", "tickers", "bogus"}},
+		{"watchlist delete", []string{"watchlist", "delete", "bogus"}},
+		{"watchlist add-ticker", []string{"watchlist", "add-ticker", "bogus"}},
+		{"watchlist create", []string{"watchlist", "create", "bogus"}},
+		{"watchlist edit", []string{"watchlist", "edit", "bogus"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewRootCmd("test")
+			_, _, err := testutil.ExecuteCommand(t, cmd, context.Background(), tt.args...)
+			if err == nil {
+				t.Fatalf("expected error for args %v, got nil", tt.args)
+			}
+		})
+	}
+}
+
+func TestArbitraryArgsCommandsAcceptPositionalArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"trade list", []string{"trade", "list", "AAPL"}},
+		{"trade clusters", []string{"trade", "clusters", "AAPL"}},
+		{"trade cluster-bombs", []string{"trade", "cluster-bombs", "AAPL"}},
+		{"trade levels", []string{"trade", "levels", "AAPL"}},
+		{"trade level-touches", []string{"trade", "level-touches", "AAPL"}},
+		{"volume institutional", []string{"volume", "institutional", "--date", "2025-01-01", "AAPL"}},
+		{"volume ah-institutional", []string{"volume", "ah-institutional", "--date", "2025-01-01", "AAPL"}},
+		{"volume total", []string{"volume", "total", "--date", "2025-01-01", "AAPL"}},
+	}
+
+	rejectMsgs := []string{"unknown command", "does not accept"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := NewRootCmd("test")
+			_, _, err := testutil.ExecuteCommand(t, cmd, context.Background(), tt.args...)
+			if err != nil {
+				msg := err.Error()
+				for _, reject := range rejectMsgs {
+					if strings.Contains(msg, reject) {
+						t.Fatalf("command rejected positional arg: %v", err)
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/trade/presets.go
+++ b/internal/cli/trade/presets.go
@@ -199,7 +199,15 @@ func watchlistConfigToFilters(cfg *models.WatchListConfig) map[string]string {
 }
 
 func newTradePresetTickersCommand() *cobra.Command {
-	cmd := &cobra.Command{Use: "preset-tickers", Short: "Extract ticker symbols from a preset", Example: "volumeleaders-agent trade preset-tickers --preset NAME", RunE: runTradePresetTickers}
+	cmd := &cobra.Command{
+		Use:        "preset-tickers",
+		Short:      "Extract ticker symbols from a preset",
+		Long:       "Extract the ticker symbols configured in a named trade filter preset, showing whether the preset uses an explicit ticker list, a sector/industry filter, or is unfiltered. Requires --preset with the preset name (case-insensitive). Outputs JSON with the preset name, group, type, and ticker details.",
+		Example:    "volumeleaders-agent trade preset-tickers --preset NAME",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"presettickers", "preset-ticker"},
+		RunE:       runTradePresetTickers,
+	}
 	cmd.Flags().String("preset", "", "Preset name (case-insensitive)")
 	_ = cmd.MarkFlagRequired("preset")
 	return cmd
@@ -240,7 +248,15 @@ func splitTickers(tickers string) []string {
 }
 
 func newTradePresetsCommand() *cobra.Command {
-	cmd := &cobra.Command{Use: "presets", Short: "List available trade filter presets", Example: "volumeleaders-agent trade presets", RunE: runTradePresets}
+	cmd := &cobra.Command{
+		Use:        "presets",
+		Short:      "List available trade filter presets",
+		Long:       "List all built-in trade filter presets with their names, groups, and filter configurations. Each preset defines a named set of filters that can be applied to trade list queries via --preset. Outputs compact JSON by default; use --format csv or tsv for tabular output.",
+		Example:    "volumeleaders-agent trade presets",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"preset", "prsets"},
+		RunE:       runTradePresets,
+	}
 	common.AddOutputFormatFlags(cmd)
 	return cmd
 }

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -218,7 +218,7 @@ func newTradeLevelsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "levels [ticker]",
 		Short:      "Query significant price levels for a ticker",
-		Long:       "Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Do not add cobra.MaximumNArgs(1) here; SingleTickerValue in RunE provides the validation with a better error message.",
+		Long:       "Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Outputs compact JSON by default.",
 		Example:    "volumeleaders-agent trade levels AAPL",
 		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"level", "lvels"},

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -59,7 +59,7 @@ type tradeLevelOptions struct {
 
 // NewCmd returns the "trade" command group with all subcommands.
 func NewCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "trade", Short: "Trade-related commands"}
+	cmd := &cobra.Command{Use: "trade", Short: "Trade-related commands", GroupID: "trading"}
 	cmd.AddCommand(
 		newTradeListCommand(),
 		newTradeSentimentCommand(),

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -59,7 +59,13 @@ type tradeLevelOptions struct {
 
 // NewCmd returns the "trade" command group with all subcommands.
 func NewCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "trade", Short: "Trade-related commands", GroupID: "trading"}
+	cmd := &cobra.Command{
+		Use:     "trade",
+		Short:   "Trade-related commands",
+		GroupID: "trading",
+		Args:    cobra.NoArgs,
+		Long:    "trade contains subcommands for querying institutional trade data, trade clusters, sentiment metrics, price levels, and alert activity from VolumeLeaders. Use subcommands to filter by ticker, date range, dollar amounts, trade conditions, and more. All subcommands output compact JSON to stdout by default.",
+	}
 	cmd.AddCommand(
 		newTradeListCommand(),
 		newTradeSentimentCommand(),
@@ -82,13 +88,17 @@ func newTradeListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list [tickers...]",
 		Short: "Query institutional trades",
+		Long:  "Query individual institutional trades from VolumeLeaders, filterable by ticker, date range, dollar amounts, volume, trade conditions, session type, and trade rank. Supports built-in filter presets (--preset) and watchlist-based filtering (--watchlist). Outputs compact JSON or CSV/TSV with --format; use --summary for aggregate metrics grouped by ticker or day.",
 		Example: `volumeleaders-agent trade list AAPL MSFT
 volumeleaders-agent trade list --tickers AAPL,MSFT
 volumeleaders-agent trade list --tickers NVDA --dark-pools 1 --min-dollars 1000000
 volumeleaders-agent trade list --sector Technology --relative-size 10 --length 50
 volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
 volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24`,
-		RunE: runTradeList,
+		Args:       cobra.ArbitraryArgs,
+		Aliases:    []string{"ls"},
+		SuggestFor: []string{"lst", "lis"},
+		RunE:       runTradeList,
 	}
 	common.AddOptionalDateRangeFlags(cmd)
 	addTradeRangeFlags(cmd, 500000)
@@ -107,10 +117,13 @@ volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-
 
 func newTradeSentimentCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "sentiment",
-		Short:   "Summarize leveraged ETF bull/bear flow by day",
-		Example: "volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25",
-		RunE:    runTradeSentiment,
+		Use:        "sentiment",
+		Short:      "Summarize leveraged ETF bull/bear flow by day",
+		Long:       "Summarize leveraged ETF bull and bear flow by trading day, showing aggregate institutional dollar volume on the bull and bear side. Requires --start-date and --end-date (or --days). Outputs one record per day with bull and bear totals.",
+		Example:    "volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"sentment", "sentimnt"},
+		RunE:       runTradeSentiment,
 	}
 	common.AddDateRangeFlags(cmd)
 	addTradeRangeFlags(cmd, 5000000)
@@ -121,10 +134,13 @@ func newTradeSentimentCommand() *cobra.Command {
 
 func newTradeClustersCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "clusters [tickers...]",
-		Short:   "Query aggregated trade clusters",
-		Example: "volumeleaders-agent trade clusters AAPL --days 7",
-		RunE:    runTradeClusters,
+		Use:        "clusters [tickers...]",
+		Short:      "Query aggregated trade clusters",
+		Long:       "Query aggregated trade clusters, which group multiple trades in a short window into a single cluster record. Filterable by ticker, date range, dollar amounts, sector, and trade cluster rank. Outputs compact JSON or CSV/TSV with --format.",
+		Example:    "volumeleaders-agent trade clusters AAPL --days 7",
+		Args:       cobra.ArbitraryArgs,
+		SuggestFor: []string{"cluster", "clsters"},
+		RunE:       runTradeClusters,
 	}
 	common.AddDateRangeFlags(cmd)
 	addTradeRangeFlags(cmd, 10000000)
@@ -142,10 +158,13 @@ func newTradeClustersCommand() *cobra.Command {
 
 func newTradeClusterBombsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "cluster-bombs [tickers...]",
-		Short:   "Query trade cluster bombs",
-		Example: "volumeleaders-agent trade cluster-bombs TSLA --days 3",
-		RunE:    runTradeClusterBombs,
+		Use:        "cluster-bombs [tickers...]",
+		Short:      "Query trade cluster bombs",
+		Long:       "Query trade cluster bombs, which are extreme-magnitude trade clusters that exceed normal institutional activity thresholds. Filterable by ticker, date range, dollar amounts, sector, and cluster bomb rank. Outputs compact JSON by default.",
+		Example:    "volumeleaders-agent trade cluster-bombs TSLA --days 3",
+		Args:       cobra.ArbitraryArgs,
+		SuggestFor: []string{"clusterbombs", "cluster-bomb"},
+		RunE:       runTradeClusterBombs,
 	}
 	common.AddDateRangeFlags(cmd)
 	common.AddVolumeRangeFlags(cmd)
@@ -163,10 +182,13 @@ func newTradeClusterBombsCommand() *cobra.Command {
 
 func newTradeAlertsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "alerts",
-		Short:   "Query trade alerts for a date",
-		Example: "volumeleaders-agent trade alerts --date 2025-01-15",
-		RunE:    runTradeAlerts,
+		Use:        "alerts",
+		Short:      "Query trade alerts for a date",
+		Long:       "Query trade alerts fired on a specific date based on saved alert configurations. Requires --date. Returns alert records matching your configured filters. Outputs compact JSON or CSV/TSV with --format.",
+		Example:    "volumeleaders-agent trade alerts --date 2025-01-15",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"alert", "alrts"},
+		RunE:       runTradeAlerts,
 	}
 	cmd.Flags().String("date", "", "Date YYYY-MM-DD")
 	_ = cmd.MarkFlagRequired("date")
@@ -177,10 +199,13 @@ func newTradeAlertsCommand() *cobra.Command {
 
 func newTradeClusterAlertsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "cluster-alerts",
-		Short:   "Query trade cluster alerts for a date",
-		Example: "volumeleaders-agent trade cluster-alerts --date 2025-01-15",
-		RunE:    runTradeClusterAlerts,
+		Use:        "cluster-alerts",
+		Short:      "Query trade cluster alerts for a date",
+		Long:       "Query trade cluster alerts fired on a specific date based on saved alert configurations that target cluster activity. Requires --date. Returns cluster alert records matching your configured filters.",
+		Example:    "volumeleaders-agent trade cluster-alerts --date 2025-01-15",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"clusteralerts", "cluster-alert"},
+		RunE:       runTradeClusterAlerts,
 	}
 	cmd.Flags().String("date", "", "Date YYYY-MM-DD")
 	_ = cmd.MarkFlagRequired("date")
@@ -191,10 +216,13 @@ func newTradeClusterAlertsCommand() *cobra.Command {
 
 func newTradeLevelsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "levels [ticker]",
-		Short:   "Query significant price levels for a ticker",
-		Example: "volumeleaders-agent trade levels AAPL",
-		RunE:    runTradeLevels,
+		Use:        "levels [ticker]",
+		Short:      "Query significant price levels for a ticker",
+		Long:       "Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Do not add cobra.MaximumNArgs(1) here; SingleTickerValue in RunE provides the validation with a better error message.",
+		Example:    "volumeleaders-agent trade levels AAPL",
+		Args:       cobra.ArbitraryArgs,
+		SuggestFor: []string{"level", "lvels"},
+		RunE:       runTradeLevels,
 	}
 	common.AddOptionalDateRangeFlags(cmd)
 	addTradeRangeFlags(cmd, 500000)
@@ -210,10 +238,13 @@ func newTradeLevelsCommand() *cobra.Command {
 
 func newTradeLevelTouchesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "level-touches [ticker]",
-		Short:   "Query trade events at notable price levels",
-		Example: "volumeleaders-agent trade level-touches AAPL --days 14",
-		RunE:    runTradeLevelTouches,
+		Use:        "level-touches [ticker]",
+		Short:      "Query trade events at notable price levels",
+		Long:       "Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).",
+		Example:    "volumeleaders-agent trade level-touches AAPL --days 14",
+		Args:       cobra.ArbitraryArgs,
+		SuggestFor: []string{"leveltouches", "level-touch"},
+		RunE:       runTradeLevelTouches,
 	}
 	common.AddDateRangeFlags(cmd)
 	addTradeRangeFlags(cmd, 500000)

--- a/internal/cli/volume/volume.go
+++ b/internal/cli/volume/volume.go
@@ -11,8 +11,9 @@ import (
 // NewVolumeCommand returns the "volume" command group with all subcommands.
 func NewVolumeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "volume",
-		Short: "Volume leaderboard commands",
+		Use:      "volume",
+		Short:    "Volume leaderboard commands",
+		GroupID:  "volume",
 	}
 	cmd.AddCommand(
 		newInstitutionalCmd(),

--- a/internal/cli/volume/volume.go
+++ b/internal/cli/volume/volume.go
@@ -14,6 +14,8 @@ func NewVolumeCommand() *cobra.Command {
 		Use:      "volume",
 		Short:    "Volume leaderboard commands",
 		GroupID:  "volume",
+		Args:     cobra.NoArgs,
+		Long:     "volume contains subcommands for querying volume leaderboard data from VolumeLeaders, showing tickers ranked by institutional trade volume. Filter by date and optional ticker list. All subcommands output compact JSON or CSV/TSV with --format.",
 	}
 	cmd.AddCommand(
 		newInstitutionalCmd(),
@@ -26,9 +28,12 @@ func NewVolumeCommand() *cobra.Command {
 // newInstitutionalCmd returns the "institutional" subcommand.
 func newInstitutionalCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "institutional",
-		Short:   "Query institutional volume leaderboard",
-		Example: "volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15",
+		Use:       "institutional [tickers...]",
+		Short:     "Query institutional volume leaderboard",
+		Long:      "Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format.",
+		Example:   "volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15",
+		Args:      cobra.ArbitraryArgs,
+		SuggestFor: []string{"inst", "insitutional"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVolume(cmd,
 				"/InstitutionalVolume/GetInstitutionalVolume",
@@ -42,9 +47,12 @@ func newInstitutionalCmd() *cobra.Command {
 // newAHInstitutionalCmd returns the "ah-institutional" subcommand.
 func newAHInstitutionalCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "ah-institutional",
-		Short:   "Query after-hours institutional volume leaderboard",
-		Example: "volumeleaders-agent volume ah-institutional --date 2025-01-15",
+		Use:       "ah-institutional [tickers...]",
+		Short:     "Query after-hours institutional volume leaderboard",
+		Long:      "Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.",
+		Example:   "volumeleaders-agent volume ah-institutional --date 2025-01-15",
+		Args:      cobra.ArbitraryArgs,
+		SuggestFor: []string{"ah", "afterhours"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVolume(cmd,
 				"/AHInstitutionalVolume/GetAHInstitutionalVolume",
@@ -58,9 +66,12 @@ func newAHInstitutionalCmd() *cobra.Command {
 // newTotalCmd returns the "total" subcommand.
 func newTotalCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "total",
-		Short:   "Query total volume leaderboard",
-		Example: "volumeleaders-agent volume total XLE --date 2025-01-15 --length 20",
+		Use:       "total [tickers...]",
+		Short:     "Query total volume leaderboard",
+		Long:      "Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.",
+		Example:   "volumeleaders-agent volume total XLE --date 2025-01-15 --length 20",
+		Args:      cobra.ArbitraryArgs,
+		SuggestFor: []string{"totl", "all"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVolume(cmd,
 				"/TotalVolume/GetTotalVolume",

--- a/internal/cli/watchlist/watchlist.go
+++ b/internal/cli/watchlist/watchlist.go
@@ -16,8 +16,9 @@ import (
 // NewCmd returns the "watchlist" command group with all subcommands.
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "watchlist",
-		Short: "Watch list commands",
+		Use:      "watchlist",
+		Short:    "Watch list commands",
+		GroupID:  "watchlists",
 	}
 	cmd.AddCommand(
 		newConfigsCmd(),

--- a/internal/cli/watchlist/watchlist.go
+++ b/internal/cli/watchlist/watchlist.go
@@ -16,9 +16,11 @@ import (
 // NewCmd returns the "watchlist" command group with all subcommands.
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:      "watchlist",
-		Short:    "Watch list commands",
-		GroupID:  "watchlists",
+		Use:     "watchlist",
+		Short:   "Watch list commands",
+		Long:    "watchlist contains subcommands for managing saved watchlist configurations that group and track ticker symbols for use in trade filtering. Use create to define new watchlists, edit to update them, delete to remove them, configs to list all watchlists, and tickers to view the symbols in a watchlist.",
+		GroupID: "watchlists",
+		Args:    cobra.NoArgs,
 	}
 	cmd.AddCommand(
 		newConfigsCmd(),
@@ -34,9 +36,13 @@ func NewCmd() *cobra.Command {
 // newConfigsCmd returns the "configs" subcommand.
 func newConfigsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "configs",
-		Short:   "List saved watch list configurations",
-		Example: "volumeleaders-agent watchlist configs",
+		Use:        "configs",
+		Short:      "List saved watch list configurations",
+		Long:       "List all saved watchlist configurations with their keys and names. Outputs compact JSON or CSV/TSV with --format. Each row shows the watchlist key and name; use the tickers subcommand to view symbols in a specific watchlist.",
+		Example:    "volumeleaders-agent watchlist configs",
+		Args:       cobra.NoArgs,
+		Aliases:    []string{"ls"},
+		SuggestFor: []string{"config", "cfg"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			format, _ := cmd.Flags().GetString("format")
 			opts := common.DataTableOptions{
@@ -62,9 +68,12 @@ func newConfigsCmd() *cobra.Command {
 // newTickersCmd returns the "tickers" subcommand.
 func newTickersCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "tickers",
-		Short:   "Query tickers for a selected watch list",
-		Example: "volumeleaders-agent watchlist tickers --watchlist-key 1",
+		Use:        "tickers",
+		Short:      "Query tickers for a selected watch list",
+		Long:       "Query the ticker symbols belonging to a specific watchlist identified by --watchlist-key. Returns all tickers in the watchlist with their metadata. Outputs compact JSON or CSV/TSV with --format.",
+		Example:    "volumeleaders-agent watchlist tickers --watchlist-key 1",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"ticker", "tkrs"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			watchlistKey, _ := cmd.Flags().GetInt("watchlist-key")
 			format, _ := cmd.Flags().GetString("format")
@@ -95,9 +104,13 @@ func newTickersCmd() *cobra.Command {
 // newDeleteCmd returns the "delete" subcommand.
 func newDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "delete",
-		Short:   "Delete a watch list configuration",
-		Example: "volumeleaders-agent watchlist delete --key 1",
+		Use:        "delete",
+		Short:      "Delete a watch list configuration",
+		Long:       "Remove a saved watchlist configuration by its numeric key. Requires --key with the watchlist key (visible in configs output). The deletion is permanent and removes the watchlist and all its tickers.",
+		Example:    "volumeleaders-agent watchlist delete --key 1",
+		Args:       cobra.NoArgs,
+		Aliases:    []string{"rm"},
+		SuggestFor: []string{"del", "remove"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key, _ := cmd.Flags().GetInt("key")
 			ctx := cmd.Context()
@@ -125,9 +138,12 @@ func newDeleteCmd() *cobra.Command {
 // newAddTickerCmd returns the "add-ticker" subcommand.
 func newAddTickerCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add-ticker",
-		Short:   "Add a ticker to an existing watch list",
-		Example: "volumeleaders-agent watchlist add-ticker --watchlist-key 1 --ticker NVDA",
+		Use:        "add-ticker",
+		Short:      "Add a ticker to an existing watch list",
+		Long:       "Add a ticker symbol to an existing watchlist. Requires --watchlist-key with the watchlist key and --ticker with the symbol to add. The ticker is appended to the watchlist without affecting existing symbols.",
+		Example:    "volumeleaders-agent watchlist add-ticker --watchlist-key 1 --ticker NVDA",
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"addticker", "add-tkr"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			watchlistKey, _ := cmd.Flags().GetInt("watchlist-key")
 			ticker, _ := cmd.Flags().GetString("ticker")
@@ -163,8 +179,12 @@ func newCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new watch list configuration",
+		Long:  "Create a new watchlist configuration with a name and optional filter settings such as minimum volume, price range, sector, and trade conditions. Requires --name. Use --tickers to specify an explicit ticker list or leave unset for a filter-based watchlist.",
 		Example: `volumeleaders-agent watchlist create --name "Tech stocks" --tickers AAPL,MSFT,GOOGL
 volumeleaders-agent watchlist create --name "Large caps" --security-type 1 --min-dollars 10000000`,
+		Args:       cobra.NoArgs,
+		Aliases:    []string{"new"},
+		SuggestFor: []string{"crate", "creat"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCreateEdit(cmd, 0)
 		},
@@ -177,9 +197,12 @@ volumeleaders-agent watchlist create --name "Large caps" --security-type 1 --min
 // newEditCmd returns the "edit" subcommand.
 func newEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "edit",
-		Short:   "Edit an existing watch list configuration",
-		Example: `volumeleaders-agent watchlist edit --key 1 --name "Updated watchlist" --tickers AAPL,MSFT`,
+		Use:        "edit",
+		Short:      "Edit an existing watch list configuration",
+		Long:       "Modify an existing watchlist configuration identified by its numeric key. Requires --key with the watchlist key. Specify only the fields you want to change; unspecified fields retain their current values.",
+		Example:    `volumeleaders-agent watchlist edit --key 1 --name "Updated watchlist" --tickers AAPL,MSFT`,
+		Args:       cobra.NoArgs,
+		SuggestFor: []string{"edt", "modify"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key, _ := cmd.Flags().GetInt("key")
 			return runCreateEdit(cmd, key)


### PR DESCRIPTION
## Summary

Add 6 Cobra best-practice features to all 32 commands (root + 5 group parents + 26 subcommands) as groundwork for future structcli 0.17.0 adoption.

**Features added:**
- `Args` validators on all 32 commands (`cobra.NoArgs` on 24, `cobra.ArbitraryArgs` on 8 ticker-accepting commands)
- `TraverseChildren = true` on root (structcli prerequisite, allows `--pretty trade list` flag ordering)
- `AddGroup()` on root with 5 command families, `GroupID` on all group parents (grouped `--help` output)
- `Long` descriptions on all 32 commands (2-4 sentences, no Markdown)
- `Aliases` on action-verb subcommands: `ls` (list/configs), `rm` (delete), `new` (create)
- `SuggestFor` typo hints on all 26 subcommands (2-3 entries each)

**What didn't change:**
- No RunE logic modified
- No flag validators moved (validateTradeRequestLength, validateTradeLevelCount, validateTradeLevelTouchesLength stay in RunE)
- No `cobra.MaximumNArgs(1)` on levels/level-touches (SingleTickerValue provides better error messages)
- No Example fields touched (26 commands already had them)
- No help template customization

**Testing:**
- 8 new structural tests in `root_test.go` covering Args, groups, aliases, Long descriptions, and alias conflict detection
- All existing tests pass, `make lint` clean, `make build` clean
- Live data fetching verified across all 5 command groups