### PR TITLE
Group structcli help flags

### DIFF
--- a/internal/cli/alert/alert.go
+++ b/internal/cli/alert/alert.go
@@ -15,47 +15,47 @@ import (
 
 // alertConfigsOptions holds flags for the "alert configs" subcommand.
 type alertConfigsOptions struct {
-	Format string `flag:"format" default:"json" flagdescr:"Output format: json, csv, or tsv"`
-	Fields string `flag:"fields" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
+	Format string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	Fields string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
 }
 
 // alertDeleteOptions holds flags for the "alert delete" subcommand.
 type alertDeleteOptions struct {
-	Key int `flag:"key" flagrequired:"true" flagdescr:"Alert config key to delete"`
+	Key int `flag:"key" flaggroup:"Input" flagshort:"k" flagrequired:"true" flagdescr:"Alert config key to delete"`
 }
 
 // alertConfigFlags holds the shared flag set for alert create/edit commands.
 type alertConfigFlags struct {
-	Name                   string `flag:"name" flagdescr:"Alert name (max 50 chars)"`
-	TickerGroup            string `flag:"ticker-group" flagdescr:"Ticker group (AllTickers or SelectedTickers)"`
-	Tickers                string `flag:"tickers" flagdescr:"Comma-separated ticker symbols (max 500, used with SelectedTickers)"`
-	TradeRankLTE           int    `flag:"trade-rank-lte" flagdescr:"Trade rank <= (0=N/A, 1/3/5/10/25/50/100)"`
-	TradeVCDGTE            int    `flag:"trade-vcd-gte" flagdescr:"Trade VCD >= (0=N/A, 99/100)"`
-	TradeMultGTE           int    `flag:"trade-mult-gte" flagdescr:"Trade multiplier >= (0=N/A, 5/10/25/50/100)"`
-	TradeVolumeGTE         int    `flag:"trade-volume-gte" flagdescr:"Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000)"`
-	TradeDollarsGTE        int    `flag:"trade-dollars-gte" flagdescr:"Trade dollars >= (0=N/A, 1000000/10000000/...)"`
-	TradeConditions        string `flag:"trade-conditions" flagdescr:"Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos)"`
-	DarkPool               bool   `flag:"dark-pool" flagdescr:"Dark pool filter"`
-	Sweep                  bool   `flag:"sweep" flagdescr:"Sweep filter"`
-	ClosingTradeRankLTE    int    `flag:"closing-trade-rank-lte" flagdescr:"Closing trade rank <="`
-	ClosingTradeVCDGTE     int    `flag:"closing-trade-vcd-gte" flagdescr:"Closing trade VCD >= (0/97/98/99/100)"`
-	ClosingTradeMultGTE    int    `flag:"closing-trade-mult-gte" flagdescr:"Closing trade multiplier >="`
-	ClosingTradeVolumeGTE  int    `flag:"closing-trade-volume-gte" flagdescr:"Closing trade volume >="`
-	ClosingTradeDollarsGTE int    `flag:"closing-trade-dollars-gte" flagdescr:"Closing trade dollars >="`
-	ClosingTradeConditions string `flag:"closing-trade-conditions" flagdescr:"Closing trade conditions"`
-	ClusterRankLTE         int    `flag:"cluster-rank-lte" flagdescr:"Trade cluster rank <="`
-	ClusterVCDGTE          int    `flag:"cluster-vcd-gte" flagdescr:"Trade cluster VCD >= (0/97/98/99/100)"`
-	ClusterMultGTE         int    `flag:"cluster-mult-gte" flagdescr:"Trade cluster multiplier >="`
-	ClusterVolumeGTE       int    `flag:"cluster-volume-gte" flagdescr:"Trade cluster volume >="`
-	ClusterDollarsGTE      int    `flag:"cluster-dollars-gte" flagdescr:"Trade cluster dollars >="`
-	TotalRankLTE           int    `flag:"total-rank-lte" flagdescr:"Total rank <= (0/1/3/10/25/50/100)"`
-	TotalVolumeGTE         int    `flag:"total-volume-gte" flagdescr:"Total volume >="`
-	TotalDollarsGTE        int    `flag:"total-dollars-gte" flagdescr:"Total dollars >="`
-	AHRankLTE              int    `flag:"ah-rank-lte" flagdescr:"After-hours rank <="`
-	AHVolumeGTE            int    `flag:"ah-volume-gte" flagdescr:"After-hours volume >="`
-	AHDollarsGTE           int    `flag:"ah-dollars-gte" flagdescr:"After-hours dollars >="`
-	OffsettingPrint        bool   `flag:"offsetting-print" flagdescr:"Offsetting print filter"`
-	PhantomPrint           bool   `flag:"phantom-print" flagdescr:"Phantom print filter"`
+	Name                   string `flag:"name" flaggroup:"Basic" flagdescr:"Alert name (max 50 chars)"`
+	TickerGroup            string `flag:"ticker-group" flaggroup:"Basic" flagdescr:"Ticker group (AllTickers or SelectedTickers)"`
+	Tickers                string `flag:"tickers" flaggroup:"Basic" flagshort:"t" flagdescr:"Comma-separated ticker symbols (max 500, used with SelectedTickers)"`
+	TradeRankLTE           int    `flag:"trade-rank-lte" flaggroup:"Trade Filters" flagdescr:"Trade rank <= (0=N/A, 1/3/5/10/25/50/100)"`
+	TradeVCDGTE            int    `flag:"trade-vcd-gte" flaggroup:"Trade Filters" flagdescr:"Trade VCD >= (0=N/A, 99/100)"`
+	TradeMultGTE           int    `flag:"trade-mult-gte" flaggroup:"Trade Filters" flagdescr:"Trade multiplier >= (0=N/A, 5/10/25/50/100)"`
+	TradeVolumeGTE         int    `flag:"trade-volume-gte" flaggroup:"Trade Filters" flagdescr:"Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000)"`
+	TradeDollarsGTE        int    `flag:"trade-dollars-gte" flaggroup:"Trade Filters" flagdescr:"Trade dollars >= (0=N/A, 1000000/10000000/...)"`
+	TradeConditions        string `flag:"trade-conditions" flaggroup:"Trade Filters" flagdescr:"Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos)"`
+	DarkPool               bool   `flag:"dark-pool" flaggroup:"Trade Filters" flagdescr:"Dark pool filter"`
+	Sweep                  bool   `flag:"sweep" flaggroup:"Trade Filters" flagdescr:"Sweep filter"`
+	ClosingTradeRankLTE    int    `flag:"closing-trade-rank-lte" flaggroup:"Closing Filters" flagdescr:"Closing trade rank <="`
+	ClosingTradeVCDGTE     int    `flag:"closing-trade-vcd-gte" flaggroup:"Closing Filters" flagdescr:"Closing trade VCD >= (0/97/98/99/100)"`
+	ClosingTradeMultGTE    int    `flag:"closing-trade-mult-gte" flaggroup:"Closing Filters" flagdescr:"Closing trade multiplier >="`
+	ClosingTradeVolumeGTE  int    `flag:"closing-trade-volume-gte" flaggroup:"Closing Filters" flagdescr:"Closing trade volume >="`
+	ClosingTradeDollarsGTE int    `flag:"closing-trade-dollars-gte" flaggroup:"Closing Filters" flagdescr:"Closing trade dollars >="`
+	ClosingTradeConditions string `flag:"closing-trade-conditions" flaggroup:"Closing Filters" flagdescr:"Closing trade conditions"`
+	ClusterRankLTE         int    `flag:"cluster-rank-lte" flaggroup:"Cluster Filters" flagdescr:"Trade cluster rank <="`
+	ClusterVCDGTE          int    `flag:"cluster-vcd-gte" flaggroup:"Cluster Filters" flagdescr:"Trade cluster VCD >= (0/97/98/99/100)"`
+	ClusterMultGTE         int    `flag:"cluster-mult-gte" flaggroup:"Cluster Filters" flagdescr:"Trade cluster multiplier >="`
+	ClusterVolumeGTE       int    `flag:"cluster-volume-gte" flaggroup:"Cluster Filters" flagdescr:"Trade cluster volume >="`
+	ClusterDollarsGTE      int    `flag:"cluster-dollars-gte" flaggroup:"Cluster Filters" flagdescr:"Trade cluster dollars >="`
+	TotalRankLTE           int    `flag:"total-rank-lte" flaggroup:"Total Filters" flagdescr:"Total rank <= (0/1/3/10/25/50/100)"`
+	TotalVolumeGTE         int    `flag:"total-volume-gte" flaggroup:"Total Filters" flagdescr:"Total volume >="`
+	TotalDollarsGTE        int    `flag:"total-dollars-gte" flaggroup:"Total Filters" flagdescr:"Total dollars >="`
+	AHRankLTE              int    `flag:"ah-rank-lte" flaggroup:"After-Hours Filters" flagdescr:"After-hours rank <="`
+	AHVolumeGTE            int    `flag:"ah-volume-gte" flaggroup:"After-Hours Filters" flagdescr:"After-hours volume >="`
+	AHDollarsGTE           int    `flag:"ah-dollars-gte" flaggroup:"After-Hours Filters" flagdescr:"After-hours dollars >="`
+	OffsettingPrint        bool   `flag:"offsetting-print" flaggroup:"Trade Filters" flagdescr:"Offsetting print filter"`
+	PhantomPrint           bool   `flag:"phantom-print" flaggroup:"Trade Filters" flagdescr:"Phantom print filter"`
 }
 
 // alertCreateOptions holds flags for the "alert create" subcommand.
@@ -65,7 +65,7 @@ type alertCreateOptions struct {
 
 // alertEditOptions holds flags for the "alert edit" subcommand.
 type alertEditOptions struct {
-	Key int `flag:"key" flagrequired:"true" flagdescr:"Alert config key to edit"`
+	Key int `flag:"key" flaggroup:"Input" flagshort:"k" flagrequired:"true" flagdescr:"Alert config key to edit"`
 	alertConfigFlags
 }
 

--- a/internal/cli/market/market.go
+++ b/internal/cli/market/market.go
@@ -24,16 +24,16 @@ var marketEarningsDefaultFields = []string{
 
 // earningsOptions holds flags for the "market earnings" subcommand.
 type earningsOptions struct {
-	StartDate string `flag:"start-date" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
-	EndDate   string `flag:"end-date" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`
-	Days      int    `flag:"days" flagdescr:"Look back this many days from --end-date or today"`
-	Format    string `flag:"format" flagdescr:"Output format: json, csv, or tsv" default:"json"`
-	Fields    string `flag:"fields" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
+	StartDate string `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
+	EndDate   string `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`
+	Days      int    `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today"`
+	Format    string `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv" default:"json"`
+	Fields    string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated fields to include (use 'all' for every field)"`
 }
 
 // exhaustionOptions holds flags for the "market exhaustion" subcommand.
 type exhaustionOptions struct {
-	Date string `flag:"date" flagdescr:"Date YYYY-MM-DD (empty for current day)"`
+	Date string `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD (empty for current day)"`
 }
 
 // NewMarketCommand returns the "market" command group with all subcommands.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,7 +21,7 @@ import (
 // rootOptions holds flags bound to the root command via structcli.Bind.
 // The bind pipeline populates these fields before PersistentPreRunE fires.
 type rootOptions struct {
-	Pretty bool `flag:"pretty" flagdescr:"Pretty-print JSON output with indentation"`
+	Pretty bool `flag:"pretty" flaggroup:"Output" flagshort:"p" flagdescr:"Pretty-print JSON output with indentation"`
 }
 
 // NewRootCmd returns the root cobra command for volumeleaders-agent.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/major/volumeleaders-agent/internal/cli/common"
 	"github.com/major/volumeleaders-agent/internal/cli/testutil"
@@ -226,6 +227,32 @@ func TestNoAliasConflictsWithinParentScope(t *testing.T) {
 	})
 }
 
+func TestNoShortFlagConflictsWithinCommand(t *testing.T) {
+	t.Parallel()
+	cmd := NewRootCmd("test")
+
+	walkCommands(cmd, func(c *cobra.Command) {
+		t.Run(c.CommandPath(), func(t *testing.T) {
+			t.Parallel()
+			seen := make(map[string]string) // shorthand -> owning flag
+			check := func(flags *pflag.FlagSet) {
+				flags.VisitAll(func(flag *pflag.Flag) {
+					if flag.Shorthand == "" {
+						return
+					}
+					if owner, ok := seen[flag.Shorthand]; ok {
+						t.Fatalf("command %q has duplicate shorthand -%s on --%s and --%s", c.CommandPath(), flag.Shorthand, owner, flag.Name)
+					}
+					seen[flag.Shorthand] = flag.Name
+				})
+			}
+
+			check(c.LocalFlags())
+			check(c.InheritedFlags())
+		})
+	})
+}
+
 func TestNoArgsCommandsRejectPositionalArgs(t *testing.T) {
 	t.Parallel()
 
@@ -377,6 +404,130 @@ func TestJSONSchemaSubcommandProducesValidJSON(t *testing.T) {
 		if _, exists := props[flag]; !exists {
 			t.Errorf("trade list --jsonschema missing expected flag %q", flag)
 		}
+	}
+}
+
+func TestJSONSchemaSubcommandIncludesFlagUsabilityMetadata(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	out, err := exec.Command(binary, "trade", "list", "--jsonschema").CombinedOutput()
+	if err != nil {
+		t.Fatalf("trade list --jsonschema failed: %v\nOutput: %s", err, out)
+	}
+
+	var schema map[string]any
+	if jsonErr := json.Unmarshal(out, &schema); jsonErr != nil {
+		t.Fatalf("output is not valid JSON object: %v\nOutput: %s", jsonErr, out)
+	}
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing 'properties' key")
+	}
+
+	groupedFlags := map[string]string{
+		"tickers":    "Input",
+		"start-date": "Dates",
+		"min-volume": "Ranges",
+		"conditions": "Filters",
+		"premarket":  "Sessions",
+		"length":     "Pagination",
+		"format":     "Output",
+	}
+	for flag, expectedGroup := range groupedFlags {
+		t.Run("group "+flag, func(t *testing.T) {
+			t.Parallel()
+			flagSchema, ok := props[flag].(map[string]any)
+			if !ok {
+				t.Fatalf("flag %q schema is not an object", flag)
+			}
+			group, ok := flagSchema["x-structcli-group"].(string)
+			if !ok {
+				t.Fatalf("flag %q missing x-structcli-group", flag)
+			}
+			if group != expectedGroup {
+				t.Fatalf("flag %q group = %q, want %q", flag, group, expectedGroup)
+			}
+		})
+	}
+
+	shortFlags := map[string]string{
+		"tickers":    "t",
+		"start-date": "s",
+		"end-date":   "e",
+		"days":       "d",
+		"length":     "l",
+		"format":     "f",
+	}
+	for flag, expectedShort := range shortFlags {
+		t.Run("short "+flag, func(t *testing.T) {
+			t.Parallel()
+			flagSchema, ok := props[flag].(map[string]any)
+			if !ok {
+				t.Fatalf("flag %q schema is not an object", flag)
+			}
+			short, ok := flagSchema["x-structcli-shorthand"].(string)
+			if !ok {
+				t.Fatalf("flag %q missing x-structcli-shorthand", flag)
+			}
+			if short != expectedShort {
+				t.Fatalf("flag %q shorthand = %q, want %q", flag, short, expectedShort)
+			}
+		})
+	}
+
+	groups, ok := schema["x-structcli-groups"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing top-level x-structcli-groups map")
+	}
+	for _, expectedGroup := range []string{"Dates", "Filters", "Input", "Output", "Pagination", "Ranges", "Sessions"} {
+		if _, ok := groups[expectedGroup]; !ok {
+			t.Fatalf("schema groups missing %q: %v", expectedGroup, groups)
+		}
+	}
+}
+
+func TestHelpOutputDisplaysFlagGroups(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectedGroups []string
+	}{
+		{
+			name:           "trade list help",
+			args:           []string{"trade", "list", "--help"},
+			expectedGroups: []string{"Dates Flags:", "Filters Flags:", "Input Flags:", "Output Flags:", "Pagination Flags:", "Ranges Flags:", "Sessions Flags:"},
+		},
+		{
+			name:           "alert create help",
+			args:           []string{"alert", "create", "--help"},
+			expectedGroups: []string{"After-Hours Filters Flags:", "Basic Flags:", "Closing Filters Flags:", "Cluster Filters Flags:", "Total Filters Flags:", "Trade Filters Flags:"},
+		},
+		{
+			name:           "watchlist create help",
+			args:           []string{"watchlist", "create", "--help"},
+			expectedGroups: []string{"Basic Flags:", "Filters Flags:", "Print Types Flags:", "Ranges Flags:", "RSI Flags:", "Sessions Flags:", "Venues Flags:"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := exec.Command(binary, tc.args...).CombinedOutput()
+			if err != nil {
+				t.Fatalf("%v failed: %v\nOutput: %s", tc.args, err, out)
+			}
+			helpText := string(out)
+			for _, expected := range tc.expectedGroups {
+				if !strings.Contains(helpText, expected) {
+					t.Fatalf("help output missing %q\nOutput: %s", expected, helpText)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -61,72 +61,72 @@ type tradeLevelOptions struct {
 }
 
 type tradeDateRangeFlags struct {
-	StartDate string `flag:"start-date" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
-	EndDate   string `flag:"end-date" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`
-	Days      int    `flag:"days" flagdescr:"Look back this many days from --end-date or today"`
+	StartDate string `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
+	EndDate   string `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`
+	Days      int    `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today"`
 }
 
 type tradeOptionalDateRangeFlags struct {
-	StartDate string `flag:"start-date" flagdescr:"Start date YYYY-MM-DD (default: auto)"`
-	EndDate   string `flag:"end-date" flagdescr:"End date YYYY-MM-DD (default: today)"`
-	Days      int    `flag:"days" flagdescr:"Look back this many days from --end-date or today"`
+	StartDate string `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (default: auto)"`
+	EndDate   string `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (default: today)"`
+	Days      int    `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today"`
 }
 
 type tradeRangeFlags struct {
-	MinVolume  int     `flag:"min-volume" flagdescr:"Minimum volume"`
-	MaxVolume  int     `flag:"max-volume" flagdescr:"Maximum volume"`
-	MinPrice   float64 `flag:"min-price" flagdescr:"Minimum price"`
-	MaxPrice   float64 `flag:"max-price" flagdescr:"Maximum price"`
-	MinDollars float64 `flag:"min-dollars" flagdescr:"Minimum dollar value"`
-	MaxDollars float64 `flag:"max-dollars" flagdescr:"Maximum dollar value"`
+	MinVolume  int     `flag:"min-volume" flaggroup:"Ranges" flagdescr:"Minimum volume"`
+	MaxVolume  int     `flag:"max-volume" flaggroup:"Ranges" flagdescr:"Maximum volume"`
+	MinPrice   float64 `flag:"min-price" flaggroup:"Ranges" flagdescr:"Minimum price"`
+	MaxPrice   float64 `flag:"max-price" flaggroup:"Ranges" flagdescr:"Maximum price"`
+	MinDollars float64 `flag:"min-dollars" flaggroup:"Ranges" flagdescr:"Minimum dollar value"`
+	MaxDollars float64 `flag:"max-dollars" flaggroup:"Ranges" flagdescr:"Maximum dollar value"`
 }
 
 type tradeVolumeDollarRangeFlags struct {
-	MinVolume  int     `flag:"min-volume" flagdescr:"Minimum volume"`
-	MaxVolume  int     `flag:"max-volume" flagdescr:"Maximum volume"`
-	MinDollars float64 `flag:"min-dollars" flagdescr:"Minimum dollar value"`
-	MaxDollars float64 `flag:"max-dollars" flagdescr:"Maximum dollar value"`
+	MinVolume  int     `flag:"min-volume" flaggroup:"Ranges" flagdescr:"Minimum volume"`
+	MaxVolume  int     `flag:"max-volume" flaggroup:"Ranges" flagdescr:"Maximum volume"`
+	MinDollars float64 `flag:"min-dollars" flaggroup:"Ranges" flagdescr:"Minimum dollar value"`
+	MaxDollars float64 `flag:"max-dollars" flaggroup:"Ranges" flagdescr:"Maximum dollar value"`
 }
 
 type tradeFilterFlags struct {
-	Conditions   int `flag:"conditions" flagdescr:"Trade conditions filter"`
-	VCD          int `flag:"vcd" flagdescr:"VCD filter"`
-	SecurityType int `flag:"security-type" flagdescr:"Security type key"`
-	RelativeSize int `flag:"relative-size" flagdescr:"Relative size threshold"`
-	DarkPools    int `flag:"dark-pools" flagdescr:"Dark pool filter"`
-	Sweeps       int `flag:"sweeps" flagdescr:"Sweep filter"`
-	LatePrints   int `flag:"late-prints" flagdescr:"Late print filter"`
-	SigPrints    int `flag:"sig-prints" flagdescr:"Signature print filter"`
-	EvenShared   int `flag:"even-shared" flagdescr:"Even shared filter"`
-	TradeRank    int `flag:"trade-rank" flagdescr:"Trade rank filter"`
-	RankSnapshot int `flag:"rank-snapshot" flagdescr:"Trade rank snapshot filter"`
-	MarketCap    int `flag:"market-cap" flagdescr:"Market cap filter"`
-	Premarket    int `flag:"premarket" flagdescr:"Include premarket"`
-	RTH          int `flag:"rth" flagdescr:"Include regular trading hours"`
-	AH           int `flag:"ah" flagdescr:"Include after hours"`
-	Opening      int `flag:"opening" flagdescr:"Include opening trades"`
-	Closing      int `flag:"closing" flagdescr:"Include closing trades"`
-	Phantom      int `flag:"phantom" flagdescr:"Include phantom prints"`
-	Offsetting   int `flag:"offsetting" flagdescr:"Include offsetting trades"`
+	Conditions   int `flag:"conditions" flaggroup:"Filters" flagdescr:"Trade conditions filter"`
+	VCD          int `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
+	SecurityType int `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key"`
+	RelativeSize int `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
+	DarkPools    int `flag:"dark-pools" flaggroup:"Filters" flagdescr:"Dark pool filter"`
+	Sweeps       int `flag:"sweeps" flaggroup:"Filters" flagdescr:"Sweep filter"`
+	LatePrints   int `flag:"late-prints" flaggroup:"Filters" flagdescr:"Late print filter"`
+	SigPrints    int `flag:"sig-prints" flaggroup:"Filters" flagdescr:"Signature print filter"`
+	EvenShared   int `flag:"even-shared" flaggroup:"Filters" flagdescr:"Even shared filter"`
+	TradeRank    int `flag:"trade-rank" flaggroup:"Filters" flagdescr:"Trade rank filter"`
+	RankSnapshot int `flag:"rank-snapshot" flaggroup:"Filters" flagdescr:"Trade rank snapshot filter"`
+	MarketCap    int `flag:"market-cap" flaggroup:"Filters" flagdescr:"Market cap filter"`
+	Premarket    int `flag:"premarket" flaggroup:"Sessions" flagdescr:"Include premarket"`
+	RTH          int `flag:"rth" flaggroup:"Sessions" flagdescr:"Include regular trading hours"`
+	AH           int `flag:"ah" flaggroup:"Sessions" flagdescr:"Include after hours"`
+	Opening      int `flag:"opening" flaggroup:"Sessions" flagdescr:"Include opening trades"`
+	Closing      int `flag:"closing" flaggroup:"Sessions" flagdescr:"Include closing trades"`
+	Phantom      int `flag:"phantom" flaggroup:"Sessions" flagdescr:"Include phantom prints"`
+	Offsetting   int `flag:"offsetting" flaggroup:"Sessions" flagdescr:"Include offsetting trades"`
 }
 
 type tradePaginationFlags struct {
-	Start    int    `flag:"start" flagdescr:"DataTables start offset"`
-	Length   int    `flag:"length" flagdescr:"Number of results"`
-	OrderCol int    `flag:"order-col" flagdescr:"Order column index"`
-	OrderDir string `flag:"order-dir" flagdescr:"Order direction"`
+	Start    int    `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
+	Length   int    `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
+	OrderCol int    `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
+	OrderDir string `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
 }
 
 type tradeFormatFlag struct {
-	Format string `flag:"format" flagdescr:"Output format: json, csv, or tsv"`
+	Format string `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 type tradeTickersFlag struct {
-	Tickers string `flag:"tickers" flagdescr:"Comma-separated ticker symbols"`
+	Tickers string `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols"`
 }
 
 type tradeTickerFlag struct {
-	Ticker string `flag:"ticker" flagdescr:"Ticker symbol"`
+	Ticker string `flag:"ticker" flaggroup:"Input" flagshort:"t" flagdescr:"Ticker symbol"`
 }
 
 type tradeListOptions struct {
@@ -134,12 +134,12 @@ type tradeListOptions struct {
 	tradeOptionalDateRangeFlags
 	tradeRangeFlags
 	tradeFilterFlags
-	Sector    string `flag:"sector" flagdescr:"Sector/Industry filter"`
-	Preset    string `flag:"preset" flagdescr:"Apply a built-in filter preset (see: trade presets)"`
-	Watchlist string `flag:"watchlist" flagdescr:"Apply filters from a saved watchlist by name"`
-	Fields    string `flag:"fields" flagdescr:"Comma-separated trade fields to include in output"`
-	Summary   bool   `flag:"summary" flagdescr:"Return aggregate metrics instead of individual trades"`
-	GroupBy   string `flag:"group-by" flagdescr:"Summary grouping (requires --summary): ticker, day, or ticker,day"`
+	Sector    string `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
+	Preset    string `flag:"preset" flaggroup:"Input" flagdescr:"Apply a built-in filter preset (see: trade presets)"`
+	Watchlist string `flag:"watchlist" flaggroup:"Input" flagdescr:"Apply filters from a saved watchlist by name"`
+	Fields    string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated trade fields to include in output"`
+	Summary   bool   `flag:"summary" flaggroup:"Output" flagdescr:"Return aggregate metrics instead of individual trades"`
+	GroupBy   string `flag:"group-by" flaggroup:"Output" flagdescr:"Summary grouping (requires --summary): ticker, day, or ticker,day"`
 	tradeFormatFlag
 	tradePaginationFlags
 }
@@ -155,12 +155,12 @@ type tradeClustersOptions struct {
 	tradeTickersFlag
 	tradeDateRangeFlags
 	tradeRangeFlags
-	VCD              int    `flag:"vcd" flagdescr:"VCD filter"`
-	SecurityType     int    `flag:"security-type" flagdescr:"Security type key"`
-	RelativeSize     int    `flag:"relative-size" flagdescr:"Relative size threshold"`
-	TradeClusterRank int    `flag:"trade-cluster-rank" flagdescr:"Trade cluster rank filter"`
-	Sector           string `flag:"sector" flagdescr:"Sector/Industry filter"`
-	Fields           string `flag:"fields" flagdescr:"Comma-separated TradeCluster fields to include in output, or 'all' for every field"`
+	VCD              int    `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
+	SecurityType     int    `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key"`
+	RelativeSize     int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
+	TradeClusterRank int    `flag:"trade-cluster-rank" flaggroup:"Filters" flagdescr:"Trade cluster rank filter"`
+	Sector           string `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
+	Fields           string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated TradeCluster fields to include in output, or 'all' for every field"`
 	tradeFormatFlag
 	tradePaginationFlags
 }
@@ -169,11 +169,11 @@ type tradeClusterBombsOptions struct {
 	tradeTickersFlag
 	tradeDateRangeFlags
 	tradeVolumeDollarRangeFlags
-	VCD                  int    `flag:"vcd" flagdescr:"VCD filter"`
-	SecurityType         int    `flag:"security-type" flagdescr:"Security type key"`
-	RelativeSize         int    `flag:"relative-size" flagdescr:"Relative size threshold"`
-	TradeClusterBombRank int    `flag:"trade-cluster-bomb-rank" flagdescr:"Trade cluster bomb rank filter"`
-	Sector               string `flag:"sector" flagdescr:"Sector/Industry filter"`
+	VCD                  int    `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
+	SecurityType         int    `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key"`
+	RelativeSize         int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
+	TradeClusterBombRank int    `flag:"trade-cluster-bomb-rank" flaggroup:"Filters" flagdescr:"Trade cluster bomb rank filter"`
+	Sector               string `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
 	tradeFormatFlag
 	tradePaginationFlags
 }
@@ -182,11 +182,11 @@ type tradeLevelsOptions struct {
 	tradeTickerFlag
 	tradeOptionalDateRangeFlags
 	tradeRangeFlags
-	VCD             int    `flag:"vcd" flagdescr:"VCD filter"`
-	RelativeSize    int    `flag:"relative-size" flagdescr:"Relative size threshold"`
-	TradeLevelRank  int    `flag:"trade-level-rank" flagdescr:"Trade level rank filter"`
-	TradeLevelCount int    `flag:"trade-level-count" flagdescr:"Number of price levels to return (1-50)"`
-	Fields          string `flag:"fields" flagdescr:"Comma-separated TradeLevel fields to include in output, or 'all' for every field"`
+	VCD             int    `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
+	RelativeSize    int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
+	TradeLevelRank  int    `flag:"trade-level-rank" flaggroup:"Filters" flagdescr:"Trade level rank filter"`
+	TradeLevelCount int    `flag:"trade-level-count" flaggroup:"Output" flagdescr:"Number of price levels to return (1-50)"`
+	Fields          string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated TradeLevel fields to include in output, or 'all' for every field"`
 	tradeFormatFlag
 }
 
@@ -194,10 +194,10 @@ type tradeLevelTouchesOptions struct {
 	tradeTickerFlag
 	tradeDateRangeFlags
 	tradeRangeFlags
-	VCD             int `flag:"vcd" flagdescr:"VCD filter"`
-	RelativeSize    int `flag:"relative-size" flagdescr:"Relative size threshold"`
-	TradeLevelRank  int `flag:"trade-level-rank" flagdescr:"Trade level rank filter"`
-	TradeLevelCount int `flag:"trade-level-count" flagdescr:"Number of price levels to include (1-50)"`
+	VCD             int `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
+	RelativeSize    int `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
+	TradeLevelRank  int `flag:"trade-level-rank" flaggroup:"Filters" flagdescr:"Trade level rank filter"`
+	TradeLevelCount int `flag:"trade-level-count" flaggroup:"Output" flagdescr:"Number of price levels to include (1-50)"`
 	tradeFormatFlag
 	tradePaginationFlags
 }
@@ -227,13 +227,13 @@ func (opts *tradeLevelTouchesOptions) Validate(_ context.Context) []error {
 }
 
 type tradeAlertsOptions struct {
-	Date string `flag:"date" flagdescr:"Date YYYY-MM-DD"`
+	Date string `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD"`
 	tradeFormatFlag
 	tradePaginationFlags
 }
 
 type tradeClusterAlertsOptions struct {
-	Date string `flag:"date" flagdescr:"Date YYYY-MM-DD"`
+	Date string `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD"`
 	tradeFormatFlag
 	tradePaginationFlags
 }

--- a/internal/cli/volume/volume.go
+++ b/internal/cli/volume/volume.go
@@ -13,23 +13,23 @@ import (
 
 // volumeOptions holds flags shared by all volume subcommands.
 type volumeOptions struct {
-	Date     string `flag:"date" flagdescr:"Date YYYY-MM-DD" flagrequired:"true"`
-	Tickers  string `flag:"tickers" flagdescr:"Comma-separated ticker symbols"`
-	Format   string `flag:"format" default:"json" flagdescr:"Output format: json, csv, or tsv"`
-	Start    int    `flag:"start" flagdescr:"DataTables start offset"`
-	Length   int    `flag:"length" flagdescr:"Number of results"`
-	OrderCol int    `flag:"order-col" flagdescr:"Order column index"`
-	OrderDir string `flag:"order-dir" flagdescr:"Order direction"`
+	Date     string `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD" flagrequired:"true"`
+	Tickers  string `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols"`
+	Format   string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	Start    int    `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
+	Length   int    `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
+	OrderCol int    `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
+	OrderDir string `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
 }
 
 // NewVolumeCommand returns the "volume" command group with all subcommands.
 func NewVolumeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:      "volume",
-		Short:    "Volume leaderboard commands",
-		GroupID:  "volume",
-		Args:     cobra.NoArgs,
-		Long:     "volume contains subcommands for querying volume leaderboard data from VolumeLeaders, showing tickers ranked by institutional trade volume. Filter by date and optional ticker list. All subcommands output compact JSON or CSV/TSV with --format.",
+		Use:     "volume",
+		Short:   "Volume leaderboard commands",
+		GroupID: "volume",
+		Args:    cobra.NoArgs,
+		Long:    "volume contains subcommands for querying volume leaderboard data from VolumeLeaders, showing tickers ranked by institutional trade volume. Filter by date and optional ticker list. All subcommands output compact JSON or CSV/TSV with --format.",
 	}
 	cmd.AddCommand(
 		newInstitutionalCmd(),
@@ -43,11 +43,11 @@ func NewVolumeCommand() *cobra.Command {
 func newInstitutionalCmd() *cobra.Command {
 	opts := volumeOptions{Length: 100, OrderCol: 1, OrderDir: "asc"}
 	cmd := &cobra.Command{
-		Use:       "institutional [tickers...]",
-		Short:     "Query institutional volume leaderboard",
-		Long:      "Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format.",
-		Example:   "volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15",
-		Args:      cobra.ArbitraryArgs,
+		Use:        "institutional [tickers...]",
+		Short:      "Query institutional volume leaderboard",
+		Long:       "Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format.",
+		Example:    "volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15",
+		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"inst", "insitutional"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVolume(cmd, &opts,
@@ -65,11 +65,11 @@ func newInstitutionalCmd() *cobra.Command {
 func newAHInstitutionalCmd() *cobra.Command {
 	opts := volumeOptions{Length: 100, OrderCol: 1, OrderDir: "asc"}
 	cmd := &cobra.Command{
-		Use:       "ah-institutional [tickers...]",
-		Short:     "Query after-hours institutional volume leaderboard",
-		Long:      "Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.",
-		Example:   "volumeleaders-agent volume ah-institutional --date 2025-01-15",
-		Args:      cobra.ArbitraryArgs,
+		Use:        "ah-institutional [tickers...]",
+		Short:      "Query after-hours institutional volume leaderboard",
+		Long:       "Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.",
+		Example:    "volumeleaders-agent volume ah-institutional --date 2025-01-15",
+		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"ah", "afterhours"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVolume(cmd, &opts,
@@ -87,11 +87,11 @@ func newAHInstitutionalCmd() *cobra.Command {
 func newTotalCmd() *cobra.Command {
 	opts := volumeOptions{Length: 100, OrderCol: 1, OrderDir: "asc"}
 	cmd := &cobra.Command{
-		Use:       "total [tickers...]",
-		Short:     "Query total volume leaderboard",
-		Long:      "Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.",
-		Example:   "volumeleaders-agent volume total XLE --date 2025-01-15 --length 20",
-		Args:      cobra.ArbitraryArgs,
+		Use:        "total [tickers...]",
+		Short:      "Query total volume leaderboard",
+		Long:       "Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.",
+		Example:    "volumeleaders-agent volume total XLE --date 2025-01-15 --length 20",
+		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"totl", "all"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVolume(cmd, &opts,

--- a/internal/cli/watchlist/watchlist.go
+++ b/internal/cli/watchlist/watchlist.go
@@ -16,60 +16,60 @@ import (
 
 // watchlistConfigsOptions holds flags for the "watchlist configs" subcommand.
 type watchlistConfigsOptions struct {
-	Format string `flag:"format" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	Format string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 // watchlistTickersOptions holds flags for the "watchlist tickers" subcommand.
 type watchlistTickersOptions struct {
-	WatchlistKey int    `flag:"watchlist-key" flagdescr:"Watch list key (-1 for all)"`
-	Format       string `flag:"format" default:"json" flagdescr:"Output format: json, csv, or tsv"`
+	WatchlistKey int    `flag:"watchlist-key" flaggroup:"Input" flagshort:"k" flagdescr:"Watch list key (-1 for all)"`
+	Format       string `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 // watchlistDeleteOptions holds flags for the "watchlist delete" subcommand.
 type watchlistDeleteOptions struct {
-	Key int `flag:"key" flagrequired:"true" flagdescr:"Watch list key to delete"`
+	Key int `flag:"key" flaggroup:"Input" flagshort:"k" flagrequired:"true" flagdescr:"Watch list key to delete"`
 }
 
 // watchlistAddTickerOptions holds flags for the "watchlist add-ticker" subcommand.
 type watchlistAddTickerOptions struct {
-	WatchlistKey int    `flag:"watchlist-key" flagrequired:"true" flagdescr:"Watch list key"`
-	Ticker       string `flag:"ticker" flagrequired:"true" flagdescr:"Ticker symbol to add"`
+	WatchlistKey int    `flag:"watchlist-key" flaggroup:"Input" flagshort:"k" flagrequired:"true" flagdescr:"Watch list key"`
+	Ticker       string `flag:"ticker" flaggroup:"Input" flagshort:"t" flagrequired:"true" flagdescr:"Ticker symbol to add"`
 }
 
 // watchlistConfigFlags holds the shared flag set for watchlist create/edit commands.
 type watchlistConfigFlags struct {
-	Name                string  `flag:"name" flagdescr:"Watch list name"`
-	Tickers             string  `flag:"tickers" flagdescr:"Comma-separated ticker symbols (max 500)"`
-	MinVolume           int     `flag:"min-volume" flagdescr:"Minimum volume filter"`
-	MaxVolume           int     `flag:"max-volume" flagdescr:"Maximum volume filter"`
-	MinDollars          float64 `flag:"min-dollars" flagdescr:"Minimum dollars filter"`
-	MaxDollars          float64 `flag:"max-dollars" flagdescr:"Maximum dollars filter"`
-	MinPrice            float64 `flag:"min-price" flagdescr:"Minimum price filter"`
-	MaxPrice            float64 `flag:"max-price" flagdescr:"Maximum price filter"`
-	MinVCD              float64 `flag:"min-vcd" flagdescr:"Minimum VCD percentile (0-100)"`
-	SectorIndustry      string  `flag:"sector-industry" flagdescr:"Sector/industry filter (max 100 chars)"`
-	SecurityType        int     `flag:"security-type" flagdescr:"Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs)"`
-	MinRelativeSize     int     `flag:"min-relative-size" flagdescr:"Minimum relative size (0/5/10/25/50/100)"`
-	MaxTradeRank        int     `flag:"max-trade-rank" flagdescr:"Maximum trade rank (-1=all, 1/3/5/10/25/50/100)"`
-	NormalPrints        bool    `flag:"normal-prints" flagdescr:"Include normal prints"`
-	SignaturePrints     bool    `flag:"signature-prints" flagdescr:"Include signature prints"`
-	LatePrints          bool    `flag:"late-prints" flagdescr:"Include late prints"`
-	TimelyPrints        bool    `flag:"timely-prints" flagdescr:"Include timely prints"`
-	DarkPools           bool    `flag:"dark-pools" flagdescr:"Include dark pool trades"`
-	LitExchanges        bool    `flag:"lit-exchanges" flagdescr:"Include lit exchange trades"`
-	Sweeps              bool    `flag:"sweeps" flagdescr:"Include sweep trades"`
-	Blocks              bool    `flag:"blocks" flagdescr:"Include block trades"`
-	PremarketTrades     bool    `flag:"premarket-trades" flagdescr:"Include premarket trades"`
-	RTHTrades           bool    `flag:"rth-trades" flagdescr:"Include regular trading hours trades"`
-	AHTrades            bool    `flag:"ah-trades" flagdescr:"Include after-hours trades"`
-	OpeningTrades       bool    `flag:"opening-trades" flagdescr:"Include opening trades"`
-	ClosingTrades       bool    `flag:"closing-trades" flagdescr:"Include closing trades"`
-	PhantomTrades       bool    `flag:"phantom-trades" flagdescr:"Include phantom trades"`
-	OffsettingTrades    bool    `flag:"offsetting-trades" flagdescr:"Include offsetting trades"`
-	RSIOverboughtDaily  int     `flag:"rsi-overbought-daily" flagdescr:"RSI overbought daily (1=yes, 0=no, -1=ignore)"`
-	RSIOverboughtHourly int     `flag:"rsi-overbought-hourly" flagdescr:"RSI overbought hourly (1=yes, 0=no, -1=ignore)"`
-	RSIOversoldDaily    int     `flag:"rsi-oversold-daily" flagdescr:"RSI oversold daily (1=yes, 0=no, -1=ignore)"`
-	RSIOversoldHourly   int     `flag:"rsi-oversold-hourly" flagdescr:"RSI oversold hourly (1=yes, 0=no, -1=ignore)"`
+	Name                string  `flag:"name" flaggroup:"Basic" flagdescr:"Watch list name"`
+	Tickers             string  `flag:"tickers" flaggroup:"Basic" flagshort:"t" flagdescr:"Comma-separated ticker symbols (max 500)"`
+	MinVolume           int     `flag:"min-volume" flaggroup:"Ranges" flagdescr:"Minimum volume filter"`
+	MaxVolume           int     `flag:"max-volume" flaggroup:"Ranges" flagdescr:"Maximum volume filter"`
+	MinDollars          float64 `flag:"min-dollars" flaggroup:"Ranges" flagdescr:"Minimum dollars filter"`
+	MaxDollars          float64 `flag:"max-dollars" flaggroup:"Ranges" flagdescr:"Maximum dollars filter"`
+	MinPrice            float64 `flag:"min-price" flaggroup:"Ranges" flagdescr:"Minimum price filter"`
+	MaxPrice            float64 `flag:"max-price" flaggroup:"Ranges" flagdescr:"Maximum price filter"`
+	MinVCD              float64 `flag:"min-vcd" flaggroup:"Filters" flagdescr:"Minimum VCD percentile (0-100)"`
+	SectorIndustry      string  `flag:"sector-industry" flaggroup:"Filters" flagdescr:"Sector/industry filter (max 100 chars)"`
+	SecurityType        int     `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs)"`
+	MinRelativeSize     int     `flag:"min-relative-size" flaggroup:"Filters" flagdescr:"Minimum relative size (0/5/10/25/50/100)"`
+	MaxTradeRank        int     `flag:"max-trade-rank" flaggroup:"Filters" flagdescr:"Maximum trade rank (-1=all, 1/3/5/10/25/50/100)"`
+	NormalPrints        bool    `flag:"normal-prints" flaggroup:"Print Types" flagdescr:"Include normal prints"`
+	SignaturePrints     bool    `flag:"signature-prints" flaggroup:"Print Types" flagdescr:"Include signature prints"`
+	LatePrints          bool    `flag:"late-prints" flaggroup:"Print Types" flagdescr:"Include late prints"`
+	TimelyPrints        bool    `flag:"timely-prints" flaggroup:"Print Types" flagdescr:"Include timely prints"`
+	DarkPools           bool    `flag:"dark-pools" flaggroup:"Venues" flagdescr:"Include dark pool trades"`
+	LitExchanges        bool    `flag:"lit-exchanges" flaggroup:"Venues" flagdescr:"Include lit exchange trades"`
+	Sweeps              bool    `flag:"sweeps" flaggroup:"Venues" flagdescr:"Include sweep trades"`
+	Blocks              bool    `flag:"blocks" flaggroup:"Venues" flagdescr:"Include block trades"`
+	PremarketTrades     bool    `flag:"premarket-trades" flaggroup:"Sessions" flagdescr:"Include premarket trades"`
+	RTHTrades           bool    `flag:"rth-trades" flaggroup:"Sessions" flagdescr:"Include regular trading hours trades"`
+	AHTrades            bool    `flag:"ah-trades" flaggroup:"Sessions" flagdescr:"Include after-hours trades"`
+	OpeningTrades       bool    `flag:"opening-trades" flaggroup:"Sessions" flagdescr:"Include opening trades"`
+	ClosingTrades       bool    `flag:"closing-trades" flaggroup:"Sessions" flagdescr:"Include closing trades"`
+	PhantomTrades       bool    `flag:"phantom-trades" flaggroup:"Sessions" flagdescr:"Include phantom trades"`
+	OffsettingTrades    bool    `flag:"offsetting-trades" flaggroup:"Sessions" flagdescr:"Include offsetting trades"`
+	RSIOverboughtDaily  int     `flag:"rsi-overbought-daily" flaggroup:"RSI" flagdescr:"RSI overbought daily (1=yes, 0=no, -1=ignore)"`
+	RSIOverboughtHourly int     `flag:"rsi-overbought-hourly" flaggroup:"RSI" flagdescr:"RSI overbought hourly (1=yes, 0=no, -1=ignore)"`
+	RSIOversoldDaily    int     `flag:"rsi-oversold-daily" flaggroup:"RSI" flagdescr:"RSI oversold daily (1=yes, 0=no, -1=ignore)"`
+	RSIOversoldHourly   int     `flag:"rsi-oversold-hourly" flaggroup:"RSI" flagdescr:"RSI oversold hourly (1=yes, 0=no, -1=ignore)"`
 }
 
 // watchlistCreateOptions holds flags for the "watchlist create" subcommand.
@@ -79,7 +79,7 @@ type watchlistCreateOptions struct {
 
 // watchlistEditOptions holds flags for the "watchlist edit" subcommand.
 type watchlistEditOptions struct {
-	Key int `flag:"key" flagrequired:"true" flagdescr:"Watch list key to edit"`
+	Key int `flag:"key" flaggroup:"Input" flagshort:"k" flagrequired:"true" flagdescr:"Watch list key to edit"`
 	watchlistConfigFlags
 }
 


### PR DESCRIPTION
## Summary
- Groups related CLI flags with structcli `flaggroup` metadata so dense commands render clearer help sections.
- Adds conservative short flags for common inputs like format, dates, tickers, length, keys, and pretty output.
- Adds tests for shorthand collisions, JSON schema usability metadata, and grouped help output.

## Verification
- LSP diagnostics on `internal/cli`: 0 diagnostics
- `go test ./internal/cli/...`
- `make test`
- `make lint`
- `make build`
- Five-agent post-implementation review: PASS