### PR TITLE
feat(cli): add structcli help topics

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/helptopics"
 	"github.com/spf13/cobra"
 
 	"github.com/major/volumeleaders-agent/internal/cli/alert"
@@ -117,6 +118,7 @@ func SetupCLI(cmd *cobra.Command) {
 		cmd,
 		structcli.WithAppName("volumeleaders-agent"),
 		structcli.WithJSONSchema(),
+		structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
 		structcli.WithFlagErrors(),
 	); err != nil {
 		panic(fmt.Sprintf("structcli.Setup: %v", err))

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -380,6 +380,52 @@ func TestJSONSchemaSubcommandProducesValidJSON(t *testing.T) {
 	}
 }
 
+func TestHelpTopicsAreAvailableAsReferenceCommands(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	helpOut, err := exec.Command(binary, "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("--help failed: %v\nOutput: %s", err, helpOut)
+	}
+	helpText := string(helpOut)
+	for _, expected := range []string{"Reference:", "config-keys List all configuration file keys", "env-vars    List all environment variable bindings"} {
+		if !strings.Contains(helpText, expected) {
+			t.Errorf("--help missing %q\nOutput: %s", expected, helpText)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		contains string
+	}{
+		{
+			name:     "environment variables topic",
+			args:     []string{"env-vars"},
+			contains: "Environment Variables",
+		},
+		{
+			name:     "configuration keys topic",
+			args:     []string{"config-keys"},
+			contains: "Configuration Keys",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, cmdErr := exec.Command(binary, tc.args...).CombinedOutput()
+			if cmdErr != nil {
+				t.Fatalf("%v failed: %v\nOutput: %s", tc.args, cmdErr, out)
+			}
+			if !strings.Contains(string(out), tc.contains) {
+				t.Errorf("%v output missing %q\nOutput: %s", tc.args, tc.contains, out)
+			}
+		})
+	}
+}
+
 func TestStructuredErrorExitCodes(t *testing.T) {
 	t.Parallel()
 	binary := buildBinary(t)


### PR DESCRIPTION
## Summary
- Add structcli help-topic commands under a root `Reference:` section.
- Cover `env-vars` and `config-keys` with root command tests so the reference commands stay discoverable and executable.

## Tests
- `go test ./internal/cli -run 'Test(HelpTopicsAreAvailableAsReferenceCommands|JSONSchema|StructuredError)'`
- `go test ./...`
- `make build`