### PR TITLE
feat(docs): generate LLM discovery files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,12 @@ When modifying CLI commands, flags, models, or behavior:
 
 - Update `AGENTS.md` if the change affects project structure, build process, or conventions.
 - Use `volumeleaders-agent --jsonschema=tree` as the source of truth for command names, flags, aliases, defaults, and examples. Command Long descriptions contain embedded domain knowledge (workflows, conventions, gotchas).
+- Run `make generate-discovery` when commands, flags, defaults, examples, or Long descriptions change. The generated LLM discovery files live in `docs/llm/` so they do not overwrite this hand-maintained root `AGENTS.md`.
 
 Command documentation mapping:
 
 - All command groups -> `volumeleaders-agent --jsonschema=tree` for command shape and Long descriptions for semantic guidance.
+- Generated LLM discovery files -> `make generate-discovery` writes `docs/llm/AGENTS.md`, `docs/llm/SKILL.md`, and `docs/llm/llms.txt` from structcli metadata.
 - Shared conventions, workflows, output behavior, auth guidance, and domain gotchas -> root command Long description (run `volumeleaders-agent --help`).
 
 ## Project Layout
@@ -20,9 +22,11 @@ Command documentation mapping:
 cmd/volumeleaders-agent/main.go    Entry point
 internal/auth/                     Browser cookie + XSRF token extraction
 internal/client/                   HTTP client (DataTables + JSON requests)
-internal/commands/                 CLI command definitions (6 top-level commands, 26 subcommands)
+internal/cli/                      CLI command definitions (5 top-level commands, 26 subcommands)
+internal/discovery/                Generated LLM discovery file writer
 internal/datatables/               DataTables protocol encoding + column definitions
 internal/models/                   Response type definitions
+docs/llm/                          Generated AGENTS.md, SKILL.md, and llms.txt for LLM clients
 ```
 
 ## Build and Test
@@ -32,6 +36,7 @@ make build      # Build binary
 make test       # Run tests
 make lint       # Run linters
 make install    # Install to $GOPATH/bin
+make generate-discovery # Refresh docs/llm discovery files
 ```
 
 ## Conventions
@@ -53,7 +58,8 @@ make install    # Install to $GOPATH/bin
 - For `internal/auth/**/*.go`, check cookie extraction, browser profile handling, and token lookup paths for credential safety, useful error messages, and graceful behavior when browsers or cookies are unavailable.
 - For `internal/client/**/*.go`, check HTTP status handling, request context propagation, response body closure, DataTables encoding, and errors that explain the endpoint or operation that failed.
 - For `internal/models/**/*.go`, verify JSON tags match VolumeLeaders response fields and that model changes do not silently drop data needed by commands, summaries, or CSV/TSV output.
-- For `internal/commands/**/*.go`, verify command behavior matches README, `volumeleaders-agent --jsonschema=tree`, and the conventions above. If commands, flags, aliases, defaults, or examples change, verify `--jsonschema=tree` output reflects the changes. If workflows, behavior, models, or output formats change, update the relevant command Long descriptions.
+- For `internal/cli/**/*.go`, verify command behavior matches README, `volumeleaders-agent --jsonschema=tree`, and the conventions above. If commands, flags, aliases, defaults, or examples change, verify `--jsonschema=tree` output reflects the changes and run `make generate-discovery`. If workflows, behavior, models, or output formats change, update the relevant command Long descriptions.
+- For `internal/discovery/**/*.go`, verify generated files are deterministic, do not overwrite the root `AGENTS.md`, and stay in sync with `docs/llm/` through tests.
 - For tests, expect table-driven subtests with `t.Run`, parallelization where safe, `t.TempDir()` for filesystem work, deterministic fixtures, and assertions on observable behavior rather than implementation details. Do not request arbitrary coverage percentage changes.
 - For GitHub Actions workflows, treat unpinned actions, excessive permissions, secret exposure in logs, or unsafe pull request execution patterns as P1.
 - For `Makefile`, check that non-file targets are declared `.PHONY` and avoid adding flags that duplicate tool defaults.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Fork the repo, create a branch, and open a PR against `main`.
 
 ## Code Style
 
-Follow the patterns already in the codebase. `make lint` catches most issues. When in doubt, look at how existing commands in `internal/commands/` are structured and match that style.
+Follow the patterns already in the codebase. `make lint` catches most issues. When in doubt, look at how existing commands in `internal/cli/` are structured and match that style.
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean install release
+.PHONY: build test lint clean install generate-discovery release
 
 build:
 	go build -o volumeleaders-agent ./cmd/volumeleaders-agent
@@ -16,6 +16,9 @@ clean:
 
 install:
 	go install ./cmd/volumeleaders-agent
+
+generate-discovery:
+	go run ./cmd/generate-discovery
 
 release:
 ifndef VERSION

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ volumeleaders-agent trade list --tickers NVDA --start-date 2025-01-01 --end-date
 volumeleaders-agent --pretty market exhaustion
 ```
 
-Commands emit compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr. Use `--jsonschema=tree` on the root command for a machine-readable JSON Schema of the full CLI.
+Commands emit compact JSON to stdout by default. Use `--pretty` for indented output. Errors go to stderr. Use `--jsonschema=tree` on the root command for a machine-readable JSON Schema of the full CLI. Generated LLM discovery files live in `docs/llm/` and can be refreshed with `make generate-discovery`.
 
 ## Commands
 
@@ -48,6 +48,14 @@ Commands emit compact JSON to stdout by default. Use `--pretty` for indented out
 
 Use `volumeleaders-agent --jsonschema=tree` for the machine-readable JSON Schema of all commands and flags. Run `volumeleaders-agent --help` for embedded domain knowledge, filter conventions, workflows, and domain gotchas.
 
+## LLM discovery files
+
+The `docs/llm/` directory contains generated `AGENTS.md`, `SKILL.md`, and `llms.txt` files built from the Cobra and structcli command tree. Refresh them after command, flag, default, or example changes:
+
+```bash
+make generate-discovery
+```
+
 ## Build
 
 ```bash
@@ -55,6 +63,7 @@ make build      # Build binary
 make test       # Run tests
 make lint       # Run golangci-lint
 make install    # Install to $GOPATH/bin
+make generate-discovery # Refresh docs/llm discovery files
 ```
 
 ## License

--- a/cmd/generate-discovery/main.go
+++ b/cmd/generate-discovery/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/major/volumeleaders-agent/internal/discovery"
+)
+
+func main() {
+	outputDir := flag.String("output", discovery.DefaultOutputDir, "directory for generated discovery files")
+	version := flag.String("version", "dev", "version to record in generated discovery files")
+	flag.Parse()
+
+	if err := discovery.Generate(*outputDir, *version); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docs/llm/AGENTS.md
+++ b/docs/llm/AGENTS.md
@@ -1,0 +1,589 @@
+# volumeleaders-agent
+
+volumeleaders-agent queries institutional trade data from VolumeLeaders. Use it for trades, volume leaderboards, market data, alerts, and watchlists.
+
+Auth: reads browser cookies automatically. If auth fails with exit code 2 and "Authentication required: VolumeLeaders session has expired.", log in at https://www.volumeleaders.com in your browser, then retry.
+
+Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable JSON Schema output, or --jsonschema=tree on the root for the full CLI tree. Errors and logs go to stderr.
+
+COMMAND CHOOSER
+
+Goal                                          Start with                              Notes
+--------------------------------------------  --------------------------------------  -----------------------------------------------
+Find individual institutional prints          trade list X --days N                   Use ticker filters, presets, or watchlists
+Compare leveraged ETF bull/bear flow          trade sentiment --days N                Fixed leveraged ETF universe, not buy/sell flow
+Find converging price-level activity          trade clusters --days N                 Cluster conviction around similar prices
+Find sudden aggressive bursts                 trade cluster-bombs --days N            Burst detection, different defaults than clusters
+Inspect trade or cluster alerts               trade alerts --date D                   System-generated alerts
+Find support/resistance levels                trade levels X --days N                 One ticker, capped level count
+Find revisits to institutional levels         trade level-touches X --days N          Level retests, capped pagination
+See institutional volume leaders              volume institutional --date D            Same trade model, volume-ranked
+See after-hours institutional leaders         volume ah-institutional --date D        After-hours institutional flow
+See total volume leaders                      volume total --date D                   Total market volume across trade types
+Get current prices                            market snapshots                        JSON object
+Find earnings with prior institutional flow   market earnings --days N                CSV/TSV supported
+Check exhaustion/reversal signals             market exhaustion --date D              Lower rank is stronger
+Manage alert configs                          alert configs/create/edit/delete        Edit replaces unspecified values with defaults
+Manage watchlists                             watchlist configs/create/edit/delete    Edit replaces unspecified values with defaults
+Get watchlist tickers                         watchlist tickers --watchlist-key K     Key comes from watchlist configs
+
+ANALYSIS WORKFLOW
+
+1. volume institutional --date D for top dollar movers.
+2. trade list X --days N for individual prints.
+3. trade levels X --days N for support/resistance.
+4. trade clusters X --days N when prints appear concentrated around a price.
+5. market earnings --days N and market exhaustion --date D for event and reversal context.
+
+GLOBAL CONVENTIONS
+
+Dates: YYYY-MM-DD. Commands with date ranges accept either --start-date D --end-date D or --days N. --days counts backward from today unless --end-date is also set, and cannot be combined with --start-date.
+
+Pagination: --start offset, --length count, --length -1 means all rows unless a capped endpoint rejects it. trade list, trade list --summary, and trade level-touches only allow 1 to 50 rows. trade levels caps --trade-level-count at 50.
+
+Toggle filters: -1 means all/unfiltered, 0 means exclude, 1 means include/only.
+
+Tickers: --tickers is comma-separated, --ticker is single-symbol. Commands that take tickers generally accept positional tickers too, for example: trade list XLE XLK. Trade and volume ticker filters also accept --symbol and --symbols aliases.
+
+Output formats: list-style commands may support --format json/csv/tsv. CSV/TSV include headers, booleans render as true/false, null or missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless the schema shows a format flag.
+
+Performance: use explicit dates and tickers when possible. Start narrow, then expand. VolumeLeaders endpoints can be expensive and some trade retrieval endpoints are intentionally capped.
+
+## Installation
+
+```bash
+go install github.com/major/volumeleaders-agent/cmd/volumeleaders-agent@latest
+```
+
+## Commands
+
+| Command | Description | Required Flags |
+|---------|-------------|---------------|
+| `volumeleaders-agent alert configs` | List all saved alert configurations with their keys, names, ticker filters, trade conditions, and notification settings. Outputs compact JSON or CSV/TSV with --format. Use --fields to select specific output fields. |  |
+| `volumeleaders-agent alert create` | Create a new alert configuration with a name and filter settings for institutional trade activity. Requires --name. Specify filters such as trade rank, dollar thresholds, dark pool and sweep conditions, and ticker scope. Returns a success response with the new configuration key. | `--name` |
+| `volumeleaders-agent alert delete` | Remove a saved alert configuration by its numeric key. Requires --key with the alert config key (visible in configs output). The deletion is permanent and cannot be undone. | `--key` |
+| `volumeleaders-agent alert edit` | Modify an existing alert configuration identified by its numeric key. Requires --key with the alert config key. Specify only the fields you want to change; unspecified fields retain their current values. | `--key` |
+| `volumeleaders-agent market earnings` | Query the earnings calendar for a date range, showing tickers with earnings dates and associated trade activity counts. Requires --start-date and --end-date (or --days). Outputs compact JSON or CSV/TSV with --format. |  |
+| `volumeleaders-agent market exhaustion` | Query exhaustion scores that indicate overbought or oversold market conditions based on institutional trade clustering patterns. Omit --date to query the current trading day. Outputs compact JSON with rank metrics at different lookback periods. |  |
+| `volumeleaders-agent market snapshots` | Retrieve current price snapshot data for all symbols tracked by VolumeLeaders, returning the latest available price and volume data. No date filtering is available; always returns the most recent data. Outputs compact JSON by default. |  |
+| `volumeleaders-agent trade alerts` | Query trade alerts fired on a specific date based on saved alert configurations. Requires --date. Returns alert records matching your configured filters. Outputs compact JSON or CSV/TSV with --format.
+
+Alert configs trigger when trades match thresholds. Threshold names follow the pattern CategoryMetricLTE or CategoryMetricGTE where LTE is maximum rank and GTE is minimum value. Use alert configs to see your configured thresholds. | `--date` |
+| `volumeleaders-agent trade cluster-alerts` | Query trade cluster alerts fired on a specific date based on saved alert configurations that target cluster activity. Requires --date. Returns cluster alert records matching your configured filters.
+
+Cluster alert rows use the full cluster-shaped model rather than the compact default from trade clusters. Use trade alerts for individual trade alert rows and this command for cluster-level alert rows. | `--date` |
+| `volumeleaders-agent trade cluster-bombs` | Query trade cluster bombs, which are extreme-magnitude trade clusters that exceed normal institutional activity thresholds. Filterable by ticker, date range, dollar amounts, sector, and cluster bomb rank. Outputs compact JSON by default.
+
+Cluster bombs find sudden aggressive bursts tightly grouped in time and price, with different defaults and rank fields than trade clusters. Use this command when looking for extreme concentration events, not general price-level clustering. |  |
+| `volumeleaders-agent trade clusters` | Query aggregated trade clusters, which group multiple trades in a short window into a single cluster record. Filterable by ticker, date range, dollar amounts, sector, and trade cluster rank. Outputs compact JSON or CSV/TSV with --format.
+
+Use clusters when the question is about price-level concentration, not single prints. This command uses larger default retrieval and dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price. |  |
+| `volumeleaders-agent trade level-touches` | Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
+
+Defaults to --length 50 and rejects --length -1, --length 0, and values above 50. Use trade levels first to identify significant price zones, then use this command to find events where price revisited those levels. |  |
+| `volumeleaders-agent trade levels` | Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Outputs compact JSON by default.
+
+Defaults to a 1-year lookback when dates are omitted. Uses non-standard --relative-size 0 and caps level count from 1 to 50 via --trade-level-count. Default JSON is compact and omits repetitive ticker metadata and the verbose Dates list; use --fields all or CSV/TSV when raw fields are needed. |  |
+| `volumeleaders-agent trade list` | Query individual institutional trades from VolumeLeaders, filterable by ticker, date range, dollar amounts, volume, trade conditions, session type, and trade rank. Supports built-in filter presets (--preset) and watchlist-based filtering (--watchlist). Outputs compact JSON or CSV/TSV with --format; use --summary for aggregate metrics grouped by ticker or day.
+
+Date defaults: 365-day lookback when tickers are provided, today-only without tickers. Preset and watchlist filters do not supply dates. Filter precedence is preset baseline, then watchlist merge, then explicit CLI flags override both.
+
+Default JSON is compact and omits repetitive/internal fields. Use --fields FIELD1,FIELD2, CSV/TSV, or --fields all where supported when raw API fields are needed. --summary returns aggregate JSON with valid --group-by values of ticker, day, or ticker,day; do not combine summary mode with --fields or non-JSON formats.
+
+KEY METRICS
+
+Field                      Meaning
+-------------------------  ---------------------------------------------------------------
+CumulativeDistribution     Volume percentile, 0 to 1, higher means more accumulation
+DollarsMultiplier          Trade dollars relative to average block size
+TradeRank                  VL significance rank now, lower is stronger
+TradeRankSnapshot          VL significance rank at print time, lower is stronger
+TradeClusterRank           Rank for cluster significance, lower is stronger
+TradeClusterBombRank       Rank for burst significance, lower is stronger
+TradeLevelRank             Rank for level significance, lower is stronger
+RelativeSize               Trade size vs normal activity
+PercentDailyVolume         Trade volume as percent of average daily volume
+VCD                        Volume Confirmation Distribution score
+FrequencyLast30TD          Similar-magnitude trade frequency over last 30 trading days
+FrequencyLast90TD          Similar-magnitude trade frequency over last 90 trading days
+FrequencyLast1CY           Similar-magnitude trade frequency over last calendar year
+RSIHour                    Hourly RSI at time of trade
+RSIDay                     Daily RSI at time of trade
+DarkPool                   Boolean: trade printed on a dark pool
+Sweep                      Boolean: trade was a sweep order
+LatePrint                  Boolean: trade was a late print
+SignaturePrint             Boolean: trade matched a signature print pattern
+PhantomPrint               Boolean: trade was a phantom print
+InsideBar                  Boolean: bar was an inside bar
+
+Shared trade filters include volume, price, dollars, conditions, VCD, relative size, security type, market cap, trade rank, dark pools, sweeps, late prints, signature prints, even-share prints, and session/event toggles. |  |
+| `volumeleaders-agent trade preset-tickers` | Extract the ticker symbols configured in a named trade filter preset, showing whether the preset uses an explicit ticker list, a sector/industry filter, or is unfiltered. Requires --preset with the preset name (case-insensitive). Outputs JSON with the preset name, group, type, and ticker details. | `--preset` |
+| `volumeleaders-agent trade presets` | List all built-in trade filter presets with their names, groups, and filter configurations. Each preset defines a named set of filters that can be applied to trade list queries via --preset. Outputs compact JSON by default; use --format csv or tsv for tabular output. |  |
+| `volumeleaders-agent trade sentiment` | Summarize leveraged ETF bull and bear flow by trading day, showing aggregate institutional dollar volume on the bull and bear side. Requires --start-date and --end-date (or --days). Outputs one record per day with bull and bear totals.
+
+This command always queries the combined leveraged ETF sector filter SectorIndustry=X B, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags. Non-standard defaults include --min-dollars 5000000 and --vcd 97; shared --relative-size 5 still applies.
+
+Ratio is bull dollars divided by bear dollars and is null when bear flow is zero. Treat the output as leveraged ETF proxy flow, not signed buy/sell flow for the broader market. |  |
+| `volumeleaders-agent volume ah-institutional` | Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date. | `--date` |
+| `volumeleaders-agent volume institutional` | Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format. | `--date` |
+| `volumeleaders-agent volume total` | Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date. | `--date` |
+| `volumeleaders-agent watchlist add-ticker` | Add a ticker symbol to an existing watchlist. Requires --watchlist-key with the watchlist key and --ticker with the symbol to add. The ticker is appended to the watchlist without affecting existing symbols. | `--ticker`, `--watchlist-key` |
+| `volumeleaders-agent watchlist configs` | List all saved watchlist configurations with their keys and names. Outputs compact JSON or CSV/TSV with --format. Each row shows the watchlist key and name; use the tickers subcommand to view symbols in a specific watchlist. |  |
+| `volumeleaders-agent watchlist create` | Create a new watchlist configuration with a name and optional filter settings such as minimum volume, price range, sector, and trade conditions. Requires --name. Use --tickers to specify an explicit ticker list or leave unset for a filter-based watchlist. | `--name` |
+| `volumeleaders-agent watchlist delete` | Remove a saved watchlist configuration by its numeric key. Requires --key with the watchlist key (visible in configs output). The deletion is permanent and removes the watchlist and all its tickers. | `--key` |
+| `volumeleaders-agent watchlist edit` | Modify an existing watchlist configuration identified by its numeric key. Requires --key with the watchlist key. Specify only the fields you want to change; unspecified fields retain their current values. | `--key` |
+| `volumeleaders-agent watchlist tickers` | Query the ticker symbols belonging to a specific watchlist identified by --watchlist-key. Returns all tickers in the watchlist with their metadata. Outputs compact JSON or CSV/TSV with --format. |  |
+
+## Configuration
+
+### Flags
+
+#### `volumeleaders-agent alert configs`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--fields` | string | - | Comma-separated fields to include (use 'all' for every field) |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+
+#### `volumeleaders-agent alert create`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah-dollars-gte` | int | 0 | After-hours dollars >= |
+| `--ah-rank-lte` | int | 0 | After-hours rank <= |
+| `--ah-volume-gte` | int | 0 | After-hours volume >= |
+| `--closing-trade-conditions` | string | 0 | Closing trade conditions |
+| `--closing-trade-dollars-gte` | int | 0 | Closing trade dollars >= |
+| `--closing-trade-mult-gte` | int | 0 | Closing trade multiplier >= |
+| `--closing-trade-rank-lte` | int | 0 | Closing trade rank <= |
+| `--closing-trade-vcd-gte` | int | 0 | Closing trade VCD >= (0/97/98/99/100) |
+| `--closing-trade-volume-gte` | int | 0 | Closing trade volume >= |
+| `--cluster-dollars-gte` | int | 0 | Trade cluster dollars >= |
+| `--cluster-mult-gte` | int | 0 | Trade cluster multiplier >= |
+| `--cluster-rank-lte` | int | 0 | Trade cluster rank <= |
+| `--cluster-vcd-gte` | int | 0 | Trade cluster VCD >= (0/97/98/99/100) |
+| `--cluster-volume-gte` | int | 0 | Trade cluster volume >= |
+| `--dark-pool` | bool | false | Dark pool filter |
+| `--name` | string | - | Alert name (max 50 chars) |
+| `--offsetting-print` | bool | false | Offsetting print filter |
+| `--phantom-print` | bool | false | Phantom print filter |
+| `--sweep` | bool | false | Sweep filter |
+| `--ticker-group` | string | AllTickers | Ticker group (AllTickers or SelectedTickers) |
+| `--tickers` | string | - | Comma-separated ticker symbols (max 500, used with SelectedTickers) |
+| `--total-dollars-gte` | int | 0 | Total dollars >= |
+| `--total-rank-lte` | int | 0 | Total rank <= (0/1/3/10/25/50/100) |
+| `--total-volume-gte` | int | 0 | Total volume >= |
+| `--trade-conditions` | string | 0 | Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos) |
+| `--trade-dollars-gte` | int | 0 | Trade dollars >= (0=N/A, 1000000/10000000/...) |
+| `--trade-mult-gte` | int | 0 | Trade multiplier >= (0=N/A, 5/10/25/50/100) |
+| `--trade-rank-lte` | int | 0 | Trade rank <= (0=N/A, 1/3/5/10/25/50/100) |
+| `--trade-vcd-gte` | int | 0 | Trade VCD >= (0=N/A, 99/100) |
+| `--trade-volume-gte` | int | 0 | Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000) |
+
+#### `volumeleaders-agent alert delete`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--key` | int | 0 | Alert config key to delete |
+
+#### `volumeleaders-agent alert edit`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah-dollars-gte` | int | 0 | After-hours dollars >= |
+| `--ah-rank-lte` | int | 0 | After-hours rank <= |
+| `--ah-volume-gte` | int | 0 | After-hours volume >= |
+| `--closing-trade-conditions` | string | 0 | Closing trade conditions |
+| `--closing-trade-dollars-gte` | int | 0 | Closing trade dollars >= |
+| `--closing-trade-mult-gte` | int | 0 | Closing trade multiplier >= |
+| `--closing-trade-rank-lte` | int | 0 | Closing trade rank <= |
+| `--closing-trade-vcd-gte` | int | 0 | Closing trade VCD >= (0/97/98/99/100) |
+| `--closing-trade-volume-gte` | int | 0 | Closing trade volume >= |
+| `--cluster-dollars-gte` | int | 0 | Trade cluster dollars >= |
+| `--cluster-mult-gte` | int | 0 | Trade cluster multiplier >= |
+| `--cluster-rank-lte` | int | 0 | Trade cluster rank <= |
+| `--cluster-vcd-gte` | int | 0 | Trade cluster VCD >= (0/97/98/99/100) |
+| `--cluster-volume-gte` | int | 0 | Trade cluster volume >= |
+| `--dark-pool` | bool | false | Dark pool filter |
+| `--key` | int | 0 | Alert config key to edit |
+| `--name` | string | - | Alert name (max 50 chars) |
+| `--offsetting-print` | bool | false | Offsetting print filter |
+| `--phantom-print` | bool | false | Phantom print filter |
+| `--sweep` | bool | false | Sweep filter |
+| `--ticker-group` | string | AllTickers | Ticker group (AllTickers or SelectedTickers) |
+| `--tickers` | string | - | Comma-separated ticker symbols (max 500, used with SelectedTickers) |
+| `--total-dollars-gte` | int | 0 | Total dollars >= |
+| `--total-rank-lte` | int | 0 | Total rank <= (0/1/3/10/25/50/100) |
+| `--total-volume-gte` | int | 0 | Total volume >= |
+| `--trade-conditions` | string | 0 | Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos) |
+| `--trade-dollars-gte` | int | 0 | Trade dollars >= (0=N/A, 1000000/10000000/...) |
+| `--trade-mult-gte` | int | 0 | Trade multiplier >= (0=N/A, 5/10/25/50/100) |
+| `--trade-rank-lte` | int | 0 | Trade rank <= (0=N/A, 1/3/5/10/25/50/100) |
+| `--trade-vcd-gte` | int | 0 | Trade VCD >= (0=N/A, 99/100) |
+| `--trade-volume-gte` | int | 0 | Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000) |
+
+#### `volumeleaders-agent market earnings`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (required unless --days is set) |
+| `--fields` | string | - | Comma-separated fields to include (use 'all' for every field) |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--start-date` | string | - | Start date YYYY-MM-DD (required unless --days is set) |
+
+#### `volumeleaders-agent market exhaustion`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--date` | string | - | Date YYYY-MM-DD (empty for current day) |
+
+#### `volumeleaders-agent trade alerts`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--date` | string | - | Date YYYY-MM-DD |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 100 | Number of results |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | desc | Order direction (asc, desc) |
+| `--start` | int | 0 | DataTables start offset |
+
+#### `volumeleaders-agent trade cluster-alerts`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--date` | string | - | Date YYYY-MM-DD |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 100 | Number of results |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | desc | Order direction (asc, desc) |
+| `--start` | int | 0 | DataTables start offset |
+
+#### `volumeleaders-agent trade cluster-bombs`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (required unless --days is set) |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 100 | Number of results |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 0 | Minimum dollar value |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | desc | Order direction (asc, desc) |
+| `--relative-size` | int | 0 | Relative size threshold |
+| `--sector` | string | - | Sector/Industry filter |
+| `--security-type` | int | 0 | Security type key |
+| `--start` | int | 0 | DataTables start offset |
+| `--start-date` | string | - | Start date YYYY-MM-DD (required unless --days is set) |
+| `--tickers` | string | - | Comma-separated ticker symbols |
+| `--trade-cluster-bomb-rank` | int | -1 | Trade cluster bomb rank filter |
+| `--vcd` | int | 0 | VCD filter |
+
+#### `volumeleaders-agent trade clusters`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (required unless --days is set) |
+| `--fields` | string | - | Comma-separated TradeCluster fields to include in output, or 'all' for every field |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 1000 | Number of results |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-price` | float64 | 100000 | Maximum price |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 10000000 | Minimum dollar value |
+| `--min-price` | float64 | 0 | Minimum price |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | desc | Order direction (asc, desc) |
+| `--relative-size` | int | 5 | Relative size threshold |
+| `--sector` | string | - | Sector/Industry filter |
+| `--security-type` | int | -1 | Security type key |
+| `--start` | int | 0 | DataTables start offset |
+| `--start-date` | string | - | Start date YYYY-MM-DD (required unless --days is set) |
+| `--tickers` | string | - | Comma-separated ticker symbols |
+| `--trade-cluster-rank` | int | -1 | Trade cluster rank filter |
+| `--vcd` | int | 0 | VCD filter |
+
+#### `volumeleaders-agent trade level-touches`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (required unless --days is set) |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 50 | Number of results |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-price` | float64 | 100000 | Maximum price |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 500000 | Minimum dollar value |
+| `--min-price` | float64 | 0 | Minimum price |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--order-col` | int | 0 | Order column index |
+| `--order-dir` | string | desc | Order direction (asc, desc) |
+| `--relative-size` | int | 0 | Relative size threshold |
+| `--start` | int | 0 | DataTables start offset |
+| `--start-date` | string | - | Start date YYYY-MM-DD (required unless --days is set) |
+| `--ticker` | string | - | Ticker symbol |
+| `--trade-level-count` | int | 50 | Number of price levels to include (1-50) |
+| `--trade-level-rank` | int | 10 | Trade level rank filter |
+| `--vcd` | int | 0 | VCD filter |
+
+#### `volumeleaders-agent trade levels`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (default: today) |
+| `--fields` | string | - | Comma-separated TradeLevel fields to include in output, or 'all' for every field |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-price` | float64 | 100000 | Maximum price |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 500000 | Minimum dollar value |
+| `--min-price` | float64 | 0 | Minimum price |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--relative-size` | int | 0 | Relative size threshold |
+| `--start-date` | string | - | Start date YYYY-MM-DD (default: auto) |
+| `--ticker` | string | - | Ticker symbol |
+| `--trade-level-count` | int | 10 | Number of price levels to return (1-50) |
+| `--trade-level-rank` | int | -1 | Trade level rank filter |
+| `--vcd` | int | 0 | VCD filter |
+
+#### `volumeleaders-agent trade list`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah` | int | 1 | Include after hours |
+| `--closing` | int | 1 | Include closing trades |
+| `--conditions` | int | -1 | Trade conditions filter |
+| `--dark-pools` | int | -1 | Dark pool filter |
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (default: today) |
+| `--even-shared` | int | -1 | Even shared filter |
+| `--fields` | string | - | Comma-separated trade fields to include in output |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--group-by` | string | ticker | Summary grouping (requires --summary): ticker, day, or ticker,day (day, ticker, ticker,day) |
+| `--late-prints` | int | -1 | Late print filter |
+| `--length` | int | 10 | Number of results |
+| `--market-cap` | int | 0 | Market cap filter |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-price` | float64 | 100000 | Maximum price |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 500000 | Minimum dollar value |
+| `--min-price` | float64 | 0 | Minimum price |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--offsetting` | int | 1 | Include offsetting trades |
+| `--opening` | int | 1 | Include opening trades |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | desc | Order direction (asc, desc) |
+| `--phantom` | int | 1 | Include phantom prints |
+| `--premarket` | int | 1 | Include premarket |
+| `--preset` | string | - | Apply a built-in filter preset (see: trade presets) |
+| `--rank-snapshot` | int | -1 | Trade rank snapshot filter |
+| `--relative-size` | int | 5 | Relative size threshold |
+| `--rth` | int | 1 | Include regular trading hours |
+| `--sector` | string | - | Sector/Industry filter |
+| `--security-type` | int | -1 | Security type key |
+| `--sig-prints` | int | -1 | Signature print filter |
+| `--start` | int | 0 | DataTables start offset |
+| `--start-date` | string | - | Start date YYYY-MM-DD (default: auto) |
+| `--summary` | bool | false | Return aggregate metrics instead of individual trades |
+| `--sweeps` | int | -1 | Sweep filter |
+| `--tickers` | string | - | Comma-separated ticker symbols |
+| `--trade-rank` | int | -1 | Trade rank filter |
+| `--vcd` | int | 97 | VCD filter |
+| `--watchlist` | string | - | Apply filters from a saved watchlist by name |
+
+#### `volumeleaders-agent trade preset-tickers`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--preset` | string | - | Preset name (case-insensitive) |
+
+#### `volumeleaders-agent trade presets`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+
+#### `volumeleaders-agent trade sentiment`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah` | int | 1 | Include after hours |
+| `--closing` | int | 1 | Include closing trades |
+| `--conditions` | int | -1 | Trade conditions filter |
+| `--dark-pools` | int | -1 | Dark pool filter |
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (required unless --days is set) |
+| `--even-shared` | int | -1 | Even shared filter |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--late-prints` | int | -1 | Late print filter |
+| `--market-cap` | int | 0 | Market cap filter |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-price` | float64 | 100000 | Maximum price |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 5000000 | Minimum dollar value |
+| `--min-price` | float64 | 0 | Minimum price |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--offsetting` | int | 1 | Include offsetting trades |
+| `--opening` | int | 1 | Include opening trades |
+| `--phantom` | int | 1 | Include phantom prints |
+| `--premarket` | int | 1 | Include premarket |
+| `--rank-snapshot` | int | -1 | Trade rank snapshot filter |
+| `--relative-size` | int | 5 | Relative size threshold |
+| `--rth` | int | 1 | Include regular trading hours |
+| `--security-type` | int | -1 | Security type key |
+| `--sig-prints` | int | -1 | Signature print filter |
+| `--start-date` | string | - | Start date YYYY-MM-DD (required unless --days is set) |
+| `--sweeps` | int | -1 | Sweep filter |
+| `--trade-rank` | int | -1 | Trade rank filter |
+| `--vcd` | int | 97 | VCD filter |
+
+#### `volumeleaders-agent volume ah-institutional`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--date` | string | - | Date YYYY-MM-DD |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 100 | Number of results |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | asc | Order direction (asc, desc) |
+| `--start` | int | 0 | DataTables start offset |
+| `--tickers` | string | - | Comma-separated ticker symbols |
+
+#### `volumeleaders-agent volume institutional`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--date` | string | - | Date YYYY-MM-DD |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 100 | Number of results |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | asc | Order direction (asc, desc) |
+| `--start` | int | 0 | DataTables start offset |
+| `--tickers` | string | - | Comma-separated ticker symbols |
+
+#### `volumeleaders-agent volume total`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--date` | string | - | Date YYYY-MM-DD |
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--length` | int | 100 | Number of results |
+| `--order-col` | int | 1 | Order column index |
+| `--order-dir` | string | asc | Order direction (asc, desc) |
+| `--start` | int | 0 | DataTables start offset |
+| `--tickers` | string | - | Comma-separated ticker symbols |
+
+#### `volumeleaders-agent watchlist add-ticker`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ticker` | string | - | Ticker symbol to add |
+| `--watchlist-key` | int | 0 | Watch list key |
+
+#### `volumeleaders-agent watchlist configs`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+
+#### `volumeleaders-agent watchlist create`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah-trades` | bool | true | Include after-hours trades |
+| `--blocks` | bool | true | Include block trades |
+| `--closing-trades` | bool | true | Include closing trades |
+| `--dark-pools` | bool | true | Include dark pool trades |
+| `--late-prints` | bool | true | Include late prints |
+| `--lit-exchanges` | bool | true | Include lit exchange trades |
+| `--max-dollars` | float64 | 3e+10 | Maximum dollars filter |
+| `--max-price` | float64 | 100000 | Maximum price filter |
+| `--max-trade-rank` | int | -1 | Maximum trade rank (-1=all, 1/3/5/10/25/50/100) |
+| `--max-volume` | int | 2000000000 | Maximum volume filter |
+| `--min-dollars` | float64 | 0 | Minimum dollars filter |
+| `--min-price` | float64 | 0 | Minimum price filter |
+| `--min-relative-size` | int | 0 | Minimum relative size (0/5/10/25/50/100) |
+| `--min-vcd` | float64 | 0 | Minimum VCD percentile (0-100) |
+| `--min-volume` | int | 0 | Minimum volume filter |
+| `--name` | string | - | Watch list name |
+| `--normal-prints` | bool | true | Include normal prints |
+| `--offsetting-trades` | bool | true | Include offsetting trades |
+| `--opening-trades` | bool | true | Include opening trades |
+| `--phantom-trades` | bool | true | Include phantom trades |
+| `--premarket-trades` | bool | true | Include premarket trades |
+| `--rsi-overbought-daily` | int | -1 | RSI overbought daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-overbought-hourly` | int | -1 | RSI overbought hourly (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-daily` | int | -1 | RSI oversold daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-hourly` | int | -1 | RSI oversold hourly (1=yes, 0=no, -1=ignore) |
+| `--rth-trades` | bool | true | Include regular trading hours trades |
+| `--sector-industry` | string | - | Sector/industry filter (max 100 chars) |
+| `--security-type` | int | -1 | Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs) |
+| `--signature-prints` | bool | true | Include signature prints |
+| `--sweeps` | bool | true | Include sweep trades |
+| `--tickers` | string | - | Comma-separated ticker symbols (max 500) |
+| `--timely-prints` | bool | true | Include timely prints |
+
+#### `volumeleaders-agent watchlist delete`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--key` | int | 0 | Watch list key to delete |
+
+#### `volumeleaders-agent watchlist edit`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah-trades` | bool | true | Include after-hours trades |
+| `--blocks` | bool | true | Include block trades |
+| `--closing-trades` | bool | true | Include closing trades |
+| `--dark-pools` | bool | true | Include dark pool trades |
+| `--key` | int | 0 | Watch list key to edit |
+| `--late-prints` | bool | true | Include late prints |
+| `--lit-exchanges` | bool | true | Include lit exchange trades |
+| `--max-dollars` | float64 | 3e+10 | Maximum dollars filter |
+| `--max-price` | float64 | 100000 | Maximum price filter |
+| `--max-trade-rank` | int | -1 | Maximum trade rank (-1=all, 1/3/5/10/25/50/100) |
+| `--max-volume` | int | 2000000000 | Maximum volume filter |
+| `--min-dollars` | float64 | 0 | Minimum dollars filter |
+| `--min-price` | float64 | 0 | Minimum price filter |
+| `--min-relative-size` | int | 0 | Minimum relative size (0/5/10/25/50/100) |
+| `--min-vcd` | float64 | 0 | Minimum VCD percentile (0-100) |
+| `--min-volume` | int | 0 | Minimum volume filter |
+| `--name` | string | - | Watch list name |
+| `--normal-prints` | bool | true | Include normal prints |
+| `--offsetting-trades` | bool | true | Include offsetting trades |
+| `--opening-trades` | bool | true | Include opening trades |
+| `--phantom-trades` | bool | true | Include phantom trades |
+| `--premarket-trades` | bool | true | Include premarket trades |
+| `--rsi-overbought-daily` | int | -1 | RSI overbought daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-overbought-hourly` | int | -1 | RSI overbought hourly (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-daily` | int | -1 | RSI oversold daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-hourly` | int | -1 | RSI oversold hourly (1=yes, 0=no, -1=ignore) |
+| `--rth-trades` | bool | true | Include regular trading hours trades |
+| `--sector-industry` | string | - | Sector/industry filter (max 100 chars) |
+| `--security-type` | int | -1 | Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs) |
+| `--signature-prints` | bool | true | Include signature prints |
+| `--sweeps` | bool | true | Include sweep trades |
+| `--tickers` | string | - | Comma-separated ticker symbols (max 500) |
+| `--timely-prints` | bool | true | Include timely prints |
+
+#### `volumeleaders-agent watchlist tickers`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | string | json | Output format: json, csv, or tsv (csv, json, tsv) |
+| `--watchlist-key` | int | -1 | Watch list key (-1 for all) |
+
+## Machine Interface
+
+- JSON Schema: `volumeleaders-agent --jsonschema`
+- Structured errors: JSON on stderr with semantic exit codes
+

--- a/docs/llm/SKILL.md
+++ b/docs/llm/SKILL.md
@@ -1,0 +1,949 @@
+---
+name: volumeleaders-agent
+description: |
+  volumeleaders-agent queries institutional trade data from VolumeLeaders. Use it for trades, volume leaderboards, market data, alerts, and watchlists.
+  
+  Auth: reads browser cookies automatically. If auth fails with exit code 2 and "Authentication required: VolumeLeaders session has expired.", log in at https://www.volumeleaders.com in your browser, then retry.
+  
+  Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable JSON Schema output, or --jsonschema=tree on the root for the full CLI tree. Errors and logs go to stderr.
+  
+  COMMAND CHOOSER
+  
+  Goal                                          Start with                              Notes
+  --------------------------------------------  --------------------------------------  -----------------------------------------------
+  Find individual institutional prints          trade list X --days N                   Use ticker filters, presets, or watchlists
+  Compare leveraged ETF bull/...
+metadata:
+  author: major
+  version: dev
+---
+
+# volumeleaders-agent
+
+## Instructions
+
+### Available Commands
+
+#### `volumeleaders-agent alert configs`
+
+List all saved alert configurations with their keys, names, ticker filters, trade conditions, and notification settings. Outputs compact JSON or CSV/TSV with --format. Use --fields to select specific output fields.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--fields` | string | - | no | Comma-separated fields to include (use 'all' for every field) |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+
+**Example:**
+
+```bash
+volumeleaders-agent alert configs
+```
+
+#### `volumeleaders-agent alert create`
+
+Create a new alert configuration with a name and filter settings for institutional trade activity. Requires --name. Specify filters such as trade rank, dollar thresholds, dark pool and sweep conditions, and ticker scope. Returns a success response with the new configuration key.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah-dollars-gte` | int | 0 | no | After-hours dollars >= |
+| `--ah-rank-lte` | int | 0 | no | After-hours rank <= |
+| `--ah-volume-gte` | int | 0 | no | After-hours volume >= |
+| `--closing-trade-conditions` | string | 0 | no | Closing trade conditions |
+| `--closing-trade-dollars-gte` | int | 0 | no | Closing trade dollars >= |
+| `--closing-trade-mult-gte` | int | 0 | no | Closing trade multiplier >= |
+| `--closing-trade-rank-lte` | int | 0 | no | Closing trade rank <= |
+| `--closing-trade-vcd-gte` | int | 0 | no | Closing trade VCD >= (0/97/98/99/100) |
+| `--closing-trade-volume-gte` | int | 0 | no | Closing trade volume >= |
+| `--cluster-dollars-gte` | int | 0 | no | Trade cluster dollars >= |
+| `--cluster-mult-gte` | int | 0 | no | Trade cluster multiplier >= |
+| `--cluster-rank-lte` | int | 0 | no | Trade cluster rank <= |
+| `--cluster-vcd-gte` | int | 0 | no | Trade cluster VCD >= (0/97/98/99/100) |
+| `--cluster-volume-gte` | int | 0 | no | Trade cluster volume >= |
+| `--dark-pool` | bool | false | no | Dark pool filter |
+| `--name` | string | - | yes | Alert name (max 50 chars) |
+| `--offsetting-print` | bool | false | no | Offsetting print filter |
+| `--phantom-print` | bool | false | no | Phantom print filter |
+| `--sweep` | bool | false | no | Sweep filter |
+| `--ticker-group` | string | AllTickers | no | Ticker group (AllTickers or SelectedTickers) |
+| `--tickers` | string | - | no | Comma-separated ticker symbols (max 500, used with SelectedTickers) |
+| `--total-dollars-gte` | int | 0 | no | Total dollars >= |
+| `--total-rank-lte` | int | 0 | no | Total rank <= (0/1/3/10/25/50/100) |
+| `--total-volume-gte` | int | 0 | no | Total volume >= |
+| `--trade-conditions` | string | 0 | no | Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos) |
+| `--trade-dollars-gte` | int | 0 | no | Trade dollars >= (0=N/A, 1000000/10000000/...) |
+| `--trade-mult-gte` | int | 0 | no | Trade multiplier >= (0=N/A, 5/10/25/50/100) |
+| `--trade-rank-lte` | int | 0 | no | Trade rank <= (0=N/A, 1/3/5/10/25/50/100) |
+| `--trade-vcd-gte` | int | 0 | no | Trade VCD >= (0=N/A, 99/100) |
+| `--trade-volume-gte` | int | 0 | no | Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000) |
+
+**Example:**
+
+```bash
+volumeleaders-agent alert create --name "Big trades" --tickers AAPL,MSFT --trade-rank-lte 5
+volumeleaders-agent alert create --name "Dark pool sweeps" --sweep --dark-pool --trade-volume-gte 1000000
+```
+
+#### `volumeleaders-agent alert delete`
+
+Remove a saved alert configuration by its numeric key. Requires --key with the alert config key (visible in configs output). The deletion is permanent and cannot be undone.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--key` | int | 0 | yes | Alert config key to delete |
+
+**Example:**
+
+```bash
+volumeleaders-agent alert delete --key 42
+```
+
+#### `volumeleaders-agent alert edit`
+
+Modify an existing alert configuration identified by its numeric key. Requires --key with the alert config key. Specify only the fields you want to change; unspecified fields retain their current values.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah-dollars-gte` | int | 0 | no | After-hours dollars >= |
+| `--ah-rank-lte` | int | 0 | no | After-hours rank <= |
+| `--ah-volume-gte` | int | 0 | no | After-hours volume >= |
+| `--closing-trade-conditions` | string | 0 | no | Closing trade conditions |
+| `--closing-trade-dollars-gte` | int | 0 | no | Closing trade dollars >= |
+| `--closing-trade-mult-gte` | int | 0 | no | Closing trade multiplier >= |
+| `--closing-trade-rank-lte` | int | 0 | no | Closing trade rank <= |
+| `--closing-trade-vcd-gte` | int | 0 | no | Closing trade VCD >= (0/97/98/99/100) |
+| `--closing-trade-volume-gte` | int | 0 | no | Closing trade volume >= |
+| `--cluster-dollars-gte` | int | 0 | no | Trade cluster dollars >= |
+| `--cluster-mult-gte` | int | 0 | no | Trade cluster multiplier >= |
+| `--cluster-rank-lte` | int | 0 | no | Trade cluster rank <= |
+| `--cluster-vcd-gte` | int | 0 | no | Trade cluster VCD >= (0/97/98/99/100) |
+| `--cluster-volume-gte` | int | 0 | no | Trade cluster volume >= |
+| `--dark-pool` | bool | false | no | Dark pool filter |
+| `--key` | int | 0 | yes | Alert config key to edit |
+| `--name` | string | - | no | Alert name (max 50 chars) |
+| `--offsetting-print` | bool | false | no | Offsetting print filter |
+| `--phantom-print` | bool | false | no | Phantom print filter |
+| `--sweep` | bool | false | no | Sweep filter |
+| `--ticker-group` | string | AllTickers | no | Ticker group (AllTickers or SelectedTickers) |
+| `--tickers` | string | - | no | Comma-separated ticker symbols (max 500, used with SelectedTickers) |
+| `--total-dollars-gte` | int | 0 | no | Total dollars >= |
+| `--total-rank-lte` | int | 0 | no | Total rank <= (0/1/3/10/25/50/100) |
+| `--total-volume-gte` | int | 0 | no | Total volume >= |
+| `--trade-conditions` | string | 0 | no | Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos) |
+| `--trade-dollars-gte` | int | 0 | no | Trade dollars >= (0=N/A, 1000000/10000000/...) |
+| `--trade-mult-gte` | int | 0 | no | Trade multiplier >= (0=N/A, 5/10/25/50/100) |
+| `--trade-rank-lte` | int | 0 | no | Trade rank <= (0=N/A, 1/3/5/10/25/50/100) |
+| `--trade-vcd-gte` | int | 0 | no | Trade VCD >= (0=N/A, 99/100) |
+| `--trade-volume-gte` | int | 0 | no | Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000) |
+
+**Example:**
+
+```bash
+volumeleaders-agent alert edit --key 42 --name "Updated alert" --trade-rank-lte 3
+```
+
+#### `volumeleaders-agent market earnings`
+
+Query the earnings calendar for a date range, showing tickers with earnings dates and associated trade activity counts. Requires --start-date and --end-date (or --days). Outputs compact JSON or CSV/TSV with --format.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (required unless --days is set) |
+| `--fields` | string | - | no | Comma-separated fields to include (use 'all' for every field) |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (required unless --days is set) |
+
+**Example:**
+
+```bash
+volumeleaders-agent market earnings --days 5
+```
+
+#### `volumeleaders-agent market exhaustion`
+
+Query exhaustion scores that indicate overbought or oversold market conditions based on institutional trade clustering patterns. Omit --date to query the current trading day. Outputs compact JSON with rank metrics at different lookback periods.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--date` | string | - | no | Date YYYY-MM-DD (empty for current day) |
+
+**Example:**
+
+```bash
+volumeleaders-agent market exhaustion --date 2025-01-15
+```
+
+#### `volumeleaders-agent market snapshots`
+
+Retrieve current price snapshot data for all symbols tracked by VolumeLeaders, returning the latest available price and volume data. No date filtering is available; always returns the most recent data. Outputs compact JSON by default.
+
+**Example:**
+
+```bash
+volumeleaders-agent market snapshots
+```
+
+#### `volumeleaders-agent trade alerts`
+
+Query trade alerts fired on a specific date based on saved alert configurations. Requires --date. Returns alert records matching your configured filters. Outputs compact JSON or CSV/TSV with --format.
+
+Alert configs trigger when trades match thresholds. Threshold names follow the pattern CategoryMetricLTE or CategoryMetricGTE where LTE is maximum rank and GTE is minimum value. Use alert configs to see your configured thresholds.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--date` | string | - | yes | Date YYYY-MM-DD |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 100 | no | Number of results |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | desc | no | Order direction |
+| `--start` | int | 0 | no | DataTables start offset |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade alerts --date 2025-01-15
+```
+
+#### `volumeleaders-agent trade cluster-alerts`
+
+Query trade cluster alerts fired on a specific date based on saved alert configurations that target cluster activity. Requires --date. Returns cluster alert records matching your configured filters.
+
+Cluster alert rows use the full cluster-shaped model rather than the compact default from trade clusters. Use trade alerts for individual trade alert rows and this command for cluster-level alert rows.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--date` | string | - | yes | Date YYYY-MM-DD |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 100 | no | Number of results |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | desc | no | Order direction |
+| `--start` | int | 0 | no | DataTables start offset |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade cluster-alerts --date 2025-01-15
+```
+
+#### `volumeleaders-agent trade cluster-bombs`
+
+Query trade cluster bombs, which are extreme-magnitude trade clusters that exceed normal institutional activity thresholds. Filterable by ticker, date range, dollar amounts, sector, and cluster bomb rank. Outputs compact JSON by default.
+
+Cluster bombs find sudden aggressive bursts tightly grouped in time and price, with different defaults and rank fields than trade clusters. Use this command when looking for extreme concentration events, not general price-level clustering.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (required unless --days is set) |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 100 | no | Number of results |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 0 | no | Minimum dollar value |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | desc | no | Order direction |
+| `--relative-size` | int | 0 | no | Relative size threshold |
+| `--sector` | string | - | no | Sector/Industry filter |
+| `--security-type` | int | 0 | no | Security type key |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (required unless --days is set) |
+| `--tickers` | string | - | no | Comma-separated ticker symbols |
+| `--trade-cluster-bomb-rank` | int | -1 | no | Trade cluster bomb rank filter |
+| `--vcd` | int | 0 | no | VCD filter |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade cluster-bombs TSLA --days 3
+```
+
+#### `volumeleaders-agent trade clusters`
+
+Query aggregated trade clusters, which group multiple trades in a short window into a single cluster record. Filterable by ticker, date range, dollar amounts, sector, and trade cluster rank. Outputs compact JSON or CSV/TSV with --format.
+
+Use clusters when the question is about price-level concentration, not single prints. This command uses larger default retrieval and dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (required unless --days is set) |
+| `--fields` | string | - | no | Comma-separated TradeCluster fields to include in output, or 'all' for every field |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 1000 | no | Number of results |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-price` | float64 | 100000 | no | Maximum price |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 10000000 | no | Minimum dollar value |
+| `--min-price` | float64 | 0 | no | Minimum price |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | desc | no | Order direction |
+| `--relative-size` | int | 5 | no | Relative size threshold |
+| `--sector` | string | - | no | Sector/Industry filter |
+| `--security-type` | int | -1 | no | Security type key |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (required unless --days is set) |
+| `--tickers` | string | - | no | Comma-separated ticker symbols |
+| `--trade-cluster-rank` | int | -1 | no | Trade cluster rank filter |
+| `--vcd` | int | 0 | no | VCD filter |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade clusters AAPL --days 7
+```
+
+#### `volumeleaders-agent trade level-touches`
+
+Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
+
+Defaults to --length 50 and rejects --length -1, --length 0, and values above 50. Use trade levels first to identify significant price zones, then use this command to find events where price revisited those levels.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (required unless --days is set) |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 50 | no | Number of results |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-price` | float64 | 100000 | no | Maximum price |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 500000 | no | Minimum dollar value |
+| `--min-price` | float64 | 0 | no | Minimum price |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--order-col` | int | 0 | no | Order column index |
+| `--order-dir` | string | desc | no | Order direction |
+| `--relative-size` | int | 0 | no | Relative size threshold |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (required unless --days is set) |
+| `--ticker` | string | - | no | Ticker symbol |
+| `--trade-level-count` | int | 50 | no | Number of price levels to include (1-50) |
+| `--trade-level-rank` | int | 10 | no | Trade level rank filter |
+| `--vcd` | int | 0 | no | VCD filter |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade level-touches AAPL --days 14
+```
+
+#### `volumeleaders-agent trade levels`
+
+Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Outputs compact JSON by default.
+
+Defaults to a 1-year lookback when dates are omitted. Uses non-standard --relative-size 0 and caps level count from 1 to 50 via --trade-level-count. Default JSON is compact and omits repetitive ticker metadata and the verbose Dates list; use --fields all or CSV/TSV when raw fields are needed.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (default: today) |
+| `--fields` | string | - | no | Comma-separated TradeLevel fields to include in output, or 'all' for every field |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-price` | float64 | 100000 | no | Maximum price |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 500000 | no | Minimum dollar value |
+| `--min-price` | float64 | 0 | no | Minimum price |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--relative-size` | int | 0 | no | Relative size threshold |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (default: auto) |
+| `--ticker` | string | - | no | Ticker symbol |
+| `--trade-level-count` | int | 10 | no | Number of price levels to return (1-50) |
+| `--trade-level-rank` | int | -1 | no | Trade level rank filter |
+| `--vcd` | int | 0 | no | VCD filter |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade levels AAPL
+```
+
+#### `volumeleaders-agent trade list`
+
+Query individual institutional trades from VolumeLeaders, filterable by ticker, date range, dollar amounts, volume, trade conditions, session type, and trade rank. Supports built-in filter presets (--preset) and watchlist-based filtering (--watchlist). Outputs compact JSON or CSV/TSV with --format; use --summary for aggregate metrics grouped by ticker or day.
+
+Date defaults: 365-day lookback when tickers are provided, today-only without tickers. Preset and watchlist filters do not supply dates. Filter precedence is preset baseline, then watchlist merge, then explicit CLI flags override both.
+
+Default JSON is compact and omits repetitive/internal fields. Use --fields FIELD1,FIELD2, CSV/TSV, or --fields all where supported when raw API fields are needed. --summary returns aggregate JSON with valid --group-by values of ticker, day, or ticker,day; do not combine summary mode with --fields or non-JSON formats.
+
+KEY METRICS
+
+Field                      Meaning
+-------------------------  ---------------------------------------------------------------
+CumulativeDistribution     Volume percentile, 0 to 1, higher means more accumulation
+DollarsMultiplier          Trade dollars relative to average block size
+TradeRank                  VL significance rank now, lower is stronger
+TradeRankSnapshot          VL significance rank at print time, lower is stronger
+TradeClusterRank           Rank for cluster significance, lower is stronger
+TradeClusterBombRank       Rank for burst significance, lower is stronger
+TradeLevelRank             Rank for level significance, lower is stronger
+RelativeSize               Trade size vs normal activity
+PercentDailyVolume         Trade volume as percent of average daily volume
+VCD                        Volume Confirmation Distribution score
+FrequencyLast30TD          Similar-magnitude trade frequency over last 30 trading days
+FrequencyLast90TD          Similar-magnitude trade frequency over last 90 trading days
+FrequencyLast1CY           Similar-magnitude trade frequency over last calendar year
+RSIHour                    Hourly RSI at time of trade
+RSIDay                     Daily RSI at time of trade
+DarkPool                   Boolean: trade printed on a dark pool
+Sweep                      Boolean: trade was a sweep order
+LatePrint                  Boolean: trade was a late print
+SignaturePrint             Boolean: trade matched a signature print pattern
+PhantomPrint               Boolean: trade was a phantom print
+InsideBar                  Boolean: bar was an inside bar
+
+Shared trade filters include volume, price, dollars, conditions, VCD, relative size, security type, market cap, trade rank, dark pools, sweeps, late prints, signature prints, even-share prints, and session/event toggles.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah` | int | 1 | no | Include after hours |
+| `--closing` | int | 1 | no | Include closing trades |
+| `--conditions` | int | -1 | no | Trade conditions filter |
+| `--dark-pools` | int | -1 | no | Dark pool filter |
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (default: today) |
+| `--even-shared` | int | -1 | no | Even shared filter |
+| `--fields` | string | - | no | Comma-separated trade fields to include in output |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--group-by` | string | ticker | no | Summary grouping (requires --summary): ticker, day, or ticker,day |
+| `--late-prints` | int | -1 | no | Late print filter |
+| `--length` | int | 10 | no | Number of results |
+| `--market-cap` | int | 0 | no | Market cap filter |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-price` | float64 | 100000 | no | Maximum price |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 500000 | no | Minimum dollar value |
+| `--min-price` | float64 | 0 | no | Minimum price |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--offsetting` | int | 1 | no | Include offsetting trades |
+| `--opening` | int | 1 | no | Include opening trades |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | desc | no | Order direction |
+| `--phantom` | int | 1 | no | Include phantom prints |
+| `--premarket` | int | 1 | no | Include premarket |
+| `--preset` | string | - | no | Apply a built-in filter preset (see: trade presets) |
+| `--rank-snapshot` | int | -1 | no | Trade rank snapshot filter |
+| `--relative-size` | int | 5 | no | Relative size threshold |
+| `--rth` | int | 1 | no | Include regular trading hours |
+| `--sector` | string | - | no | Sector/Industry filter |
+| `--security-type` | int | -1 | no | Security type key |
+| `--sig-prints` | int | -1 | no | Signature print filter |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (default: auto) |
+| `--summary` | bool | false | no | Return aggregate metrics instead of individual trades |
+| `--sweeps` | int | -1 | no | Sweep filter |
+| `--tickers` | string | - | no | Comma-separated ticker symbols |
+| `--trade-rank` | int | -1 | no | Trade rank filter |
+| `--vcd` | int | 97 | no | VCD filter |
+| `--watchlist` | string | - | no | Apply filters from a saved watchlist by name |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade list AAPL MSFT
+volumeleaders-agent trade list --tickers AAPL,MSFT
+volumeleaders-agent trade list --tickers NVDA --dark-pools 1 --min-dollars 1000000
+volumeleaders-agent trade list --sector Technology --relative-size 10 --length 50
+volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
+volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
+```
+
+#### `volumeleaders-agent trade preset-tickers`
+
+Extract the ticker symbols configured in a named trade filter preset, showing whether the preset uses an explicit ticker list, a sector/industry filter, or is unfiltered. Requires --preset with the preset name (case-insensitive). Outputs JSON with the preset name, group, type, and ticker details.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--preset` | string | - | yes | Preset name (case-insensitive) |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade preset-tickers --preset NAME
+```
+
+#### `volumeleaders-agent trade presets`
+
+List all built-in trade filter presets with their names, groups, and filter configurations. Each preset defines a named set of filters that can be applied to trade list queries via --preset. Outputs compact JSON by default; use --format csv or tsv for tabular output.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade presets
+```
+
+#### `volumeleaders-agent trade sentiment`
+
+Summarize leveraged ETF bull and bear flow by trading day, showing aggregate institutional dollar volume on the bull and bear side. Requires --start-date and --end-date (or --days). Outputs one record per day with bull and bear totals.
+
+This command always queries the combined leveraged ETF sector filter SectorIndustry=X B, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags. Non-standard defaults include --min-dollars 5000000 and --vcd 97; shared --relative-size 5 still applies.
+
+Ratio is bull dollars divided by bear dollars and is null when bear flow is zero. Treat the output as leveraged ETF proxy flow, not signed buy/sell flow for the broader market.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah` | int | 1 | no | Include after hours |
+| `--closing` | int | 1 | no | Include closing trades |
+| `--conditions` | int | -1 | no | Trade conditions filter |
+| `--dark-pools` | int | -1 | no | Dark pool filter |
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (required unless --days is set) |
+| `--even-shared` | int | -1 | no | Even shared filter |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--late-prints` | int | -1 | no | Late print filter |
+| `--market-cap` | int | 0 | no | Market cap filter |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-price` | float64 | 100000 | no | Maximum price |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 5000000 | no | Minimum dollar value |
+| `--min-price` | float64 | 0 | no | Minimum price |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--offsetting` | int | 1 | no | Include offsetting trades |
+| `--opening` | int | 1 | no | Include opening trades |
+| `--phantom` | int | 1 | no | Include phantom prints |
+| `--premarket` | int | 1 | no | Include premarket |
+| `--rank-snapshot` | int | -1 | no | Trade rank snapshot filter |
+| `--relative-size` | int | 5 | no | Relative size threshold |
+| `--rth` | int | 1 | no | Include regular trading hours |
+| `--security-type` | int | -1 | no | Security type key |
+| `--sig-prints` | int | -1 | no | Signature print filter |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (required unless --days is set) |
+| `--sweeps` | int | -1 | no | Sweep filter |
+| `--trade-rank` | int | -1 | no | Trade rank filter |
+| `--vcd` | int | 97 | no | VCD filter |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25
+```
+
+#### `volumeleaders-agent volume ah-institutional`
+
+Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--date` | string | - | yes | Date YYYY-MM-DD |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 100 | no | Number of results |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | asc | no | Order direction |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--tickers` | string | - | no | Comma-separated ticker symbols |
+
+**Example:**
+
+```bash
+volumeleaders-agent volume ah-institutional --date 2025-01-15
+```
+
+#### `volumeleaders-agent volume institutional`
+
+Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--date` | string | - | yes | Date YYYY-MM-DD |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 100 | no | Number of results |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | asc | no | Order direction |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--tickers` | string | - | no | Comma-separated ticker symbols |
+
+**Example:**
+
+```bash
+volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15
+```
+
+#### `volumeleaders-agent volume total`
+
+Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--date` | string | - | yes | Date YYYY-MM-DD |
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--length` | int | 100 | no | Number of results |
+| `--order-col` | int | 1 | no | Order column index |
+| `--order-dir` | string | asc | no | Order direction |
+| `--start` | int | 0 | no | DataTables start offset |
+| `--tickers` | string | - | no | Comma-separated ticker symbols |
+
+**Example:**
+
+```bash
+volumeleaders-agent volume total XLE --date 2025-01-15 --length 20
+```
+
+#### `volumeleaders-agent watchlist add-ticker`
+
+Add a ticker symbol to an existing watchlist. Requires --watchlist-key with the watchlist key and --ticker with the symbol to add. The ticker is appended to the watchlist without affecting existing symbols.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ticker` | string | - | yes | Ticker symbol to add |
+| `--watchlist-key` | int | 0 | yes | Watch list key |
+
+**Example:**
+
+```bash
+volumeleaders-agent watchlist add-ticker --watchlist-key 1 --ticker NVDA
+```
+
+#### `volumeleaders-agent watchlist configs`
+
+List all saved watchlist configurations with their keys and names. Outputs compact JSON or CSV/TSV with --format. Each row shows the watchlist key and name; use the tickers subcommand to view symbols in a specific watchlist.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+
+**Example:**
+
+```bash
+volumeleaders-agent watchlist configs
+```
+
+#### `volumeleaders-agent watchlist create`
+
+Create a new watchlist configuration with a name and optional filter settings such as minimum volume, price range, sector, and trade conditions. Requires --name. Use --tickers to specify an explicit ticker list or leave unset for a filter-based watchlist.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah-trades` | bool | true | no | Include after-hours trades |
+| `--blocks` | bool | true | no | Include block trades |
+| `--closing-trades` | bool | true | no | Include closing trades |
+| `--dark-pools` | bool | true | no | Include dark pool trades |
+| `--late-prints` | bool | true | no | Include late prints |
+| `--lit-exchanges` | bool | true | no | Include lit exchange trades |
+| `--max-dollars` | float64 | 3e+10 | no | Maximum dollars filter |
+| `--max-price` | float64 | 100000 | no | Maximum price filter |
+| `--max-trade-rank` | int | -1 | no | Maximum trade rank (-1=all, 1/3/5/10/25/50/100) |
+| `--max-volume` | int | 2000000000 | no | Maximum volume filter |
+| `--min-dollars` | float64 | 0 | no | Minimum dollars filter |
+| `--min-price` | float64 | 0 | no | Minimum price filter |
+| `--min-relative-size` | int | 0 | no | Minimum relative size (0/5/10/25/50/100) |
+| `--min-vcd` | float64 | 0 | no | Minimum VCD percentile (0-100) |
+| `--min-volume` | int | 0 | no | Minimum volume filter |
+| `--name` | string | - | yes | Watch list name |
+| `--normal-prints` | bool | true | no | Include normal prints |
+| `--offsetting-trades` | bool | true | no | Include offsetting trades |
+| `--opening-trades` | bool | true | no | Include opening trades |
+| `--phantom-trades` | bool | true | no | Include phantom trades |
+| `--premarket-trades` | bool | true | no | Include premarket trades |
+| `--rsi-overbought-daily` | int | -1 | no | RSI overbought daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-overbought-hourly` | int | -1 | no | RSI overbought hourly (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-daily` | int | -1 | no | RSI oversold daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-hourly` | int | -1 | no | RSI oversold hourly (1=yes, 0=no, -1=ignore) |
+| `--rth-trades` | bool | true | no | Include regular trading hours trades |
+| `--sector-industry` | string | - | no | Sector/industry filter (max 100 chars) |
+| `--security-type` | int | -1 | no | Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs) |
+| `--signature-prints` | bool | true | no | Include signature prints |
+| `--sweeps` | bool | true | no | Include sweep trades |
+| `--tickers` | string | - | no | Comma-separated ticker symbols (max 500) |
+| `--timely-prints` | bool | true | no | Include timely prints |
+
+**Example:**
+
+```bash
+volumeleaders-agent watchlist create --name "Tech stocks" --tickers AAPL,MSFT,GOOGL
+volumeleaders-agent watchlist create --name "Large caps" --security-type 1 --min-dollars 10000000
+```
+
+#### `volumeleaders-agent watchlist delete`
+
+Remove a saved watchlist configuration by its numeric key. Requires --key with the watchlist key (visible in configs output). The deletion is permanent and removes the watchlist and all its tickers.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--key` | int | 0 | yes | Watch list key to delete |
+
+**Example:**
+
+```bash
+volumeleaders-agent watchlist delete --key 1
+```
+
+#### `volumeleaders-agent watchlist edit`
+
+Modify an existing watchlist configuration identified by its numeric key. Requires --key with the watchlist key. Specify only the fields you want to change; unspecified fields retain their current values.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah-trades` | bool | true | no | Include after-hours trades |
+| `--blocks` | bool | true | no | Include block trades |
+| `--closing-trades` | bool | true | no | Include closing trades |
+| `--dark-pools` | bool | true | no | Include dark pool trades |
+| `--key` | int | 0 | yes | Watch list key to edit |
+| `--late-prints` | bool | true | no | Include late prints |
+| `--lit-exchanges` | bool | true | no | Include lit exchange trades |
+| `--max-dollars` | float64 | 3e+10 | no | Maximum dollars filter |
+| `--max-price` | float64 | 100000 | no | Maximum price filter |
+| `--max-trade-rank` | int | -1 | no | Maximum trade rank (-1=all, 1/3/5/10/25/50/100) |
+| `--max-volume` | int | 2000000000 | no | Maximum volume filter |
+| `--min-dollars` | float64 | 0 | no | Minimum dollars filter |
+| `--min-price` | float64 | 0 | no | Minimum price filter |
+| `--min-relative-size` | int | 0 | no | Minimum relative size (0/5/10/25/50/100) |
+| `--min-vcd` | float64 | 0 | no | Minimum VCD percentile (0-100) |
+| `--min-volume` | int | 0 | no | Minimum volume filter |
+| `--name` | string | - | no | Watch list name |
+| `--normal-prints` | bool | true | no | Include normal prints |
+| `--offsetting-trades` | bool | true | no | Include offsetting trades |
+| `--opening-trades` | bool | true | no | Include opening trades |
+| `--phantom-trades` | bool | true | no | Include phantom trades |
+| `--premarket-trades` | bool | true | no | Include premarket trades |
+| `--rsi-overbought-daily` | int | -1 | no | RSI overbought daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-overbought-hourly` | int | -1 | no | RSI overbought hourly (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-daily` | int | -1 | no | RSI oversold daily (1=yes, 0=no, -1=ignore) |
+| `--rsi-oversold-hourly` | int | -1 | no | RSI oversold hourly (1=yes, 0=no, -1=ignore) |
+| `--rth-trades` | bool | true | no | Include regular trading hours trades |
+| `--sector-industry` | string | - | no | Sector/industry filter (max 100 chars) |
+| `--security-type` | int | -1 | no | Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs) |
+| `--signature-prints` | bool | true | no | Include signature prints |
+| `--sweeps` | bool | true | no | Include sweep trades |
+| `--tickers` | string | - | no | Comma-separated ticker symbols (max 500) |
+| `--timely-prints` | bool | true | no | Include timely prints |
+
+**Example:**
+
+```bash
+volumeleaders-agent watchlist edit --key 1 --name "Updated watchlist" --tickers AAPL,MSFT
+```
+
+#### `volumeleaders-agent watchlist tickers`
+
+Query the ticker symbols belonging to a specific watchlist identified by --watchlist-key. Returns all tickers in the watchlist with their metadata. Outputs compact JSON or CSV/TSV with --format.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--format` | string | json | no | Output format: json, csv, or tsv |
+| `--watchlist-key` | int | -1 | no | Watch list key (-1 for all) |
+
+**Example:**
+
+```bash
+volumeleaders-agent watchlist tickers --watchlist-key 1
+```
+
+### Examples
+
+#### volumeleaders-agent alert configs
+
+```bash
+volumeleaders-agent alert configs
+```
+
+#### volumeleaders-agent alert create
+
+```bash
+volumeleaders-agent alert create --name "Big trades" --tickers AAPL,MSFT --trade-rank-lte 5
+volumeleaders-agent alert create --name "Dark pool sweeps" --sweep --dark-pool --trade-volume-gte 1000000
+```
+
+#### volumeleaders-agent alert delete
+
+```bash
+volumeleaders-agent alert delete --key 42
+```
+
+#### volumeleaders-agent alert edit
+
+```bash
+volumeleaders-agent alert edit --key 42 --name "Updated alert" --trade-rank-lte 3
+```
+
+#### volumeleaders-agent market earnings
+
+```bash
+volumeleaders-agent market earnings --days 5
+```
+
+#### volumeleaders-agent market exhaustion
+
+```bash
+volumeleaders-agent market exhaustion --date 2025-01-15
+```
+
+#### volumeleaders-agent market snapshots
+
+```bash
+volumeleaders-agent market snapshots
+```
+
+#### volumeleaders-agent trade alerts
+
+```bash
+volumeleaders-agent trade alerts --date 2025-01-15
+```
+
+#### volumeleaders-agent trade cluster-alerts
+
+```bash
+volumeleaders-agent trade cluster-alerts --date 2025-01-15
+```
+
+#### volumeleaders-agent trade cluster-bombs
+
+```bash
+volumeleaders-agent trade cluster-bombs TSLA --days 3
+```
+
+#### volumeleaders-agent trade clusters
+
+```bash
+volumeleaders-agent trade clusters AAPL --days 7
+```
+
+#### volumeleaders-agent trade level-touches
+
+```bash
+volumeleaders-agent trade level-touches AAPL --days 14
+```
+
+#### volumeleaders-agent trade levels
+
+```bash
+volumeleaders-agent trade levels AAPL
+```
+
+#### volumeleaders-agent trade list
+
+```bash
+volumeleaders-agent trade list AAPL MSFT
+volumeleaders-agent trade list --tickers AAPL,MSFT
+volumeleaders-agent trade list --tickers NVDA --dark-pools 1 --min-dollars 1000000
+volumeleaders-agent trade list --sector Technology --relative-size 10 --length 50
+volumeleaders-agent trade list --preset "Top-100 Rank" --start-date 2025-04-01 --end-date 2025-04-24
+volumeleaders-agent trade list --watchlist "Magnificent 7" --start-date 2025-04-01 --end-date 2025-04-24
+```
+
+#### volumeleaders-agent trade preset-tickers
+
+```bash
+volumeleaders-agent trade preset-tickers --preset NAME
+```
+
+#### volumeleaders-agent trade presets
+
+```bash
+volumeleaders-agent trade presets
+```
+
+#### volumeleaders-agent trade sentiment
+
+```bash
+volumeleaders-agent trade sentiment --start-date 2025-04-21 --end-date 2025-04-25
+```
+
+#### volumeleaders-agent volume ah-institutional
+
+```bash
+volumeleaders-agent volume ah-institutional --date 2025-01-15
+```
+
+#### volumeleaders-agent volume institutional
+
+```bash
+volumeleaders-agent volume institutional AAPL MSFT --date 2025-01-15
+```
+
+#### volumeleaders-agent volume total
+
+```bash
+volumeleaders-agent volume total XLE --date 2025-01-15 --length 20
+```
+
+#### volumeleaders-agent watchlist add-ticker
+
+```bash
+volumeleaders-agent watchlist add-ticker --watchlist-key 1 --ticker NVDA
+```
+
+#### volumeleaders-agent watchlist configs
+
+```bash
+volumeleaders-agent watchlist configs
+```
+
+#### volumeleaders-agent watchlist create
+
+```bash
+volumeleaders-agent watchlist create --name "Tech stocks" --tickers AAPL,MSFT,GOOGL
+volumeleaders-agent watchlist create --name "Large caps" --security-type 1 --min-dollars 10000000
+```
+
+#### volumeleaders-agent watchlist delete
+
+```bash
+volumeleaders-agent watchlist delete --key 1
+```
+
+#### volumeleaders-agent watchlist edit
+
+```bash
+volumeleaders-agent watchlist edit --key 1 --name "Updated watchlist" --tickers AAPL,MSFT
+```
+
+#### volumeleaders-agent watchlist tickers
+
+```bash
+volumeleaders-agent watchlist tickers --watchlist-key 1
+```

--- a/docs/llm/llms.txt
+++ b/docs/llm/llms.txt
@@ -1,0 +1,679 @@
+# volumeleaders-agent
+
+https://github.com/major/volumeleaders-agent/cmd/volumeleaders-agent
+
+> volumeleaders-agent queries institutional trade data from VolumeLeaders. Use it for trades, volume leaderboards, market data, alerts, and watchlists.
+
+Auth: reads browser cookies automatically. If auth fails with exit code 2 and "Authentication required: VolumeLeaders session has expired.", log in at https://www.volumeleaders.com in your browser, then retry.
+
+Output: compact JSON to stdout by default. Use --pretty before the command group for indented JSON. Use --jsonschema on any command for machine-readable JSON Schema output, or --jsonschema=tree on the root for the full CLI tree. Errors and logs go to stderr.
+
+COMMAND CHOOSER
+
+Goal                                          Start with                              Notes
+--------------------------------------------  --------------------------------------  -----------------------------------------------
+Find individual institutional prints          trade list X --days N                   Use ticker filters, presets, or watchlists
+Compare leveraged ETF bull/bear flow          trade sentiment --days N                Fixed leveraged ETF universe, not buy/sell flow
+Find converging price-level activity          trade clusters --days N                 Cluster conviction around similar prices
+Find sudden aggressive bursts                 trade cluster-bombs --days N            Burst detection, different defaults than clusters
+Inspect trade or cluster alerts               trade alerts --date D                   System-generated alerts
+Find support/resistance levels                trade levels X --days N                 One ticker, capped level count
+Find revisits to institutional levels         trade level-touches X --days N          Level retests, capped pagination
+See institutional volume leaders              volume institutional --date D            Same trade model, volume-ranked
+See after-hours institutional leaders         volume ah-institutional --date D        After-hours institutional flow
+See total volume leaders                      volume total --date D                   Total market volume across trade types
+Get current prices                            market snapshots                        JSON object
+Find earnings with prior institutional flow   market earnings --days N                CSV/TSV supported
+Check exhaustion/reversal signals             market exhaustion --date D              Lower rank is stronger
+Manage alert configs                          alert configs/create/edit/delete        Edit replaces unspecified values with defaults
+Manage watchlists                             watchlist configs/create/edit/delete    Edit replaces unspecified values with defaults
+Get watchlist tickers                         watchlist tickers --watchlist-key K     Key comes from watchlist configs
+
+ANALYSIS WORKFLOW
+
+1. volume institutional --date D for top dollar movers.
+2. trade list X --days N for individual prints.
+3. trade levels X --days N for support/resistance.
+4. trade clusters X --days N when prints appear concentrated around a price.
+5. market earnings --days N and market exhaustion --date D for event and reversal context.
+
+GLOBAL CONVENTIONS
+
+Dates: YYYY-MM-DD. Commands with date ranges accept either --start-date D --end-date D or --days N. --days counts backward from today unless --end-date is also set, and cannot be combined with --start-date.
+
+Pagination: --start offset, --length count, --length -1 means all rows unless a capped endpoint rejects it. trade list, trade list --summary, and trade level-touches only allow 1 to 50 rows. trade levels caps --trade-level-count at 50.
+
+Toggle filters: -1 means all/unfiltered, 0 means exclude, 1 means include/only.
+
+Tickers: --tickers is comma-separated, --ticker is single-symbol. Commands that take tickers generally accept positional tickers too, for example: trade list XLE XLK. Trade and volume ticker filters also accept --symbol and --symbols aliases.
+
+Output formats: list-style commands may support --format json/csv/tsv. CSV/TSV include headers, booleans render as true/false, null or missing values render as empty cells. Nested summaries and single-object commands are JSON-only unless the schema shows a format flag.
+
+Performance: use explicit dates and tickers when possible. Start narrow, then expand. VolumeLeaders endpoints can be expensive and some trade retrieval endpoints are intentionally capped.
+
+## Commands
+
+- [volumeleaders-agent alert configs](#volumeleaders-agent-alert-configs): List all saved alert configurations with their keys, names, ticker filters, trade conditions, and notification settings. Outputs compact JSON or CSV/TSV with --format. Use --fields to select specific output fields.
+- [volumeleaders-agent alert create](#volumeleaders-agent-alert-create): Create a new alert configuration with a name and filter settings for institutional trade activity. Requires --name. Specify filters such as trade rank, dollar thresholds, dark pool and sweep conditions, and ticker scope. Returns a success response with the new configuration key.
+- [volumeleaders-agent alert delete](#volumeleaders-agent-alert-delete): Remove a saved alert configuration by its numeric key. Requires --key with the alert config key (visible in configs output). The deletion is permanent and cannot be undone.
+- [volumeleaders-agent alert edit](#volumeleaders-agent-alert-edit): Modify an existing alert configuration identified by its numeric key. Requires --key with the alert config key. Specify only the fields you want to change; unspecified fields retain their current values.
+- [volumeleaders-agent market earnings](#volumeleaders-agent-market-earnings): Query the earnings calendar for a date range, showing tickers with earnings dates and associated trade activity counts. Requires --start-date and --end-date (or --days). Outputs compact JSON or CSV/TSV with --format.
+- [volumeleaders-agent market exhaustion](#volumeleaders-agent-market-exhaustion): Query exhaustion scores that indicate overbought or oversold market conditions based on institutional trade clustering patterns. Omit --date to query the current trading day. Outputs compact JSON with rank metrics at different lookback periods.
+- [volumeleaders-agent market snapshots](#volumeleaders-agent-market-snapshots): Retrieve current price snapshot data for all symbols tracked by VolumeLeaders, returning the latest available price and volume data. No date filtering is available; always returns the most recent data. Outputs compact JSON by default.
+- [volumeleaders-agent trade alerts](#volumeleaders-agent-trade-alerts): Query trade alerts fired on a specific date based on saved alert configurations. Requires --date. Returns alert records matching your configured filters. Outputs compact JSON or CSV/TSV with --format.
+
+Alert configs trigger when trades match thresholds. Threshold names follow the pattern CategoryMetricLTE or CategoryMetricGTE where LTE is maximum rank and GTE is minimum value. Use alert configs to see your configured thresholds.
+- [volumeleaders-agent trade cluster-alerts](#volumeleaders-agent-trade-cluster-alerts): Query trade cluster alerts fired on a specific date based on saved alert configurations that target cluster activity. Requires --date. Returns cluster alert records matching your configured filters.
+
+Cluster alert rows use the full cluster-shaped model rather than the compact default from trade clusters. Use trade alerts for individual trade alert rows and this command for cluster-level alert rows.
+- [volumeleaders-agent trade cluster-bombs](#volumeleaders-agent-trade-cluster-bombs): Query trade cluster bombs, which are extreme-magnitude trade clusters that exceed normal institutional activity thresholds. Filterable by ticker, date range, dollar amounts, sector, and cluster bomb rank. Outputs compact JSON by default.
+
+Cluster bombs find sudden aggressive bursts tightly grouped in time and price, with different defaults and rank fields than trade clusters. Use this command when looking for extreme concentration events, not general price-level clustering.
+- [volumeleaders-agent trade clusters](#volumeleaders-agent-trade-clusters): Query aggregated trade clusters, which group multiple trades in a short window into a single cluster record. Filterable by ticker, date range, dollar amounts, sector, and trade cluster rank. Outputs compact JSON or CSV/TSV with --format.
+
+Use clusters when the question is about price-level concentration, not single prints. This command uses larger default retrieval and dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price.
+- [volumeleaders-agent trade level-touches](#volumeleaders-agent-trade-level-touches): Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
+
+Defaults to --length 50 and rejects --length -1, --length 0, and values above 50. Use trade levels first to identify significant price zones, then use this command to find events where price revisited those levels.
+- [volumeleaders-agent trade levels](#volumeleaders-agent-trade-levels): Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Outputs compact JSON by default.
+
+Defaults to a 1-year lookback when dates are omitted. Uses non-standard --relative-size 0 and caps level count from 1 to 50 via --trade-level-count. Default JSON is compact and omits repetitive ticker metadata and the verbose Dates list; use --fields all or CSV/TSV when raw fields are needed.
+- [volumeleaders-agent trade list](#volumeleaders-agent-trade-list): Query individual institutional trades from VolumeLeaders, filterable by ticker, date range, dollar amounts, volume, trade conditions, session type, and trade rank. Supports built-in filter presets (--preset) and watchlist-based filtering (--watchlist). Outputs compact JSON or CSV/TSV with --format; use --summary for aggregate metrics grouped by ticker or day.
+
+Date defaults: 365-day lookback when tickers are provided, today-only without tickers. Preset and watchlist filters do not supply dates. Filter precedence is preset baseline, then watchlist merge, then explicit CLI flags override both.
+
+Default JSON is compact and omits repetitive/internal fields. Use --fields FIELD1,FIELD2, CSV/TSV, or --fields all where supported when raw API fields are needed. --summary returns aggregate JSON with valid --group-by values of ticker, day, or ticker,day; do not combine summary mode with --fields or non-JSON formats.
+
+KEY METRICS
+
+Field                      Meaning
+-------------------------  ---------------------------------------------------------------
+CumulativeDistribution     Volume percentile, 0 to 1, higher means more accumulation
+DollarsMultiplier          Trade dollars relative to average block size
+TradeRank                  VL significance rank now, lower is stronger
+TradeRankSnapshot          VL significance rank at print time, lower is stronger
+TradeClusterRank           Rank for cluster significance, lower is stronger
+TradeClusterBombRank       Rank for burst significance, lower is stronger
+TradeLevelRank             Rank for level significance, lower is stronger
+RelativeSize               Trade size vs normal activity
+PercentDailyVolume         Trade volume as percent of average daily volume
+VCD                        Volume Confirmation Distribution score
+FrequencyLast30TD          Similar-magnitude trade frequency over last 30 trading days
+FrequencyLast90TD          Similar-magnitude trade frequency over last 90 trading days
+FrequencyLast1CY           Similar-magnitude trade frequency over last calendar year
+RSIHour                    Hourly RSI at time of trade
+RSIDay                     Daily RSI at time of trade
+DarkPool                   Boolean: trade printed on a dark pool
+Sweep                      Boolean: trade was a sweep order
+LatePrint                  Boolean: trade was a late print
+SignaturePrint             Boolean: trade matched a signature print pattern
+PhantomPrint               Boolean: trade was a phantom print
+InsideBar                  Boolean: bar was an inside bar
+
+Shared trade filters include volume, price, dollars, conditions, VCD, relative size, security type, market cap, trade rank, dark pools, sweeps, late prints, signature prints, even-share prints, and session/event toggles.
+- [volumeleaders-agent trade preset-tickers](#volumeleaders-agent-trade-preset-tickers): Extract the ticker symbols configured in a named trade filter preset, showing whether the preset uses an explicit ticker list, a sector/industry filter, or is unfiltered. Requires --preset with the preset name (case-insensitive). Outputs JSON with the preset name, group, type, and ticker details.
+- [volumeleaders-agent trade presets](#volumeleaders-agent-trade-presets): List all built-in trade filter presets with their names, groups, and filter configurations. Each preset defines a named set of filters that can be applied to trade list queries via --preset. Outputs compact JSON by default; use --format csv or tsv for tabular output.
+- [volumeleaders-agent trade sentiment](#volumeleaders-agent-trade-sentiment): Summarize leveraged ETF bull and bear flow by trading day, showing aggregate institutional dollar volume on the bull and bear side. Requires --start-date and --end-date (or --days). Outputs one record per day with bull and bear totals.
+
+This command always queries the combined leveraged ETF sector filter SectorIndustry=X B, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags. Non-standard defaults include --min-dollars 5000000 and --vcd 97; shared --relative-size 5 still applies.
+
+Ratio is bull dollars divided by bear dollars and is null when bear flow is zero. Treat the output as leveraged ETF proxy flow, not signed buy/sell flow for the broader market.
+- [volumeleaders-agent volume ah-institutional](#volumeleaders-agent-volume-ah-institutional): Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.
+- [volumeleaders-agent volume institutional](#volumeleaders-agent-volume-institutional): Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format.
+- [volumeleaders-agent volume total](#volumeleaders-agent-volume-total): Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.
+- [volumeleaders-agent watchlist add-ticker](#volumeleaders-agent-watchlist-add-ticker): Add a ticker symbol to an existing watchlist. Requires --watchlist-key with the watchlist key and --ticker with the symbol to add. The ticker is appended to the watchlist without affecting existing symbols.
+- [volumeleaders-agent watchlist configs](#volumeleaders-agent-watchlist-configs): List all saved watchlist configurations with their keys and names. Outputs compact JSON or CSV/TSV with --format. Each row shows the watchlist key and name; use the tickers subcommand to view symbols in a specific watchlist.
+- [volumeleaders-agent watchlist create](#volumeleaders-agent-watchlist-create): Create a new watchlist configuration with a name and optional filter settings such as minimum volume, price range, sector, and trade conditions. Requires --name. Use --tickers to specify an explicit ticker list or leave unset for a filter-based watchlist.
+- [volumeleaders-agent watchlist delete](#volumeleaders-agent-watchlist-delete): Remove a saved watchlist configuration by its numeric key. Requires --key with the watchlist key (visible in configs output). The deletion is permanent and removes the watchlist and all its tickers.
+- [volumeleaders-agent watchlist edit](#volumeleaders-agent-watchlist-edit): Modify an existing watchlist configuration identified by its numeric key. Requires --key with the watchlist key. Specify only the fields you want to change; unspecified fields retain their current values.
+- [volumeleaders-agent watchlist tickers](#volumeleaders-agent-watchlist-tickers): Query the ticker symbols belonging to a specific watchlist identified by --watchlist-key. Returns all tickers in the watchlist with their metadata. Outputs compact JSON or CSV/TSV with --format.
+
+## volumeleaders-agent alert configs
+
+List all saved alert configurations with their keys, names, ticker filters, trade conditions, and notification settings. Outputs compact JSON or CSV/TSV with --format. Use --fields to select specific output fields.
+
+### Flags
+
+- `--fields` (string): Comma-separated fields to include (use 'all' for every field)
+- `--format` (string, default: json): Output format: json, csv, or tsv
+
+## volumeleaders-agent alert create
+
+Create a new alert configuration with a name and filter settings for institutional trade activity. Requires --name. Specify filters such as trade rank, dollar thresholds, dark pool and sweep conditions, and ticker scope. Returns a success response with the new configuration key.
+
+### Flags
+
+- `--ah-dollars-gte` (int, default: 0): After-hours dollars >=
+- `--ah-rank-lte` (int, default: 0): After-hours rank <=
+- `--ah-volume-gte` (int, default: 0): After-hours volume >=
+- `--closing-trade-conditions` (string, default: 0): Closing trade conditions
+- `--closing-trade-dollars-gte` (int, default: 0): Closing trade dollars >=
+- `--closing-trade-mult-gte` (int, default: 0): Closing trade multiplier >=
+- `--closing-trade-rank-lte` (int, default: 0): Closing trade rank <=
+- `--closing-trade-vcd-gte` (int, default: 0): Closing trade VCD >= (0/97/98/99/100)
+- `--closing-trade-volume-gte` (int, default: 0): Closing trade volume >=
+- `--cluster-dollars-gte` (int, default: 0): Trade cluster dollars >=
+- `--cluster-mult-gte` (int, default: 0): Trade cluster multiplier >=
+- `--cluster-rank-lte` (int, default: 0): Trade cluster rank <=
+- `--cluster-vcd-gte` (int, default: 0): Trade cluster VCD >= (0/97/98/99/100)
+- `--cluster-volume-gte` (int, default: 0): Trade cluster volume >=
+- `--dark-pool` (bool, default: false): Dark pool filter
+- `--name` (string, required): Alert name (max 50 chars)
+- `--offsetting-print` (bool, default: false): Offsetting print filter
+- `--phantom-print` (bool, default: false): Phantom print filter
+- `--sweep` (bool, default: false): Sweep filter
+- `--ticker-group` (string, default: AllTickers): Ticker group (AllTickers or SelectedTickers)
+- `--tickers` (string): Comma-separated ticker symbols (max 500, used with SelectedTickers)
+- `--total-dollars-gte` (int, default: 0): Total dollars >=
+- `--total-rank-lte` (int, default: 0): Total rank <= (0/1/3/10/25/50/100)
+- `--total-volume-gte` (int, default: 0): Total volume >=
+- `--trade-conditions` (string, default: 0): Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos)
+- `--trade-dollars-gte` (int, default: 0): Trade dollars >= (0=N/A, 1000000/10000000/...)
+- `--trade-mult-gte` (int, default: 0): Trade multiplier >= (0=N/A, 5/10/25/50/100)
+- `--trade-rank-lte` (int, default: 0): Trade rank <= (0=N/A, 1/3/5/10/25/50/100)
+- `--trade-vcd-gte` (int, default: 0): Trade VCD >= (0=N/A, 99/100)
+- `--trade-volume-gte` (int, default: 0): Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000)
+
+## volumeleaders-agent alert delete
+
+Remove a saved alert configuration by its numeric key. Requires --key with the alert config key (visible in configs output). The deletion is permanent and cannot be undone.
+
+### Flags
+
+- `--key` (int, default: 0, required): Alert config key to delete
+
+## volumeleaders-agent alert edit
+
+Modify an existing alert configuration identified by its numeric key. Requires --key with the alert config key. Specify only the fields you want to change; unspecified fields retain their current values.
+
+### Flags
+
+- `--ah-dollars-gte` (int, default: 0): After-hours dollars >=
+- `--ah-rank-lte` (int, default: 0): After-hours rank <=
+- `--ah-volume-gte` (int, default: 0): After-hours volume >=
+- `--closing-trade-conditions` (string, default: 0): Closing trade conditions
+- `--closing-trade-dollars-gte` (int, default: 0): Closing trade dollars >=
+- `--closing-trade-mult-gte` (int, default: 0): Closing trade multiplier >=
+- `--closing-trade-rank-lte` (int, default: 0): Closing trade rank <=
+- `--closing-trade-vcd-gte` (int, default: 0): Closing trade VCD >= (0/97/98/99/100)
+- `--closing-trade-volume-gte` (int, default: 0): Closing trade volume >=
+- `--cluster-dollars-gte` (int, default: 0): Trade cluster dollars >=
+- `--cluster-mult-gte` (int, default: 0): Trade cluster multiplier >=
+- `--cluster-rank-lte` (int, default: 0): Trade cluster rank <=
+- `--cluster-vcd-gte` (int, default: 0): Trade cluster VCD >= (0/97/98/99/100)
+- `--cluster-volume-gte` (int, default: 0): Trade cluster volume >=
+- `--dark-pool` (bool, default: false): Dark pool filter
+- `--key` (int, default: 0, required): Alert config key to edit
+- `--name` (string): Alert name (max 50 chars)
+- `--offsetting-print` (bool, default: false): Offsetting print filter
+- `--phantom-print` (bool, default: false): Phantom print filter
+- `--sweep` (bool, default: false): Sweep filter
+- `--ticker-group` (string, default: AllTickers): Ticker group (AllTickers or SelectedTickers)
+- `--tickers` (string): Comma-separated ticker symbols (max 500, used with SelectedTickers)
+- `--total-dollars-gte` (int, default: 0): Total dollars >=
+- `--total-rank-lte` (int, default: 0): Total rank <= (0/1/3/10/25/50/100)
+- `--total-volume-gte` (int, default: 0): Total volume >=
+- `--trade-conditions` (string, default: 0): Trade conditions (0=N/A, OBH/OBD/OSH/OSD combos)
+- `--trade-dollars-gte` (int, default: 0): Trade dollars >= (0=N/A, 1000000/10000000/...)
+- `--trade-mult-gte` (int, default: 0): Trade multiplier >= (0=N/A, 5/10/25/50/100)
+- `--trade-rank-lte` (int, default: 0): Trade rank <= (0=N/A, 1/3/5/10/25/50/100)
+- `--trade-vcd-gte` (int, default: 0): Trade VCD >= (0=N/A, 99/100)
+- `--trade-volume-gte` (int, default: 0): Trade volume >= (0=N/A, 1000000/2000000/5000000/10000000)
+
+## volumeleaders-agent market earnings
+
+Query the earnings calendar for a date range, showing tickers with earnings dates and associated trade activity counts. Requires --start-date and --end-date (or --days). Outputs compact JSON or CSV/TSV with --format.
+
+### Flags
+
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (required unless --days is set)
+- `--fields` (string): Comma-separated fields to include (use 'all' for every field)
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--start-date` (string): Start date YYYY-MM-DD (required unless --days is set)
+
+## volumeleaders-agent market exhaustion
+
+Query exhaustion scores that indicate overbought or oversold market conditions based on institutional trade clustering patterns. Omit --date to query the current trading day. Outputs compact JSON with rank metrics at different lookback periods.
+
+### Flags
+
+- `--date` (string): Date YYYY-MM-DD (empty for current day)
+
+## volumeleaders-agent market snapshots
+
+Retrieve current price snapshot data for all symbols tracked by VolumeLeaders, returning the latest available price and volume data. No date filtering is available; always returns the most recent data. Outputs compact JSON by default.
+
+## volumeleaders-agent trade alerts
+
+Query trade alerts fired on a specific date based on saved alert configurations. Requires --date. Returns alert records matching your configured filters. Outputs compact JSON or CSV/TSV with --format.
+
+Alert configs trigger when trades match thresholds. Threshold names follow the pattern CategoryMetricLTE or CategoryMetricGTE where LTE is maximum rank and GTE is minimum value. Use alert configs to see your configured thresholds.
+
+### Flags
+
+- `--date` (string, required): Date YYYY-MM-DD
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 100): Number of results
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: desc): Order direction
+- `--start` (int, default: 0): DataTables start offset
+
+## volumeleaders-agent trade cluster-alerts
+
+Query trade cluster alerts fired on a specific date based on saved alert configurations that target cluster activity. Requires --date. Returns cluster alert records matching your configured filters.
+
+Cluster alert rows use the full cluster-shaped model rather than the compact default from trade clusters. Use trade alerts for individual trade alert rows and this command for cluster-level alert rows.
+
+### Flags
+
+- `--date` (string, required): Date YYYY-MM-DD
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 100): Number of results
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: desc): Order direction
+- `--start` (int, default: 0): DataTables start offset
+
+## volumeleaders-agent trade cluster-bombs
+
+Query trade cluster bombs, which are extreme-magnitude trade clusters that exceed normal institutional activity thresholds. Filterable by ticker, date range, dollar amounts, sector, and cluster bomb rank. Outputs compact JSON by default.
+
+Cluster bombs find sudden aggressive bursts tightly grouped in time and price, with different defaults and rank fields than trade clusters. Use this command when looking for extreme concentration events, not general price-level clustering.
+
+### Flags
+
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (required unless --days is set)
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 100): Number of results
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 0): Minimum dollar value
+- `--min-volume` (int, default: 0): Minimum volume
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: desc): Order direction
+- `--relative-size` (int, default: 0): Relative size threshold
+- `--sector` (string): Sector/Industry filter
+- `--security-type` (int, default: 0): Security type key
+- `--start` (int, default: 0): DataTables start offset
+- `--start-date` (string): Start date YYYY-MM-DD (required unless --days is set)
+- `--tickers` (string): Comma-separated ticker symbols
+- `--trade-cluster-bomb-rank` (int, default: -1): Trade cluster bomb rank filter
+- `--vcd` (int, default: 0): VCD filter
+
+## volumeleaders-agent trade clusters
+
+Query aggregated trade clusters, which group multiple trades in a short window into a single cluster record. Filterable by ticker, date range, dollar amounts, sector, and trade cluster rank. Outputs compact JSON or CSV/TSV with --format.
+
+Use clusters when the question is about price-level concentration, not single prints. This command uses larger default retrieval and dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price.
+
+### Flags
+
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (required unless --days is set)
+- `--fields` (string): Comma-separated TradeCluster fields to include in output, or 'all' for every field
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 1000): Number of results
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-price` (float64, default: 100000): Maximum price
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 10000000): Minimum dollar value
+- `--min-price` (float64, default: 0): Minimum price
+- `--min-volume` (int, default: 0): Minimum volume
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: desc): Order direction
+- `--relative-size` (int, default: 5): Relative size threshold
+- `--sector` (string): Sector/Industry filter
+- `--security-type` (int, default: -1): Security type key
+- `--start` (int, default: 0): DataTables start offset
+- `--start-date` (string): Start date YYYY-MM-DD (required unless --days is set)
+- `--tickers` (string): Comma-separated ticker symbols
+- `--trade-cluster-rank` (int, default: -1): Trade cluster rank filter
+- `--vcd` (int, default: 0): VCD filter
+
+## volumeleaders-agent trade level-touches
+
+Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
+
+Defaults to --length 50 and rejects --length -1, --length 0, and values above 50. Use trade levels first to identify significant price zones, then use this command to find events where price revisited those levels.
+
+### Flags
+
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (required unless --days is set)
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 50): Number of results
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-price` (float64, default: 100000): Maximum price
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 500000): Minimum dollar value
+- `--min-price` (float64, default: 0): Minimum price
+- `--min-volume` (int, default: 0): Minimum volume
+- `--order-col` (int, default: 0): Order column index
+- `--order-dir` (string, default: desc): Order direction
+- `--relative-size` (int, default: 0): Relative size threshold
+- `--start` (int, default: 0): DataTables start offset
+- `--start-date` (string): Start date YYYY-MM-DD (required unless --days is set)
+- `--ticker` (string): Ticker symbol
+- `--trade-level-count` (int, default: 50): Number of price levels to include (1-50)
+- `--trade-level-rank` (int, default: 10): Trade level rank filter
+- `--vcd` (int, default: 0): VCD filter
+
+## volumeleaders-agent trade levels
+
+Query significant price levels for a ticker, showing historical support and resistance zones identified by institutional trade clustering. Accepts a ticker as positional argument or via --ticker flag. Outputs compact JSON by default.
+
+Defaults to a 1-year lookback when dates are omitted. Uses non-standard --relative-size 0 and caps level count from 1 to 50 via --trade-level-count. Default JSON is compact and omits repetitive ticker metadata and the verbose Dates list; use --fields all or CSV/TSV when raw fields are needed.
+
+### Flags
+
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (default: today)
+- `--fields` (string): Comma-separated TradeLevel fields to include in output, or 'all' for every field
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-price` (float64, default: 100000): Maximum price
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 500000): Minimum dollar value
+- `--min-price` (float64, default: 0): Minimum price
+- `--min-volume` (int, default: 0): Minimum volume
+- `--relative-size` (int, default: 0): Relative size threshold
+- `--start-date` (string): Start date YYYY-MM-DD (default: auto)
+- `--ticker` (string): Ticker symbol
+- `--trade-level-count` (int, default: 10): Number of price levels to return (1-50)
+- `--trade-level-rank` (int, default: -1): Trade level rank filter
+- `--vcd` (int, default: 0): VCD filter
+
+## volumeleaders-agent trade list
+
+Query individual institutional trades from VolumeLeaders, filterable by ticker, date range, dollar amounts, volume, trade conditions, session type, and trade rank. Supports built-in filter presets (--preset) and watchlist-based filtering (--watchlist). Outputs compact JSON or CSV/TSV with --format; use --summary for aggregate metrics grouped by ticker or day.
+
+Date defaults: 365-day lookback when tickers are provided, today-only without tickers. Preset and watchlist filters do not supply dates. Filter precedence is preset baseline, then watchlist merge, then explicit CLI flags override both.
+
+Default JSON is compact and omits repetitive/internal fields. Use --fields FIELD1,FIELD2, CSV/TSV, or --fields all where supported when raw API fields are needed. --summary returns aggregate JSON with valid --group-by values of ticker, day, or ticker,day; do not combine summary mode with --fields or non-JSON formats.
+
+KEY METRICS
+
+Field                      Meaning
+-------------------------  ---------------------------------------------------------------
+CumulativeDistribution     Volume percentile, 0 to 1, higher means more accumulation
+DollarsMultiplier          Trade dollars relative to average block size
+TradeRank                  VL significance rank now, lower is stronger
+TradeRankSnapshot          VL significance rank at print time, lower is stronger
+TradeClusterRank           Rank for cluster significance, lower is stronger
+TradeClusterBombRank       Rank for burst significance, lower is stronger
+TradeLevelRank             Rank for level significance, lower is stronger
+RelativeSize               Trade size vs normal activity
+PercentDailyVolume         Trade volume as percent of average daily volume
+VCD                        Volume Confirmation Distribution score
+FrequencyLast30TD          Similar-magnitude trade frequency over last 30 trading days
+FrequencyLast90TD          Similar-magnitude trade frequency over last 90 trading days
+FrequencyLast1CY           Similar-magnitude trade frequency over last calendar year
+RSIHour                    Hourly RSI at time of trade
+RSIDay                     Daily RSI at time of trade
+DarkPool                   Boolean: trade printed on a dark pool
+Sweep                      Boolean: trade was a sweep order
+LatePrint                  Boolean: trade was a late print
+SignaturePrint             Boolean: trade matched a signature print pattern
+PhantomPrint               Boolean: trade was a phantom print
+InsideBar                  Boolean: bar was an inside bar
+
+Shared trade filters include volume, price, dollars, conditions, VCD, relative size, security type, market cap, trade rank, dark pools, sweeps, late prints, signature prints, even-share prints, and session/event toggles.
+
+### Flags
+
+- `--ah` (int, default: 1): Include after hours
+- `--closing` (int, default: 1): Include closing trades
+- `--conditions` (int, default: -1): Trade conditions filter
+- `--dark-pools` (int, default: -1): Dark pool filter
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (default: today)
+- `--even-shared` (int, default: -1): Even shared filter
+- `--fields` (string): Comma-separated trade fields to include in output
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--group-by` (string, default: ticker): Summary grouping (requires --summary): ticker, day, or ticker,day
+- `--late-prints` (int, default: -1): Late print filter
+- `--length` (int, default: 10): Number of results
+- `--market-cap` (int, default: 0): Market cap filter
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-price` (float64, default: 100000): Maximum price
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 500000): Minimum dollar value
+- `--min-price` (float64, default: 0): Minimum price
+- `--min-volume` (int, default: 0): Minimum volume
+- `--offsetting` (int, default: 1): Include offsetting trades
+- `--opening` (int, default: 1): Include opening trades
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: desc): Order direction
+- `--phantom` (int, default: 1): Include phantom prints
+- `--premarket` (int, default: 1): Include premarket
+- `--preset` (string): Apply a built-in filter preset (see: trade presets)
+- `--rank-snapshot` (int, default: -1): Trade rank snapshot filter
+- `--relative-size` (int, default: 5): Relative size threshold
+- `--rth` (int, default: 1): Include regular trading hours
+- `--sector` (string): Sector/Industry filter
+- `--security-type` (int, default: -1): Security type key
+- `--sig-prints` (int, default: -1): Signature print filter
+- `--start` (int, default: 0): DataTables start offset
+- `--start-date` (string): Start date YYYY-MM-DD (default: auto)
+- `--summary` (bool, default: false): Return aggregate metrics instead of individual trades
+- `--sweeps` (int, default: -1): Sweep filter
+- `--tickers` (string): Comma-separated ticker symbols
+- `--trade-rank` (int, default: -1): Trade rank filter
+- `--vcd` (int, default: 97): VCD filter
+- `--watchlist` (string): Apply filters from a saved watchlist by name
+
+## volumeleaders-agent trade preset-tickers
+
+Extract the ticker symbols configured in a named trade filter preset, showing whether the preset uses an explicit ticker list, a sector/industry filter, or is unfiltered. Requires --preset with the preset name (case-insensitive). Outputs JSON with the preset name, group, type, and ticker details.
+
+### Flags
+
+- `--preset` (string, required): Preset name (case-insensitive)
+
+## volumeleaders-agent trade presets
+
+List all built-in trade filter presets with their names, groups, and filter configurations. Each preset defines a named set of filters that can be applied to trade list queries via --preset. Outputs compact JSON by default; use --format csv or tsv for tabular output.
+
+### Flags
+
+- `--format` (string, default: json): Output format: json, csv, or tsv
+
+## volumeleaders-agent trade sentiment
+
+Summarize leveraged ETF bull and bear flow by trading day, showing aggregate institutional dollar volume on the bull and bear side. Requires --start-date and --end-date (or --days). Outputs one record per day with bull and bear totals.
+
+This command always queries the combined leveraged ETF sector filter SectorIndustry=X B, classifies bull and bear ETFs locally, and cannot be constrained by ticker or sector flags. Non-standard defaults include --min-dollars 5000000 and --vcd 97; shared --relative-size 5 still applies.
+
+Ratio is bull dollars divided by bear dollars and is null when bear flow is zero. Treat the output as leveraged ETF proxy flow, not signed buy/sell flow for the broader market.
+
+### Flags
+
+- `--ah` (int, default: 1): Include after hours
+- `--closing` (int, default: 1): Include closing trades
+- `--conditions` (int, default: -1): Trade conditions filter
+- `--dark-pools` (int, default: -1): Dark pool filter
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (required unless --days is set)
+- `--even-shared` (int, default: -1): Even shared filter
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--late-prints` (int, default: -1): Late print filter
+- `--market-cap` (int, default: 0): Market cap filter
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-price` (float64, default: 100000): Maximum price
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 5000000): Minimum dollar value
+- `--min-price` (float64, default: 0): Minimum price
+- `--min-volume` (int, default: 0): Minimum volume
+- `--offsetting` (int, default: 1): Include offsetting trades
+- `--opening` (int, default: 1): Include opening trades
+- `--phantom` (int, default: 1): Include phantom prints
+- `--premarket` (int, default: 1): Include premarket
+- `--rank-snapshot` (int, default: -1): Trade rank snapshot filter
+- `--relative-size` (int, default: 5): Relative size threshold
+- `--rth` (int, default: 1): Include regular trading hours
+- `--security-type` (int, default: -1): Security type key
+- `--sig-prints` (int, default: -1): Signature print filter
+- `--start-date` (string): Start date YYYY-MM-DD (required unless --days is set)
+- `--sweeps` (int, default: -1): Sweep filter
+- `--trade-rank` (int, default: -1): Trade rank filter
+- `--vcd` (int, default: 97): VCD filter
+
+## volumeleaders-agent volume ah-institutional
+
+Query the after-hours institutional volume leaderboard, ranking tickers by total institutional trade volume during after-hours sessions for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.
+
+### Flags
+
+- `--date` (string, required): Date YYYY-MM-DD
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 100): Number of results
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: asc): Order direction
+- `--start` (int, default: 0): DataTables start offset
+- `--tickers` (string): Comma-separated ticker symbols
+
+## volumeleaders-agent volume institutional
+
+Query the regular-hours institutional volume leaderboard, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments to filter results; also accepts --tickers flag. Requires --date. Outputs compact JSON or CSV/TSV with --format.
+
+### Flags
+
+- `--date` (string, required): Date YYYY-MM-DD
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 100): Number of results
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: asc): Order direction
+- `--start` (int, default: 0): DataTables start offset
+- `--tickers` (string): Comma-separated ticker symbols
+
+## volumeleaders-agent volume total
+
+Query the total volume leaderboard combining all session types, ranking tickers by total institutional trade volume for a given date. Accepts optional ticker positional arguments; also accepts --tickers flag. Requires --date.
+
+### Flags
+
+- `--date` (string, required): Date YYYY-MM-DD
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--length` (int, default: 100): Number of results
+- `--order-col` (int, default: 1): Order column index
+- `--order-dir` (string, default: asc): Order direction
+- `--start` (int, default: 0): DataTables start offset
+- `--tickers` (string): Comma-separated ticker symbols
+
+## volumeleaders-agent watchlist add-ticker
+
+Add a ticker symbol to an existing watchlist. Requires --watchlist-key with the watchlist key and --ticker with the symbol to add. The ticker is appended to the watchlist without affecting existing symbols.
+
+### Flags
+
+- `--ticker` (string, required): Ticker symbol to add
+- `--watchlist-key` (int, default: 0, required): Watch list key
+
+## volumeleaders-agent watchlist configs
+
+List all saved watchlist configurations with their keys and names. Outputs compact JSON or CSV/TSV with --format. Each row shows the watchlist key and name; use the tickers subcommand to view symbols in a specific watchlist.
+
+### Flags
+
+- `--format` (string, default: json): Output format: json, csv, or tsv
+
+## volumeleaders-agent watchlist create
+
+Create a new watchlist configuration with a name and optional filter settings such as minimum volume, price range, sector, and trade conditions. Requires --name. Use --tickers to specify an explicit ticker list or leave unset for a filter-based watchlist.
+
+### Flags
+
+- `--ah-trades` (bool, default: true): Include after-hours trades
+- `--blocks` (bool, default: true): Include block trades
+- `--closing-trades` (bool, default: true): Include closing trades
+- `--dark-pools` (bool, default: true): Include dark pool trades
+- `--late-prints` (bool, default: true): Include late prints
+- `--lit-exchanges` (bool, default: true): Include lit exchange trades
+- `--max-dollars` (float64, default: 3e+10): Maximum dollars filter
+- `--max-price` (float64, default: 100000): Maximum price filter
+- `--max-trade-rank` (int, default: -1): Maximum trade rank (-1=all, 1/3/5/10/25/50/100)
+- `--max-volume` (int, default: 2000000000): Maximum volume filter
+- `--min-dollars` (float64, default: 0): Minimum dollars filter
+- `--min-price` (float64, default: 0): Minimum price filter
+- `--min-relative-size` (int, default: 0): Minimum relative size (0/5/10/25/50/100)
+- `--min-vcd` (float64, default: 0): Minimum VCD percentile (0-100)
+- `--min-volume` (int, default: 0): Minimum volume filter
+- `--name` (string, required): Watch list name
+- `--normal-prints` (bool, default: true): Include normal prints
+- `--offsetting-trades` (bool, default: true): Include offsetting trades
+- `--opening-trades` (bool, default: true): Include opening trades
+- `--phantom-trades` (bool, default: true): Include phantom trades
+- `--premarket-trades` (bool, default: true): Include premarket trades
+- `--rsi-overbought-daily` (int, default: -1): RSI overbought daily (1=yes, 0=no, -1=ignore)
+- `--rsi-overbought-hourly` (int, default: -1): RSI overbought hourly (1=yes, 0=no, -1=ignore)
+- `--rsi-oversold-daily` (int, default: -1): RSI oversold daily (1=yes, 0=no, -1=ignore)
+- `--rsi-oversold-hourly` (int, default: -1): RSI oversold hourly (1=yes, 0=no, -1=ignore)
+- `--rth-trades` (bool, default: true): Include regular trading hours trades
+- `--sector-industry` (string): Sector/industry filter (max 100 chars)
+- `--security-type` (int, default: -1): Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs)
+- `--signature-prints` (bool, default: true): Include signature prints
+- `--sweeps` (bool, default: true): Include sweep trades
+- `--tickers` (string): Comma-separated ticker symbols (max 500)
+- `--timely-prints` (bool, default: true): Include timely prints
+
+## volumeleaders-agent watchlist delete
+
+Remove a saved watchlist configuration by its numeric key. Requires --key with the watchlist key (visible in configs output). The deletion is permanent and removes the watchlist and all its tickers.
+
+### Flags
+
+- `--key` (int, default: 0, required): Watch list key to delete
+
+## volumeleaders-agent watchlist edit
+
+Modify an existing watchlist configuration identified by its numeric key. Requires --key with the watchlist key. Specify only the fields you want to change; unspecified fields retain their current values.
+
+### Flags
+
+- `--ah-trades` (bool, default: true): Include after-hours trades
+- `--blocks` (bool, default: true): Include block trades
+- `--closing-trades` (bool, default: true): Include closing trades
+- `--dark-pools` (bool, default: true): Include dark pool trades
+- `--key` (int, default: 0, required): Watch list key to edit
+- `--late-prints` (bool, default: true): Include late prints
+- `--lit-exchanges` (bool, default: true): Include lit exchange trades
+- `--max-dollars` (float64, default: 3e+10): Maximum dollars filter
+- `--max-price` (float64, default: 100000): Maximum price filter
+- `--max-trade-rank` (int, default: -1): Maximum trade rank (-1=all, 1/3/5/10/25/50/100)
+- `--max-volume` (int, default: 2000000000): Maximum volume filter
+- `--min-dollars` (float64, default: 0): Minimum dollars filter
+- `--min-price` (float64, default: 0): Minimum price filter
+- `--min-relative-size` (int, default: 0): Minimum relative size (0/5/10/25/50/100)
+- `--min-vcd` (float64, default: 0): Minimum VCD percentile (0-100)
+- `--min-volume` (int, default: 0): Minimum volume filter
+- `--name` (string): Watch list name
+- `--normal-prints` (bool, default: true): Include normal prints
+- `--offsetting-trades` (bool, default: true): Include offsetting trades
+- `--opening-trades` (bool, default: true): Include opening trades
+- `--phantom-trades` (bool, default: true): Include phantom trades
+- `--premarket-trades` (bool, default: true): Include premarket trades
+- `--rsi-overbought-daily` (int, default: -1): RSI overbought daily (1=yes, 0=no, -1=ignore)
+- `--rsi-overbought-hourly` (int, default: -1): RSI overbought hourly (1=yes, 0=no, -1=ignore)
+- `--rsi-oversold-daily` (int, default: -1): RSI oversold daily (1=yes, 0=no, -1=ignore)
+- `--rsi-oversold-hourly` (int, default: -1): RSI oversold hourly (1=yes, 0=no, -1=ignore)
+- `--rth-trades` (bool, default: true): Include regular trading hours trades
+- `--sector-industry` (string): Sector/industry filter (max 100 chars)
+- `--security-type` (int, default: -1): Security type (-1=all, 1=stocks, 26=ETFs, 4=REITs)
+- `--signature-prints` (bool, default: true): Include signature prints
+- `--sweeps` (bool, default: true): Include sweep trades
+- `--tickers` (string): Comma-separated ticker symbols (max 500)
+- `--timely-prints` (bool, default: true): Include timely prints
+
+## volumeleaders-agent watchlist tickers
+
+Query the ticker symbols belonging to a specific watchlist identified by --watchlist-key. Returns all tickers in the watchlist with their metadata. Outputs compact JSON or CSV/TSV with --format.
+
+### Flags
+
+- `--format` (string, default: json): Output format: json, csv, or tsv
+- `--watchlist-key` (int, default: -1): Watch list key (-1 for all)
+
+## Optional
+
+- [JSON Schema](#json-schema): Machine-readable schema available via `volumeleaders-agent --jsonschema`

--- a/internal/discovery/generate.go
+++ b/internal/discovery/generate.go
@@ -1,0 +1,83 @@
+package discovery
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/leodido/structcli/generate"
+
+	"github.com/major/volumeleaders-agent/internal/cli"
+)
+
+const (
+	// DefaultOutputDir keeps generated agent-facing files out of the repository
+	// root so they do not overwrite the hand-maintained root AGENTS.md.
+	DefaultOutputDir = "docs/llm"
+	modulePath       = "github.com/major/volumeleaders-agent/cmd/volumeleaders-agent"
+	defaultAuthor    = "major"
+)
+
+// Generate writes the structcli discovery files for the current command tree.
+func Generate(outputDir, version string) error {
+	rootCmd := cli.NewRootCmd(version)
+
+	if err := generate.WriteAll(rootCmd, outputDir, generate.AllOptions{
+		ModulePath: modulePath,
+		Skill: generate.SkillOptions{
+			Author:  defaultAuthor,
+			Version: version,
+		},
+	}); err != nil {
+		return fmt.Errorf("generate discovery files: %w", err)
+	}
+	if err := labelMarkdownFences(outputDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func labelMarkdownFences(outputDir string) error {
+	for _, fileName := range []string{"AGENTS.md", "SKILL.md", "llms.txt"} {
+		path := filepath.Join(outputDir, fileName)
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read generated %s: %w", fileName, err)
+		}
+
+		labeled := labelPlainFences(string(contents))
+		if err := os.WriteFile(path, []byte(labeled), 0o600); err != nil {
+			return fmt.Errorf("write generated %s: %w", fileName, err)
+		}
+	}
+
+	return nil
+}
+
+func labelPlainFences(contents string) string {
+	var builder strings.Builder
+	inFence := false
+	for _, line := range strings.SplitAfter(contents, "\n") {
+		trimmed := strings.TrimSuffix(line, "\n")
+		if trimmed == "```" {
+			if inFence {
+				builder.WriteString(line)
+			} else {
+				builder.WriteString("```bash")
+				if strings.HasSuffix(line, "\n") {
+					builder.WriteString("\n")
+				}
+			}
+			inFence = !inFence
+			continue
+		}
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+		}
+		builder.WriteString(line)
+	}
+
+	return builder.String()
+}

--- a/internal/discovery/generate_test.go
+++ b/internal/discovery/generate_test.go
@@ -1,0 +1,73 @@
+package discovery
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateWritesDiscoveryFiles(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	if err := Generate(outputDir, "test"); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	for _, fileName := range []string{"AGENTS.md", "SKILL.md", "llms.txt"} {
+		fileName := fileName
+		t.Run(fileName, func(t *testing.T) {
+			t.Parallel()
+
+			contents, err := os.ReadFile(filepath.Join(outputDir, fileName))
+			if err != nil {
+				t.Fatalf("read generated %s: %v", fileName, err)
+			}
+			if !bytes.Contains(contents, []byte("volumeleaders-agent")) {
+				t.Fatalf("generated %s does not mention volumeleaders-agent", fileName)
+			}
+		})
+	}
+}
+
+func TestGeneratedFilesAreCurrent(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	if err := Generate(outputDir, "dev"); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	for _, fileName := range []string{"AGENTS.md", "SKILL.md", "llms.txt"} {
+		fileName := fileName
+		t.Run(fileName, func(t *testing.T) {
+			t.Parallel()
+
+			generated, err := os.ReadFile(filepath.Join(outputDir, fileName))
+			if err != nil {
+				t.Fatalf("read generated %s: %v", fileName, err)
+			}
+
+			committed, err := os.ReadFile(filepath.Join(repoRoot, DefaultOutputDir, fileName))
+			if err != nil {
+				t.Fatalf("read committed %s: %v", fileName, err)
+			}
+
+			if !bytes.Equal(generated, committed) {
+				t.Fatalf("%s is stale; run `make generate-discovery`", filepath.Join(DefaultOutputDir, fileName))
+			}
+		})
+	}
+}
+
+func TestLabelPlainFences(t *testing.T) {
+	t.Parallel()
+
+	input := "before\n```\nvolumeleaders-agent --help\n```\n```json\n{}\n```\nafter\n"
+	want := "before\n```bash\nvolumeleaders-agent --help\n```\n```json\n{}\n```\nafter\n"
+	if got := labelPlainFences(input); got != want {
+		t.Fatalf("labelPlainFences() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `make generate-discovery` using structcli's generator to write `AGENTS.md`, `SKILL.md`, and `llms.txt` under `docs/llm/`.
- Keep generated files out of the repo root so the hand-maintained root `AGENTS.md` is never overwritten by the default workflow.
- Add tests that regenerate the files and fail when committed discovery docs are stale.

## Verification
- `make generate-discovery`
- Generated markdown fence validation for `docs/llm/*.md`
- `go test ./internal/discovery ./cmd/generate-discovery -count=1`
- `make test`
- `make lint`
- `make build`
- Seven live read-only smoke commands: volume institutional, volume ah-institutional, volume total, trade list, trade sentiment, market exhaustion, watchlist configs
- Oracle review passed with no blockers

Local CodeRabbit hit the hourly rate limit, so GitHub CodeRabbit CI is expected to provide the review signal on this PR.