### PR TITLE
feat(cli): expose commands over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ When modifying CLI commands, flags, models, or behavior:
 
 Command documentation mapping:
 
-- All command groups -> `volumeleaders-agent --jsonschema=tree` for command shape and Long descriptions for semantic guidance.
+- All command groups -> `volumeleaders-agent --jsonschema=tree` for command shape and Long descriptions for semantic guidance. Use `volumeleaders-agent --mcp` when validating the MCP tool surface exposed to LLM clients.
 - Shared conventions, workflows, output behavior, auth guidance, and domain gotchas -> root command Long description (run `volumeleaders-agent --help`).
 
 ## Project Layout
@@ -20,7 +20,7 @@ Command documentation mapping:
 cmd/volumeleaders-agent/main.go    Entry point
 internal/auth/                     Browser cookie + XSRF token extraction
 internal/client/                   HTTP client (DataTables + JSON requests)
-internal/commands/                 CLI command definitions (6 top-level commands, 26 subcommands)
+internal/cli/                      CLI command definitions (6 top-level commands, 26 subcommands)
 internal/datatables/               DataTables protocol encoding + column definitions
 internal/models/                   Response type definitions
 ```
@@ -36,7 +36,7 @@ make install    # Install to $GOPATH/bin
 
 ## Conventions
 
-- Commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Errors go to stderr via `slog`.
+- Commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Use `--mcp` on the root command to serve leaf commands as MCP tools over stdio for trusted local LLM clients. Errors go to stderr via `slog`.
 - Dates use `YYYY-MM-DD` format on the CLI, converted internally as needed.
 - Boolean/toggle filters use integers: `-1` = all/unfiltered, `0` = exclude, `1` = include/only.
 - Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results except for capped trade retrieval endpoints. `trade list`, including `--summary`, defaults to `--length 10` and only allows `--length` values from 1 to 50 because the VolumeLeaders backend cannot safely retrieve more than 50 individual trades per request. `trade levels` caps `--trade-level-count` at 50, and `trade level-touches` only allows `--length` values from 1 to 50.
@@ -53,7 +53,8 @@ make install    # Install to $GOPATH/bin
 - For `internal/auth/**/*.go`, check cookie extraction, browser profile handling, and token lookup paths for credential safety, useful error messages, and graceful behavior when browsers or cookies are unavailable.
 - For `internal/client/**/*.go`, check HTTP status handling, request context propagation, response body closure, DataTables encoding, and errors that explain the endpoint or operation that failed.
 - For `internal/models/**/*.go`, verify JSON tags match VolumeLeaders response fields and that model changes do not silently drop data needed by commands, summaries, or CSV/TSV output.
-- For `internal/commands/**/*.go`, verify command behavior matches README, `volumeleaders-agent --jsonschema=tree`, and the conventions above. If commands, flags, aliases, defaults, or examples change, verify `--jsonschema=tree` output reflects the changes. If workflows, behavior, models, or output formats change, update the relevant command Long descriptions.
+- For `internal/cli/**/*.go`, verify command behavior matches README, `volumeleaders-agent --jsonschema=tree`, and the conventions above. If commands, flags, aliases, defaults, or examples change, verify `--jsonschema=tree` output reflects the changes. If workflows, behavior, models, or output formats change, update the relevant command Long descriptions.
+- For MCP changes, verify `volumeleaders-agent --mcp` keeps JSON-RPC protocol output on stdout, does not expose shell completion or parent routing commands as tools, and never leaks cookies, XSRF tokens, session values, or other credentials in tool results or errors.
 - For tests, expect table-driven subtests with `t.Run`, parallelization where safe, `t.TempDir()` for filesystem work, deterministic fixtures, and assertions on observable behavior rather than implementation details. Do not request arbitrary coverage percentage changes.
 - For GitHub Actions workflows, treat unpinned actions, excessive permissions, secret exposure in logs, or unsafe pull request execution patterns as P1.
 - For `Makefile`, check that non-file targets are declared `.PHONY` and avoid adding flags that duplicate tool defaults.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ volumeleaders-agent trade list --tickers NVDA --start-date 2025-01-01 --end-date
 volumeleaders-agent --pretty market exhaustion
 ```
 
-Commands emit compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr. Use `--jsonschema=tree` on the root command for a machine-readable JSON Schema of the full CLI.
+Commands emit compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr. Use `--jsonschema=tree` on the root command for a machine-readable JSON Schema of the full CLI, or `--mcp` to serve leaf commands as MCP tools over stdio for trusted local LLM clients.
 
 ## Commands
 
@@ -46,7 +46,7 @@ Commands emit compact JSON to stdout by default. Use `--pretty` for indented out
 | `alert` | Saved alert configurations |
 | `watchlist` | Saved watchlists and their tickers |
 
-Use `volumeleaders-agent --jsonschema=tree` for the machine-readable JSON Schema of all commands and flags. Run `volumeleaders-agent --help` for embedded domain knowledge, filter conventions, workflows, and domain gotchas.
+Use `volumeleaders-agent --jsonschema=tree` for the machine-readable JSON Schema of all commands and flags. Use `volumeleaders-agent --mcp` to expose the same leaf-command surface to MCP clients over stdio. Run `volumeleaders-agent --help` for embedded domain knowledge, filter conventions, workflows, and domain gotchas.
 
 ## Build
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/helptopics"
+	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
 
 	"github.com/major/volumeleaders-agent/internal/cli/alert"
@@ -34,7 +35,7 @@ func NewRootCmd(version string) *cobra.Command {
 
 Auth: reads browser cookies automatically. If auth fails with exit code 2 and "Authentication required: VolumeLeaders session has expired.", log in at https://www.volumeleaders.com in your browser, then retry.
 
-Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable JSON Schema output, or --jsonschema=tree on the root for the full CLI tree. Errors and logs go to stderr.
+Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable JSON Schema output, --jsonschema=tree on the root for the full CLI tree, or --mcp on the root to serve leaf commands as MCP tools over stdio. Errors and logs go to stderr.
 
 COMMAND CHOOSER
 
@@ -109,10 +110,9 @@ Performance: use explicit dates and tickers when possible. Start narrow, then ex
 	return cmd
 }
 
-// SetupCLI configures structcli features (JSON schema, structured flag errors)
-// on the root command. Called from main after NewRootCmd; separated because
-// WithJSONSchema uses cobra.OnInitialize (process-global) which races in
-// parallel tests.
+// SetupCLI configures structcli features on the root command. Called from main
+// after NewRootCmd; separated because WithJSONSchema uses cobra.OnInitialize
+// (process-global) which races in parallel tests.
 func SetupCLI(cmd *cobra.Command) {
 	if err := structcli.Setup(
 		cmd,
@@ -120,6 +120,16 @@ func SetupCLI(cmd *cobra.Command) {
 		structcli.WithJSONSchema(),
 		structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
 		structcli.WithFlagErrors(),
+		structcli.WithMCP(structclimcp.Options{
+			Name:    "volumeleaders-agent",
+			Version: cmd.Version,
+			Exclude: []string{
+				"completion-bash",
+				"completion-fish",
+				"completion-powershell",
+				"completion-zsh",
+			},
+		}),
 	); err != nil {
 		panic(fmt.Sprintf("structcli.Setup: %v", err))
 	}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -488,6 +488,117 @@ func TestJSONSchemaSubcommandIncludesFlagUsabilityMetadata(t *testing.T) {
 	}
 }
 
+func TestMCPToolsListExposesLeafCommands(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	cmd := exec.Command(binary, "--mcp")
+	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--mcp tools/list failed: %v\nOutput: %s", err, out)
+	}
+
+	var response struct {
+		Result struct {
+			Tools []struct {
+				Name        string         `json:"name"`
+				Description string         `json:"description"`
+				InputSchema map[string]any `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal(out, &response); jsonErr != nil {
+		t.Fatalf("MCP response is not valid JSON: %v\nOutput: %s", jsonErr, out)
+	}
+	if response.Error != nil {
+		t.Fatalf("MCP tools/list returned error: %s\nOutput: %s", response.Error.Message, out)
+	}
+
+	toolSchemas := make(map[string]map[string]any, len(response.Result.Tools))
+	for _, tool := range response.Result.Tools {
+		if tool.Description == "" {
+			t.Fatalf("tool %q has empty description", tool.Name)
+		}
+		toolSchemas[tool.Name] = tool.InputSchema
+	}
+
+	for _, expected := range []string{"trade-list", "trade-sentiment", "volume-institutional", "market-snapshots", "watchlist-configs"} {
+		if _, ok := toolSchemas[expected]; !ok {
+			t.Fatalf("MCP tools/list missing %q; got %v", expected, mapsKeys(toolSchemas))
+		}
+	}
+	for _, parent := range []string{"trade", "volume", "market", "alert", "watchlist"} {
+		if _, ok := toolSchemas[parent]; ok {
+			t.Fatalf("MCP tools/list exposed non-leaf parent command %q", parent)
+		}
+	}
+	for _, completionTool := range []string{"completion-bash", "completion-fish", "completion-powershell", "completion-zsh"} {
+		if _, ok := toolSchemas[completionTool]; ok {
+			t.Fatalf("MCP tools/list exposed shell completion tool %q", completionTool)
+		}
+	}
+
+	tradeListSchema := toolSchemas["trade-list"]
+	props, ok := tradeListSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("trade-list inputSchema missing properties: %v", tradeListSchema)
+	}
+	for _, expectedFlag := range []string{"tickers", "days", "format", "length"} {
+		if _, ok := props[expectedFlag]; !ok {
+			t.Fatalf("trade-list inputSchema missing flag %q", expectedFlag)
+		}
+	}
+}
+
+func TestMCPToolsCallReportsStructuredValidationError(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	cmd := exec.Command(binary, "--mcp")
+	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"volume-institutional","arguments":{"format":"json"}}}` + "\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--mcp tools/call failed: %v\nOutput: %s", err, out)
+	}
+
+	var response struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal(out, &response); jsonErr != nil {
+		t.Fatalf("MCP response is not valid JSON: %v\nOutput: %s", jsonErr, out)
+	}
+	if response.Error != nil {
+		t.Fatalf("MCP tools/call returned protocol error: %s\nOutput: %s", response.Error.Message, out)
+	}
+	if !response.Result.IsError {
+		t.Fatalf("expected tool call to return IsError=true; output: %s", out)
+	}
+	if len(response.Result.Content) == 0 || !strings.Contains(response.Result.Content[0].Text, "required flag") {
+		t.Fatalf("expected structured required flag error, got: %s", out)
+	}
+}
+
+func mapsKeys[V any](items map[string]V) []string {
+	keys := make([]string, 0, len(items))
+	for key := range items {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
 func TestHelpOutputDisplaysFlagGroups(t *testing.T) {
 	t.Parallel()
 	binary := buildBinary(t)


### PR DESCRIPTION
## Summary
- Add `--mcp` stdio server mode so trusted local MCP clients can call leaf CLI commands as tools.
- Exclude parent routing and shell completion commands from the MCP tool surface to keep LLM discovery focused.
- Document the MCP mode in README and repository guidance, with tests for tool discovery and validation errors.

## Verification
- `go test ./internal/cli -run 'TestMCP|TestJSONSchema' -count=1`
- `make test`
- `make lint`
- `make build`
- Local CodeRabbit: 0 findings
- Live smoke samples: 6 read-only commands against 2026-05-01 data
- MCP surface check: 26 domain leaf tools, no parent or completion tools exposed