### PR TITLE
feat(cli): add output schema contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,12 @@ Go CLI tool for querying institutional trade data from [VolumeLeaders](https://w
 When modifying CLI commands, flags, models, or behavior:
 
 - Update `AGENTS.md` if the change affects project structure, build process, or conventions.
-- Use `volumeleaders-agent --jsonschema=tree` as the source of truth for command names, flags, aliases, defaults, and examples. Command Long descriptions contain embedded domain knowledge (workflows, conventions, gotchas).
+- Use `volumeleaders-agent --jsonschema=tree` as the source of truth for command names, flags, aliases, defaults, and examples. Use `volumeleaders-agent outputschema` as the source of truth for success stdout contracts, formats, fields, and variants. Command Long descriptions contain embedded domain knowledge (workflows, conventions, gotchas).
 
 Command documentation mapping:
 
 - All command groups -> `volumeleaders-agent --jsonschema=tree` for command shape and Long descriptions for semantic guidance.
+- All command outputs -> `volumeleaders-agent outputschema` for success stdout contracts.
 - Shared conventions, workflows, output behavior, auth guidance, and domain gotchas -> root command Long description (run `volumeleaders-agent --help`).
 
 ## Project Layout
@@ -20,7 +21,7 @@ Command documentation mapping:
 cmd/volumeleaders-agent/main.go    Entry point
 internal/auth/                     Browser cookie + XSRF token extraction
 internal/client/                   HTTP client (DataTables + JSON requests)
-internal/commands/                 CLI command definitions (6 top-level commands, 26 subcommands)
+internal/cli/                      CLI command definitions and output contracts
 internal/datatables/               DataTables protocol encoding + column definitions
 internal/models/                   Response type definitions
 ```
@@ -36,7 +37,7 @@ make install    # Install to $GOPATH/bin
 
 ## Conventions
 
-- Commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Errors go to stderr via `slog`.
+- Commands output compact JSON to stdout by default. List-style commands may support `--format json|csv|tsv`; CSV/TSV include a header row, render booleans as `true`/`false`, and render null or missing values as empty cells. Use `--pretty` for indented JSON output. Use `outputschema` to inspect machine-readable success output contracts. Errors go to stderr via `slog`.
 - Dates use `YYYY-MM-DD` format on the CLI, converted internally as needed.
 - Boolean/toggle filters use integers: `-1` = all/unfiltered, `0` = exclude, `1` = include/only.
 - Pagination uses `--start` (offset) and `--length` (count). `--length -1` means all results except for capped trade retrieval endpoints. `trade list`, including `--summary`, defaults to `--length 10` and only allows `--length` values from 1 to 50 because the VolumeLeaders backend cannot safely retrieve more than 50 individual trades per request. `trade levels` caps `--trade-level-count` at 50, and `trade level-touches` only allows `--length` values from 1 to 50.
@@ -53,7 +54,7 @@ make install    # Install to $GOPATH/bin
 - For `internal/auth/**/*.go`, check cookie extraction, browser profile handling, and token lookup paths for credential safety, useful error messages, and graceful behavior when browsers or cookies are unavailable.
 - For `internal/client/**/*.go`, check HTTP status handling, request context propagation, response body closure, DataTables encoding, and errors that explain the endpoint or operation that failed.
 - For `internal/models/**/*.go`, verify JSON tags match VolumeLeaders response fields and that model changes do not silently drop data needed by commands, summaries, or CSV/TSV output.
-- For `internal/commands/**/*.go`, verify command behavior matches README, `volumeleaders-agent --jsonschema=tree`, and the conventions above. If commands, flags, aliases, defaults, or examples change, verify `--jsonschema=tree` output reflects the changes. If workflows, behavior, models, or output formats change, update the relevant command Long descriptions.
+- For `internal/cli/**/*.go`, verify command behavior matches README, `volumeleaders-agent --jsonschema=tree`, `volumeleaders-agent outputschema`, and the conventions above. If commands, flags, aliases, defaults, or examples change, verify `--jsonschema=tree` output reflects the changes. If workflows, behavior, models, output formats, or output fields change, update the relevant command Long descriptions and output contracts.
 - For tests, expect table-driven subtests with `t.Run`, parallelization where safe, `t.TempDir()` for filesystem work, deterministic fixtures, and assertions on observable behavior rather than implementation details. Do not request arbitrary coverage percentage changes.
 - For GitHub Actions workflows, treat unpinned actions, excessive permissions, secret exposure in logs, or unsafe pull request execution patterns as P1.
 - For `Makefile`, check that non-file targets are declared `.PHONY` and avoid adding flags that duplicate tool defaults.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Fork the repo, create a branch, and open a PR against `main`.
 
 ## Code Style
 
-Follow the patterns already in the codebase. `make lint` catches most issues. When in doubt, look at how existing commands in `internal/commands/` are structured and match that style.
+Follow the patterns already in the codebase. `make lint` catches most issues. When in doubt, look at how existing commands in `internal/cli/` are structured and match that style.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ volumeleaders-agent trade list --tickers NVDA --start-date 2025-01-01 --end-date
 volumeleaders-agent --pretty market exhaustion
 ```
 
-Commands emit compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr. Use `--jsonschema=tree` on the root command for a machine-readable JSON Schema of the full CLI.
+Commands emit compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr. Use `--jsonschema=tree` on the root command for a machine-readable JSON Schema of commands and flags. Use `volumeleaders-agent outputschema` for machine-readable stdout contracts.
 
 ## Commands
 
@@ -45,8 +45,9 @@ Commands emit compact JSON to stdout by default. Use `--pretty` for indented out
 | `market` | Market-wide snapshots, earnings calendar, exhaustion scores |
 | `alert` | Saved alert configurations |
 | `watchlist` | Saved watchlists and their tickers |
+| `outputschema` | Machine-readable success output contracts |
 
-Use `volumeleaders-agent --jsonschema=tree` for the machine-readable JSON Schema of all commands and flags. Run `volumeleaders-agent --help` for embedded domain knowledge, filter conventions, workflows, and domain gotchas.
+Use `volumeleaders-agent --jsonschema=tree` for the machine-readable JSON Schema of all commands and flags. Use `volumeleaders-agent outputschema trade list` for the stdout contract of a specific command, including formats, fields, and conditional variants. Run `volumeleaders-agent --help` for embedded domain knowledge, filter conventions, workflows, and domain gotchas.
 
 ## Build
 

--- a/internal/cli/outputschema.go
+++ b/internal/cli/outputschema.go
@@ -1,0 +1,329 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/major/volumeleaders-agent/internal/cli/common"
+	"github.com/major/volumeleaders-agent/internal/models"
+)
+
+// outputContract describes the stdout contract for one executable command.
+// It intentionally lives outside structcli because structcli v0.17.0 only
+// exposes input schemas. Keeping output contracts separate avoids changing
+// command execution paths while still giving LLM clients machine-readable
+// success shapes.
+type outputContract struct {
+	Command        string          `json:"command"`
+	Description    string          `json:"description"`
+	Formats        []string        `json:"formats"`
+	DefaultFormat  string          `json:"default_format"`
+	Schema         outputSchema    `json:"schema"`
+	FieldSelection *fieldSelection `json:"field_selection,omitempty"`
+	Variants       []outputVariant `json:"variants,omitempty"`
+	Notes          []string        `json:"notes,omitempty"`
+}
+
+// outputVariant captures conditional output shapes selected by flags such as
+// --summary or --fields. A command may have one default schema plus variants.
+type outputVariant struct {
+	When           string          `json:"when"`
+	Formats        []string        `json:"formats"`
+	Schema         outputSchema    `json:"schema"`
+	FieldSelection *fieldSelection `json:"field_selection,omitempty"`
+	Notes          []string        `json:"notes,omitempty"`
+}
+
+// fieldSelection documents commands where --fields narrows JSON object keys or
+// CSV and TSV columns.
+type fieldSelection struct {
+	Flag          string   `json:"flag"`
+	DefaultFields []string `json:"default_fields,omitempty"`
+	AllFields     []string `json:"all_fields"`
+	AllValue      string   `json:"all_value,omitempty"`
+}
+
+// outputSchema is a compact JSON Schema-like description of command stdout.
+// It is intentionally small and stable so agents can consume it without needing
+// a full JSON Schema validator.
+type outputSchema struct {
+	Type                 string                  `json:"type"`
+	Model                string                  `json:"model,omitempty"`
+	Format               string                  `json:"format,omitempty"`
+	Nullable             bool                    `json:"nullable,omitempty"`
+	Items                *outputSchema           `json:"items,omitempty"`
+	Properties           map[string]outputSchema `json:"properties,omitempty"`
+	AdditionalProperties *outputSchema           `json:"additional_properties,omitempty"`
+	Any                  bool                    `json:"any,omitempty"`
+}
+
+// newOutputSchemaCmd returns a reference command that prints machine-readable
+// stdout contracts for leaf commands.
+func newOutputSchemaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "outputschema [command...]",
+		Short:   "Print command output contracts",
+		GroupID: "reference",
+		Args:    cobra.ArbitraryArgs,
+		Long:    "Print machine-readable stdout contracts for executable commands. With no arguments it returns every contract as a JSON array. Pass a command path such as trade list to return one contract. This describes success output only; structured errors are documented by structcli flag errors.",
+		Example: `volumeleaders-agent outputschema
+volumeleaders-agent outputschema trade list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contracts := allOutputContracts()
+			if len(args) == 0 {
+				return common.PrintJSON(cmd.OutOrStdout(), context.WithValue(cmd.Context(), common.PrettyJSONKey, prettyFromCommand(cmd)), contracts)
+			}
+
+			commandPath := strings.Join(args, " ")
+			contract, ok := outputContractByCommand(contracts, commandPath)
+			if !ok {
+				return fmt.Errorf("unknown output contract %q; run outputschema with no arguments for all contracts", commandPath)
+			}
+			return common.PrintJSON(cmd.OutOrStdout(), context.WithValue(cmd.Context(), common.PrettyJSONKey, prettyFromCommand(cmd)), contract)
+		},
+	}
+	return cmd
+}
+
+func prettyFromCommand(cmd *cobra.Command) bool {
+	pretty, _ := cmd.Root().PersistentFlags().GetBool("pretty")
+	return pretty
+}
+
+func outputContractByCommand(contracts []outputContract, commandPath string) (outputContract, bool) {
+	for index := range contracts {
+		contract := contracts[index]
+		if contract.Command == commandPath {
+			return contract, true
+		}
+	}
+	return outputContract{}, false
+}
+
+func allOutputContracts() []outputContract {
+	contracts := []outputContract{
+		arrayOutputContract[models.TradeListRow]("trade list", "List individual institutional trades using a compact default row shape.", outputFormats(), nil, nil,
+			outputVariant{When: "--fields is set or --format is csv or tsv", Formats: outputFormats(), Schema: arraySchema[models.Trade](), FieldSelection: allFieldsSelection[models.Trade](nil), Notes: []string{"CSV and TSV include a header row matching the selected fields."}},
+			outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeSummary](), Notes: []string{"--summary cannot be combined with --fields or non-JSON formats."}},
+		),
+		objectOutputContract[models.TradeSentiment]("trade sentiment", "Summarize leveraged ETF bull and bear flow.", outputFormats(), []string{"CSV and TSV flatten one row per day."},
+			outputVariant{When: "--format is csv or tsv", Formats: []string{"csv", "tsv"}, Schema: arraySchema[models.TradeSentimentRow]()},
+		),
+		arrayOutputContract[models.TradeCluster]("trade clusters", "List institutional trade clusters around similar prices.", outputFormats(), tradeClusterDefaultFields(), allFieldsSelection[models.TradeCluster](tradeClusterDefaultFields())),
+		arrayOutputContract[models.TradeClusterBomb]("trade cluster-bombs", "List bursty trade cluster bomb activity.", outputFormats(), nil, nil),
+		arrayOutputContract[models.TradeAlert]("trade alerts", "List system-generated trade alerts for one date.", outputFormats(), nil, nil),
+		arrayOutputContract[models.TradeClusterAlert]("trade cluster-alerts", "List system-generated trade cluster alerts for one date.", outputFormats(), nil, nil),
+		arrayOutputContract[models.TradeLevelRow]("trade levels", "List support and resistance style institutional price levels.", []string{"json"}, nil, nil,
+			outputVariant{When: "--fields is set", Formats: []string{"json"}, Schema: arraySchema[models.TradeLevel](), FieldSelection: allFieldsSelection[models.TradeLevel](nil)},
+		),
+		arrayOutputContract[models.TradeLevelTouch]("trade level-touches", "List revisits to institutional price levels.", outputFormats(), nil, nil),
+		objectOutputContract[models.PresetTickersInfo]("trade preset-tickers", "List ticker symbols used by one built-in trade preset.", []string{"json"}, nil),
+		arrayOutputContract[models.PresetInfo]("trade presets", "List built-in trade filter presets.", outputFormats(), nil, nil),
+
+		arrayOutputContract[models.Trade]("volume institutional", "List regular-hours institutional volume leaders.", outputFormats(), nil, nil),
+		arrayOutputContract[models.Trade]("volume ah-institutional", "List after-hours institutional volume leaders.", outputFormats(), nil, nil),
+		arrayOutputContract[models.Trade]("volume total", "List total volume leaders across trade types.", outputFormats(), nil, nil),
+
+		objectOutputContract[map[string]any]("market snapshots", "Return current price snapshots keyed by ticker.", []string{"json"}, []string{"Snapshot objects come from the VolumeLeaders API and can vary by symbol."}),
+		arrayOutputContract[models.Earnings]("market earnings", "List earnings events with related institutional activity counts.", outputFormats(), marketEarningsDefaultFields(), allFieldsSelection[models.Earnings](marketEarningsDefaultFields())),
+		objectOutputContract[models.MarketExhaustion]("market exhaustion", "Return market exhaustion rank metrics for one trading day.", []string{"json"}, nil),
+
+		arrayOutputContract[models.AlertConfig]("alert configs", "List saved alert configurations.", outputFormats(), alertConfigDefaultFields(), allFieldsSelection[models.AlertConfig](alertConfigDefaultFields())),
+		unknownJSONContract("alert delete", "Delete an alert configuration and return the API response."),
+		mutationContract("alert create", "Create an alert configuration and return a success object."),
+		mutationContract("alert edit", "Edit an alert configuration and return a success object."),
+
+		arrayOutputContract[models.WatchListConfig]("watchlist configs", "List saved watchlist configurations.", outputFormats(), nil, nil),
+		arrayOutputContract[models.WatchListTicker]("watchlist tickers", "List tickers and nearest level metadata for one watchlist.", outputFormats(), nil, nil),
+		unknownJSONContract("watchlist delete", "Delete a watchlist configuration and return the API response."),
+		unknownJSONContract("watchlist add-ticker", "Add a ticker to a watchlist and return the API response."),
+		mutationContract("watchlist create", "Create a watchlist configuration and return a success object."),
+		mutationContract("watchlist edit", "Edit a watchlist configuration and return a success object."),
+	}
+	slices.SortFunc(contracts, func(a, b outputContract) int {
+		return strings.Compare(a.Command, b.Command)
+	})
+	return contracts
+}
+
+func outputFormats() []string {
+	return []string{"json", "csv", "tsv"}
+}
+
+func arrayOutputContract[T any](command, description string, formats, defaultFields []string, selection *fieldSelection, variants ...outputVariant) outputContract {
+	contract := outputContract{
+		Command:       command,
+		Description:   description,
+		Formats:       formats,
+		DefaultFormat: "json",
+		Schema:        arraySchema[T](),
+		Variants:      variants,
+	}
+	if selection != nil {
+		contract.FieldSelection = selection
+	} else if len(defaultFields) > 0 {
+		contract.FieldSelection = allFieldsSelection[T](defaultFields)
+	}
+	return contract
+}
+
+func objectOutputContract[T any](command, description string, formats, notes []string, variants ...outputVariant) outputContract {
+	return outputContract{
+		Command:       command,
+		Description:   description,
+		Formats:       formats,
+		DefaultFormat: "json",
+		Schema:        schemaForType(reflect.TypeFor[T](), make(map[reflect.Type]bool)),
+		Variants:      variants,
+		Notes:         notes,
+	}
+}
+
+func mutationContract(command, description string) outputContract {
+	return outputContract{
+		Command:       command,
+		Description:   description,
+		Formats:       []string{"json"},
+		DefaultFormat: "json",
+		Schema: outputSchema{
+			Type:  "object",
+			Model: "MutationResult",
+			Properties: map[string]outputSchema{
+				"success": {Type: "boolean"},
+				"action":  {Type: "string"},
+				"key":     {Type: "integer"},
+			},
+		},
+	}
+}
+
+func unknownJSONContract(command, description string) outputContract {
+	return outputContract{
+		Command:       command,
+		Description:   description,
+		Formats:       []string{"json"},
+		DefaultFormat: "json",
+		Schema:        outputSchema{Type: "object", AdditionalProperties: &outputSchema{Any: true}},
+		Notes:         []string{"Response shape is passed through from the VolumeLeaders API."},
+	}
+}
+
+func arraySchema[T any]() outputSchema {
+	item := schemaForType(reflect.TypeFor[T](), make(map[reflect.Type]bool))
+	return outputSchema{Type: "array", Items: &item}
+}
+
+func objectSchema[T any]() outputSchema {
+	return schemaForType(reflect.TypeFor[T](), make(map[reflect.Type]bool))
+}
+
+func allFieldsSelection[T any](defaultFields []string) *fieldSelection {
+	return &fieldSelection{
+		Flag:          "fields",
+		DefaultFields: slices.Clone(defaultFields),
+		AllFields:     common.JSONFieldNamesInOrder[T](),
+		AllValue:      "all",
+	}
+}
+
+func schemaForType(t reflect.Type, seen map[reflect.Type]bool) outputSchema {
+	for t.Kind() == reflect.Pointer {
+		base := schemaForType(t.Elem(), seen)
+		base.Nullable = true
+		return base
+	}
+
+	if t == reflect.TypeFor[models.AspNetDate]() || t == reflect.TypeFor[time.Time]() {
+		return outputSchema{Type: "string", Format: "date-time", Nullable: true}
+	}
+	if t == reflect.TypeFor[models.FlexBool]() {
+		return outputSchema{Type: "boolean"}
+	}
+
+	switch t.Kind() {
+	case reflect.Bool:
+		return outputSchema{Type: "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return outputSchema{Type: "integer"}
+	case reflect.Float32, reflect.Float64:
+		return outputSchema{Type: "number"}
+	case reflect.String:
+		return outputSchema{Type: "string"}
+	case reflect.Slice, reflect.Array:
+		item := schemaForType(t.Elem(), seen)
+		return outputSchema{Type: "array", Items: &item}
+	case reflect.Map:
+		value := schemaForType(t.Elem(), seen)
+		return outputSchema{Type: "object", Model: t.String(), AdditionalProperties: &value}
+	case reflect.Interface:
+		return outputSchema{Any: true}
+	case reflect.Struct:
+		if seen[t] {
+			return outputSchema{Type: "object", Model: t.Name()}
+		}
+		seen[t] = true
+		properties := make(map[string]outputSchema)
+		for field := range t.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+			if name == "" || name == "-" {
+				continue
+			}
+			properties[name] = schemaForType(field.Type, seen)
+		}
+		delete(seen, t)
+		return outputSchema{Type: "object", Model: t.Name(), Properties: properties}
+	default:
+		return outputSchema{Type: "string", Model: t.String()}
+	}
+}
+
+func tradeClusterDefaultFields() []string {
+	return []string{
+		"Date",
+		"Ticker",
+		"Price",
+		"Dollars",
+		"Volume",
+		"TradeCount",
+		"DollarsMultiplier",
+		"CumulativeDistribution",
+		"TradeClusterRank",
+		"MinFullDateTime",
+		"MaxFullDateTime",
+	}
+}
+
+func marketEarningsDefaultFields() []string {
+	return []string{
+		"Ticker",
+		"EarningsDate",
+		"AfterMarketClose",
+		"TradeCount",
+		"TradeClusterCount",
+		"TradeClusterBombCount",
+	}
+}
+
+func alertConfigDefaultFields() []string {
+	return []string{
+		"AlertConfigKey",
+		"Name",
+		"Tickers",
+		"TradeConditions",
+		"ClosingTradeConditions",
+		"DarkPool",
+		"Sweep",
+		"OffsettingPrint",
+		"PhantomPrint",
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,7 +34,7 @@ func NewRootCmd(version string) *cobra.Command {
 
 Auth: reads browser cookies automatically. If auth fails with exit code 2 and "Authentication required: VolumeLeaders session has expired.", log in at https://www.volumeleaders.com in your browser, then retry.
 
-Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable JSON Schema output, or --jsonschema=tree on the root for the full CLI tree. Errors and logs go to stderr.
+Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable input JSON Schema output, or --jsonschema=tree on the root for the full CLI tree. Use outputschema for machine-readable stdout contracts. Errors and logs go to stderr.
 
 COMMAND CHOOSER
 
@@ -75,7 +75,7 @@ Toggle filters: -1 means all/unfiltered, 0 means exclude, 1 means include/only.
 
 Tickers: --tickers is comma-separated, --ticker is single-symbol. Commands that take tickers generally accept positional tickers too, for example: trade list XLE XLK. Trade and volume ticker filters also accept --symbol and --symbols aliases.
 
-Output formats: list-style commands may support --format json/csv/tsv. CSV/TSV include headers, booleans render as true/false, null or missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless the schema shows a format flag.
+Output formats: list-style commands may support --format json/csv/tsv. CSV/TSV include headers, booleans render as true/false, null or missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless the input schema shows a format flag. Use outputschema to inspect the success stdout shape for each command.
 
 Performance: use explicit dates and tickers when possible. Start narrow, then expand. VolumeLeaders endpoints can be expensive and some trade retrieval endpoints are intentionally capped.`,
 		Version:          version,
@@ -95,6 +95,7 @@ Performance: use explicit dates and tickers when possible. Start narrow, then ex
 		&cobra.Group{ID: "market", Title: "Market Commands:"},
 		&cobra.Group{ID: "alerts", Title: "Alert Commands:"},
 		&cobra.Group{ID: "watchlists", Title: "Watchlist Commands:"},
+		&cobra.Group{ID: "reference", Title: "Reference Commands:"},
 	)
 	cmd.AddCommand(
 		trade.NewCmd(),
@@ -102,6 +103,7 @@ Performance: use explicit dates and tickers when possible. Start narrow, then ex
 		market.NewMarketCommand(),
 		alert.NewAlertCommand(),
 		watchlist.NewCmd(),
+		newOutputSchemaCmd(),
 	)
 	if err := structcli.Bind(cmd, opts); err != nil {
 		panic(fmt.Sprintf("structcli.Bind root options: %v", err))

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -100,8 +100,8 @@ func TestRootHasCommandGroups(t *testing.T) {
 	cmd := NewRootCmd("test")
 
 	groups := cmd.Groups()
-	if len(groups) != 5 {
-		t.Fatalf("expected 5 command groups, got %d", len(groups))
+	if len(groups) != 6 {
+		t.Fatalf("expected 6 command groups, got %d", len(groups))
 	}
 
 	expectedGroups := []struct {
@@ -112,6 +112,7 @@ func TestRootHasCommandGroups(t *testing.T) {
 		{"market"},
 		{"alerts"},
 		{"watchlists"},
+		{"reference"},
 	}
 	for _, tt := range expectedGroups {
 		t.Run(tt.id, func(t *testing.T) {
@@ -137,7 +138,7 @@ func TestAllTopLevelCommandsHaveGroupID(t *testing.T) {
 	t.Parallel()
 	cmd := NewRootCmd("test")
 
-	validGroups := []string{"trading", "volume", "market", "alerts", "watchlists"}
+	validGroups := []string{"trading", "volume", "market", "alerts", "watchlists", "reference"}
 	builtins := []string{"help", "completion"}
 
 	for _, sub := range cmd.Commands() {
@@ -486,6 +487,150 @@ func TestJSONSchemaSubcommandIncludesFlagUsabilityMetadata(t *testing.T) {
 			t.Fatalf("schema groups missing %q: %v", expectedGroup, groups)
 		}
 	}
+}
+
+func TestOutputSchemaTreeProducesCommandContracts(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	out, err := exec.Command(binary, "outputschema").CombinedOutput()
+	if err != nil {
+		t.Fatalf("outputschema failed: %v\nOutput: %s", err, out)
+	}
+
+	var contracts []map[string]any
+	if jsonErr := json.Unmarshal(out, &contracts); jsonErr != nil {
+		t.Fatalf("outputschema output is not valid JSON array: %v\nOutput: %s", jsonErr, out)
+	}
+	if len(contracts) != 26 {
+		t.Fatalf("expected 26 output contracts, got %d", len(contracts))
+	}
+
+	byCommand := make(map[string]map[string]any, len(contracts))
+	for _, contract := range contracts {
+		command, ok := contract["command"].(string)
+		if !ok || command == "" {
+			t.Fatalf("contract missing command string: %v", contract)
+		}
+		byCommand[command] = contract
+	}
+	for _, command := range []string{"trade list", "market exhaustion", "alert configs", "watchlist create"} {
+		if _, ok := byCommand[command]; !ok {
+			t.Fatalf("missing output contract for %q", command)
+		}
+	}
+}
+
+func TestOutputSchemaSubcommandDescribesVariantsAndFields(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	out, err := exec.Command(binary, "outputschema", "trade", "list").CombinedOutput()
+	if err != nil {
+		t.Fatalf("outputschema trade list failed: %v\nOutput: %s", err, out)
+	}
+
+	var contract map[string]any
+	if jsonErr := json.Unmarshal(out, &contract); jsonErr != nil {
+		t.Fatalf("outputschema trade list is not valid JSON object: %v\nOutput: %s", jsonErr, out)
+	}
+	if got := contract["command"]; got != "trade list" {
+		t.Fatalf("command = %v, want trade list", got)
+	}
+
+	schema := nestedMap(t, contract, "schema")
+	if got := schema["type"]; got != "array" {
+		t.Fatalf("schema.type = %v, want array", got)
+	}
+	items := nestedMap(t, schema, "items")
+	if got := items["model"]; got != "TradeListRow" {
+		t.Fatalf("schema.items.model = %v, want TradeListRow", got)
+	}
+	properties := nestedMap(t, items, "properties")
+	for _, field := range []string{"Ticker", "Dollars", "DarkPool"} {
+		if _, ok := properties[field]; !ok {
+			t.Fatalf("TradeListRow schema missing field %q", field)
+		}
+	}
+
+	variants, ok := contract["variants"].([]any)
+	if !ok {
+		t.Fatalf("contract variants missing or wrong type: %v", contract["variants"])
+	}
+	variantModels := make(map[string]bool)
+	for _, raw := range variants {
+		variant, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("variant is not an object: %v", raw)
+		}
+		variantSchema := nestedMap(t, variant, "schema")
+		model := schemaModel(variantSchema)
+		variantModels[model] = true
+	}
+	for _, model := range []string{"Trade", "TradeSummary"} {
+		if !variantModels[model] {
+			t.Fatalf("trade list contract missing variant model %q; got %v", model, variantModels)
+		}
+	}
+}
+
+func TestOutputSchemaMarketExhaustionProperties(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	out, err := exec.Command(binary, "outputschema", "market", "exhaustion").CombinedOutput()
+	if err != nil {
+		t.Fatalf("outputschema market exhaustion failed: %v\nOutput: %s", err, out)
+	}
+
+	var contract map[string]any
+	if jsonErr := json.Unmarshal(out, &contract); jsonErr != nil {
+		t.Fatalf("outputschema market exhaustion is not valid JSON object: %v\nOutput: %s", jsonErr, out)
+	}
+	schema := nestedMap(t, contract, "schema")
+	if got := schema["model"]; got != "MarketExhaustion" {
+		t.Fatalf("model = %v, want MarketExhaustion", got)
+	}
+	properties := nestedMap(t, schema, "properties")
+	for _, field := range []string{"date_key", "rank", "rank_30d", "rank_90d", "rank_365d"} {
+		fieldSchema := nestedMap(t, properties, field)
+		if got := fieldSchema["type"]; got != "integer" {
+			t.Fatalf("field %q type = %v, want integer", field, got)
+		}
+	}
+}
+
+func TestOutputSchemaUnknownCommandFails(t *testing.T) {
+	t.Parallel()
+	binary := buildBinary(t)
+
+	cmd := exec.Command(binary, "outputschema", "bogus")
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected exit error, got: %v", err)
+	}
+}
+
+func nestedMap(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	child, ok := parent[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%q missing or not an object: %v", key, parent[key])
+	}
+	return child
+}
+
+func schemaModel(schema map[string]any) string {
+	if model, ok := schema["model"].(string); ok {
+		return model
+	}
+	items, ok := schema["items"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	model, _ := items["model"].(string)
+	return model
 }
 
 func TestHelpOutputDisplaysFlagGroups(t *testing.T) {

--- a/internal/models/AGENTS.md
+++ b/internal/models/AGENTS.md
@@ -7,7 +7,7 @@ Response models for VolumeLeaders API data.
 - Verify JSON tags match VolumeLeaders response fields exactly, including capitalization and unusual API names.
 - Treat model changes that silently drop data needed by commands, summaries, or CSV/TSV output as P1.
 - Check whether new nullable or optional fields need pointer types, zero-value handling, or explicit formatting behavior.
-- Verify model changes are reflected in command field selection, summaries, tests, and `--jsonschema=tree` output where applicable. Update relevant command Long descriptions when user-visible behavior or semantic guidance changes.
+- Verify model changes are reflected in command field selection, summaries, tests, `--jsonschema=tree`, and `outputschema` output where applicable. Update relevant command Long descriptions when user-visible behavior or semantic guidance changes.
 - Do not request style-only changes that `gofmt`, `go vet`, or `golangci-lint` already enforce.
 
 ## Maintenance notes


### PR DESCRIPTION
## Summary
- Add `volumeleaders-agent outputschema` for machine-readable success stdout contracts across the 26 leaf commands.
- Document default schemas, alternate variants like `trade list --summary` and `--fields`, supported formats, and field-selection metadata without changing command output behavior.
- Update README and agent guidance so `outputschema` is the source of truth for stdout contracts.

## Verification
- `go test ./internal/cli -run 'TestOutputSchema|TestRootHasCommandGroups|TestAllTopLevelCommandsHaveGroupID' -count=1`
- `make test`
- `make lint`
- `make build`
- Direct `outputschema` JSON sanity check for all contracts, `trade list`, and `market exhaustion`
- Seven live read-only smoke commands: volume institutional, volume ah-institutional, volume total, trade list, trade sentiment, market exhaustion, watchlist configs
- Oracle goal, code quality, security, QA, and context reviews passed after docs fixes

Local CodeRabbit hit a rate limit, so GitHub CodeRabbit CI is expected to provide the review signal on this PR.