### PR TITLE
Add structcli enum validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ make install    # Install to $GOPATH/bin
 - Boolean/toggle filters use integers: `-1` = all/unfiltered, `0` = exclude, `1` = include/only.
 - Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results except for capped trade retrieval endpoints. `trade list`, including `--summary`, defaults to `--length 10` and only allows `--length` values from 1 to 50 because the VolumeLeaders backend cannot safely retrieve more than 50 individual trades per request. `trade levels` caps `--trade-level-count` at 50, and `trade level-touches` only allows `--length` values from 1 to 50.
 - The binary name is `volumeleaders-agent`.
+- structcli environment-variable and config-file features are intentionally out of scope for this project. Do not add or recommend `flagenv`, `flagenv:"only"`, `structcli.WithConfig`, `--config`, YAML/JSON/TOML config loading, or environment-variable driven CLI defaults unless this guidance is explicitly changed later.
 
 ## Review guidelines
 

--- a/internal/cli/alert/alert.go
+++ b/internal/cli/alert/alert.go
@@ -15,8 +15,8 @@ import (
 
 // alertConfigsOptions holds flags for the "alert configs" subcommand.
 type alertConfigsOptions struct {
-	Format string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
-	Fields string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
+	Format common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	Fields string              `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
 }
 
 // alertDeleteOptions holds flags for the "alert delete" subcommand.

--- a/internal/cli/common/datatables.go
+++ b/internal/cli/common/datatables.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RunDataTablesCommand is the shared handler for DataTables-backed commands.
-func RunDataTablesCommand[T any](cmd *cobra.Command, path string, columns []string, opts DataTableOptions, formatValue, label string) error {
+func RunDataTablesCommand[T any](cmd *cobra.Command, path string, columns []string, opts DataTableOptions, formatValue OutputFormat, label string) error {
 	format, err := ParseOutputFormat(formatValue)
 	if err != nil {
 		return err
@@ -37,7 +37,7 @@ func RunDataTablesCommand[T any](cmd *cobra.Command, path string, columns []stri
 
 // RunDataTablesSingleRequestCommand sends exactly one DataTables request, even
 // when opts.Length is -1.
-func RunDataTablesSingleRequestCommand[T any](cmd *cobra.Command, path string, columns []string, opts DataTableOptions, formatValue, label string) error {
+func RunDataTablesSingleRequestCommand[T any](cmd *cobra.Command, path string, columns []string, opts DataTableOptions, formatValue OutputFormat, label string) error {
 	format, err := ParseOutputFormat(formatValue)
 	if err != nil {
 		return err
@@ -89,5 +89,5 @@ func RunPaginatedCommand[T any](ctx context.Context, vlClient *client.Client, w 
 
 // NewDataTablesRequest builds the common DataTables request shape.
 func NewDataTablesRequest(columns []string, opts DataTableOptions) datatables.Request {
-	return datatables.Request{Columns: columns, Start: opts.Start, Length: opts.Length, OrderColumnIndex: opts.OrderCol, OrderDirection: opts.OrderDir, CustomFilters: opts.Filters, Draw: 1}
+	return datatables.Request{Columns: columns, Start: opts.Start, Length: opts.Length, OrderColumnIndex: opts.OrderCol, OrderDirection: string(opts.OrderDir), CustomFilters: opts.Filters, Draw: 1}
 }

--- a/internal/cli/common/flags_test.go
+++ b/internal/cli/common/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/major/volumeleaders-agent/internal/cli"
+	"github.com/major/volumeleaders-agent/internal/cli/testutil"
 )
 
 // flagSpec describes the expected name, type, and default value for a CLI flag
@@ -118,4 +119,40 @@ func TestAlertCreateFlagRegistration(t *testing.T) {
 		{"trade-rank-lte", "int", "0"},
 		{"trade-dollars-gte", "int", "0"},
 	})
+}
+
+// TestEnumFlagValidation verifies structcli rejects invalid bounded values
+// during flag parsing, before command handlers can perform API requests.
+func TestEnumFlagValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "format",
+			args:    []string{"alert", "configs", "--format", "table"},
+			wantErr: `invalid value "table"`,
+		},
+		{
+			name:    "order-dir",
+			args:    []string{"volume", "institutional", "--date", "2025-01-15", "--order-dir", "sideways"},
+			wantErr: `invalid value "sideways"`,
+		},
+		{
+			name:    "group-by",
+			args:    []string{"trade", "list", "--summary", "--group-by", "sector"},
+			wantErr: `invalid value "sector"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := testutil.ExecuteCommand(t, cli.NewRootCmd("test"), t.Context(), tt.args...)
+			testutil.AssertErrContains(t, err, tt.wantErr)
+		})
+	}
 }

--- a/internal/cli/common/format.go
+++ b/internal/cli/common/format.go
@@ -105,8 +105,8 @@ func JSONFieldNamesInOrder[T any]() []string {
 }
 
 // ParseOutputFormat normalizes and validates a command output format value.
-func ParseOutputFormat(value string) (OutputFormat, error) {
-	format := OutputFormat(strings.ToLower(strings.TrimSpace(value)))
+func ParseOutputFormat[T ~string](value T) (OutputFormat, error) {
+	format := OutputFormat(strings.ToLower(strings.TrimSpace(string(value))))
 	if format == "" {
 		return OutputFormatJSON, nil
 	}
@@ -115,6 +115,6 @@ func ParseOutputFormat(value string) (OutputFormat, error) {
 	case OutputFormatJSON, OutputFormatCSV, OutputFormatTSV:
 		return format, nil
 	default:
-		return "", fmt.Errorf("invalid format %q; valid formats: json,csv,tsv", value)
+		return "", fmt.Errorf("invalid format %q; valid formats: json,csv,tsv", string(value))
 	}
 }

--- a/internal/cli/common/types.go
+++ b/internal/cli/common/types.go
@@ -1,5 +1,19 @@
 package common
 
+import "github.com/leodido/structcli"
+
+func init() {
+	structcli.RegisterEnum[OutputFormat](map[OutputFormat][]string{
+		OutputFormatJSON: {"json"},
+		OutputFormatCSV:  {"csv"},
+		OutputFormatTSV:  {"tsv"},
+	})
+	structcli.RegisterEnum[OrderDirection](map[OrderDirection][]string{
+		OrderDirectionASC:  {"asc"},
+		OrderDirectionDESC: {"desc"},
+	})
+}
+
 // ContextKey identifies values stored in command contexts.
 type ContextKey int
 
@@ -22,12 +36,22 @@ const (
 	OutputFormatTSV OutputFormat = "tsv"
 )
 
+// OrderDirection identifies the supported DataTables sort directions.
+type OrderDirection string
+
+const (
+	// OrderDirectionASC sorts results in ascending order.
+	OrderDirectionASC OrderDirection = "asc"
+	// OrderDirectionDESC sorts results in descending order.
+	OrderDirectionDESC OrderDirection = "desc"
+)
+
 // DataTableOptions carries common DataTables request options.
 type DataTableOptions struct {
 	Start    int
 	Length   int
 	OrderCol int
-	OrderDir string
+	OrderDir OrderDirection
 	Filters  map[string]string
 	Fields   []string
 }

--- a/internal/cli/market/market.go
+++ b/internal/cli/market/market.go
@@ -24,11 +24,11 @@ var marketEarningsDefaultFields = []string{
 
 // earningsOptions holds flags for the "market earnings" subcommand.
 type earningsOptions struct {
-	StartDate string `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
-	EndDate   string `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`
-	Days      int    `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today"`
-	Format    string `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv" default:"json"`
-	Fields    string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
+	StartDate string              `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
+	EndDate   string              `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`
+	Days      int                 `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today"`
+	Format    common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv" default:"json"`
+	Fields    string              `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
 }
 
 // exhaustionOptions holds flags for the "market exhaustion" subcommand.

--- a/internal/cli/trade/presets.go
+++ b/internal/cli/trade/presets.go
@@ -21,7 +21,7 @@ type tradePreset struct {
 }
 
 type tradePresetsOptions struct {
-	Format string `flag:"format" flagdescr:"Output format: json, csv, or tsv"`
+	Format common.OutputFormat `flag:"format" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 type tradePresetTickersOptions struct {

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -25,6 +25,14 @@ const (
 	tradeListTickerLookbackDays = 365
 )
 
+func init() {
+	structcli.RegisterEnum[tradeSummaryGroup](map[tradeSummaryGroup][]string{
+		tradeSummaryGroupTicker:    {"ticker"},
+		tradeSummaryGroupDay:       {"day"},
+		tradeSummaryGroupTickerDay: {"ticker,day", "ticker, day", "ticker day", "ticker-day"},
+	})
+}
+
 var tradeClusterDefaultFields = []string{
 	"Date",
 	"Ticker",
@@ -111,14 +119,14 @@ type tradeFilterFlags struct {
 }
 
 type tradePaginationFlags struct {
-	Start    int    `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
-	Length   int    `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
-	OrderCol int    `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
-	OrderDir string `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
+	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
+	Length   int                   `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
+	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
+	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
 }
 
 type tradeFormatFlag struct {
-	Format string `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv"`
+	Format common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 type tradeTickersFlag struct {
@@ -134,12 +142,12 @@ type tradeListOptions struct {
 	tradeOptionalDateRangeFlags
 	tradeRangeFlags
 	tradeFilterFlags
-	Sector    string `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
-	Preset    string `flag:"preset" flaggroup:"Input" flagdescr:"Apply a built-in filter preset (see: trade presets)"`
-	Watchlist string `flag:"watchlist" flaggroup:"Input" flagdescr:"Apply filters from a saved watchlist by name"`
-	Fields    string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated trade fields to include in output"`
-	Summary   bool   `flag:"summary" flaggroup:"Output" flagdescr:"Return aggregate metrics instead of individual trades"`
-	GroupBy   string `flag:"group-by" flaggroup:"Output" flagdescr:"Summary grouping (requires --summary): ticker, day, or ticker,day"`
+	Sector    string            `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
+	Preset    string            `flag:"preset" flaggroup:"Input" flagdescr:"Apply a built-in filter preset (see: trade presets)"`
+	Watchlist string            `flag:"watchlist" flaggroup:"Input" flagdescr:"Apply filters from a saved watchlist by name"`
+	Fields    string            `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated trade fields to include in output"`
+	Summary   bool              `flag:"summary" flaggroup:"Output" flagdescr:"Return aggregate metrics instead of individual trades"`
+	GroupBy   tradeSummaryGroup `flag:"group-by" flaggroup:"Output" flagdescr:"Summary grouping (requires --summary): ticker, day, or ticker,day"`
 	tradeFormatFlag
 	tradePaginationFlags
 }
@@ -676,7 +684,7 @@ func runTradeListRows(cmd *cobra.Command, opts common.DataTableOptions) error {
 	return common.PrintJSON(cmd.OutOrStdout(), ctx, models.NewTradeListRows(result))
 }
 
-func runTradeSummary(cmd *cobra.Command, opts common.DataTableOptions, groupBy, startDate, endDate string) error {
+func runTradeSummary(cmd *cobra.Command, opts common.DataTableOptions, groupBy tradeSummaryGroup, startDate, endDate string) error {
 	group, err := parseTradeSummaryGroup(groupBy)
 	if err != nil {
 		return err
@@ -711,8 +719,8 @@ const (
 	tradeSummaryGroupTickerDay tradeSummaryGroup = "ticker,day"
 )
 
-func parseTradeSummaryGroup(value string) (tradeSummaryGroup, error) {
-	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), " ", ""))
+func parseTradeSummaryGroup(value tradeSummaryGroup) (tradeSummaryGroup, error) {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(string(value)), " ", ""))
 	switch tradeSummaryGroup(normalized) {
 	case tradeSummaryGroupTicker, tradeSummaryGroupDay, tradeSummaryGroupTickerDay:
 		return tradeSummaryGroup(normalized), nil

--- a/internal/cli/volume/volume.go
+++ b/internal/cli/volume/volume.go
@@ -13,13 +13,13 @@ import (
 
 // volumeOptions holds flags shared by all volume subcommands.
 type volumeOptions struct {
-	Date     string `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD" flagrequired:"true"`
-	Tickers  string `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols"`
-	Format   string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
-	Start    int    `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
-	Length   int    `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
-	OrderCol int    `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
-	OrderDir string `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
+	Date     string                `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD" flagrequired:"true"`
+	Tickers  string                `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols"`
+	Format   common.OutputFormat   `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
+	Length   int                   `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
+	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
+	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
 }
 
 // NewVolumeCommand returns the "volume" command group with all subcommands.

--- a/internal/cli/watchlist/watchlist.go
+++ b/internal/cli/watchlist/watchlist.go
@@ -16,13 +16,13 @@ import (
 
 // watchlistConfigsOptions holds flags for the "watchlist configs" subcommand.
 type watchlistConfigsOptions struct {
-	Format string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	Format common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 // watchlistTickersOptions holds flags for the "watchlist tickers" subcommand.
 type watchlistTickersOptions struct {
-	WatchlistKey int    `flag:"watchlist-key" flaggroup:"Input" flagshort:"k" flagdescr:"Watch list key (-1 for all)"`
-	Format       string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	WatchlistKey int                 `flag:"watchlist-key" flaggroup:"Input" flagshort:"k" flagdescr:"Watch list key (-1 for all)"`
+	Format       common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 // watchlistDeleteOptions holds flags for the "watchlist delete" subcommand.


### PR DESCRIPTION
## Summary

- Register structcli enums for bounded CLI values: output format, DataTables order direction, and trade summary grouping.
- Switch related option fields to typed string enums so invalid values are rejected during flag parsing and exposed in JSON schema.
- Document that structcli env-var and config-file features are out of scope for this project.

## Verification

- LSP diagnostics clean for touched Go packages.
- `make test`
- `make lint`
- `make build`
- `./volumeleaders-agent --jsonschema=tree` enum probe for `format`, `order-dir`, and `group-by`
- Five-agent post-implementation review passed.
- Live smoke sample passed across market, volume, trade, watchlist, and alert commands.