### PR TITLE
fix(auth): cache cookies and surface kooky read errors on Windows

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -66,22 +66,39 @@ func IsSessionExpired(err error) bool {
 	return errors.Is(err, ErrSessionExpired)
 }
 
-// ExtractCookies reads required VolumeLeaders cookies from supported browsers.
+// ExtractCookies reads required VolumeLeaders cookies, checking a local
+// cache first and falling back to browser cookie stores on cache miss.
 //
 // Kooky scans all registered browsers and returns accumulated errors for
 // browsers that could not be read (uninstalled, locked, etc.). We ignore
 // those errors as long as the required auth cookies were found in at least
-// one browser.
+// one browser. When no cookies are found, the accumulated errors are
+// included in the diagnostic to help troubleshoot (e.g. Windows SQLite
+// lock failures that silently prevent reads).
+//
+// Successfully extracted cookies are cached so subsequent invocations
+// avoid the cost of reading browser stores. Call InvalidateCache when
+// the server reports a session expiry so the next call re-reads from
+// browser stores.
 func ExtractCookies(ctx context.Context) (map[string]string, error) {
+	if cached, err := loadCache(); err == nil {
+		return cached, nil
+	}
+
 	// ReadCookies returns cookies it could find plus errors from browsers
 	// it could not read. Errors from missing browsers are expected.
-	validCookies, _ := kooky.ReadCookies(ctx, kooky.Valid, kooky.DomainHasSuffix(volumeLeadersDomain))
+	validCookies, validErr := kooky.ReadCookies(ctx, kooky.Valid, kooky.DomainHasSuffix(volumeLeadersDomain))
 	found := authCookies(validCookies)
 
 	if found["ASP.NET_SessionId"] == "" || found[".ASPXAUTH"] == "" {
-		allCookies, _ := kooky.ReadCookies(ctx, kooky.DomainHasSuffix(volumeLeadersDomain))
-		return nil, fmt.Errorf("required browser cookies unavailable: %s", cookieDiagnostic(found, allCookies, validCookies))
+		allCookies, allErr := kooky.ReadCookies(ctx, kooky.DomainHasSuffix(volumeLeadersDomain))
+		browserErrs := errors.Join(validErr, allErr)
+		return nil, fmt.Errorf("required browser cookies unavailable: %s", cookieDiagnostic(found, allCookies, validCookies, browserErrs))
 	}
+
+	// Cache for subsequent runs (best-effort, failures are not fatal).
+	_ = saveCache(found)
+
 	return found, nil
 }
 
@@ -118,7 +135,7 @@ func authCookies(cookies kooky.Cookies) map[string]string {
 	return found
 }
 
-func cookieDiagnostic(found map[string]string, allCookies, validCookies kooky.Cookies) string {
+func cookieDiagnostic(found map[string]string, allCookies, validCookies kooky.Cookies, browserErrs error) string {
 	missing := missingRequiredCookies(found)
 	rejected := rejectedRequiredCookies(found, allCookies)
 	parts := []string{
@@ -131,6 +148,9 @@ func cookieDiagnostic(found map[string]string, allCookies, validCookies kooky.Co
 	}
 	if len(rejected) > 0 {
 		parts = append(parts, fmt.Sprintf("matching required cookies found but not usable as valid cookies: %s", strings.Join(rejected, ", ")))
+	}
+	if browserErrs != nil {
+		parts = append(parts, fmt.Sprintf("browser read errors: %v", browserErrs))
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -182,6 +182,7 @@ func TestCookieDiagnostic(t *testing.T) {
 		found        map[string]string
 		allCookies   kooky.Cookies
 		validCookies kooky.Cookies
+		browserErrs  error
 		wantParts    []string
 		forbidParts  []string
 	}{
@@ -195,6 +196,9 @@ func TestCookieDiagnostic(t *testing.T) {
 				"browser stores with VolumeLeaders cookies: 0",
 				"missing valid cookies: ASP.NET_SessionId, .ASPXAUTH",
 				"only cookie storage is inspected; local storage, session storage, and IndexedDB are not inspected",
+			},
+			forbidParts: []string{
+				"browser read errors",
 			},
 		},
 		{
@@ -222,13 +226,32 @@ func TestCookieDiagnostic(t *testing.T) {
 				"/home/",
 			},
 		},
+		{
+			name:        "surfaces browser read errors",
+			found:       map[string]string{},
+			browserErrs: fmt.Errorf("database is locked"),
+			wantParts: []string{
+				"browser read errors: database is locked",
+				"missing valid cookies: ASP.NET_SessionId, .ASPXAUTH",
+			},
+		},
+		{
+			name:        "surfaces joined browser errors",
+			found:       map[string]string{},
+			browserErrs: errors.Join(fmt.Errorf("firefox: database is locked"), fmt.Errorf("chrome: profile not found")),
+			wantParts: []string{
+				"browser read errors:",
+				"database is locked",
+				"profile not found",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			diagnostic := cookieDiagnostic(tt.found, tt.allCookies, tt.validCookies)
+			diagnostic := cookieDiagnostic(tt.found, tt.allCookies, tt.validCookies, tt.browserErrs)
 			for _, want := range tt.wantParts {
 				if !strings.Contains(diagnostic, want) {
 					t.Errorf("expected diagnostic to contain %q, got %q", want, diagnostic)

--- a/internal/auth/cache.go
+++ b/internal/auth/cache.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const cacheSubdir = "volumeleaders-agent"
+const cacheFileName = "cookies.json"
+
+// cookieCache is the on-disk format for cached authentication cookies.
+type cookieCache struct {
+	Cookies  map[string]string `json:"cookies"`
+	CachedAt time.Time         `json:"cached_at"`
+}
+
+// cachePath returns the full path to the cookie cache file using the
+// platform-appropriate user cache directory.
+func cachePath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("user cache directory: %w", err)
+	}
+	return filepath.Join(dir, cacheSubdir, cacheFileName), nil
+}
+
+// loadCacheFile reads cached cookies from the given path. Returns
+// os.ErrNotExist on cache miss, or an error if the file is corrupt
+// or missing required cookie values.
+func loadCacheFile(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cache cookieCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, fmt.Errorf("decode cookie cache: %w", err)
+	}
+
+	if cache.Cookies["ASP.NET_SessionId"] == "" || cache.Cookies[".ASPXAUTH"] == "" {
+		return nil, fmt.Errorf("cached cookies missing required values")
+	}
+
+	return cache.Cookies, nil
+}
+
+// saveCacheFile writes cookies to the given path, creating parent
+// directories as needed. The file is written with 0o600 permissions
+// since it contains authentication cookies.
+func saveCacheFile(path string, cookies map[string]string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create cache directory: %w", err)
+	}
+
+	cache := cookieCache{
+		Cookies:  cookies,
+		CachedAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return fmt.Errorf("encode cookie cache: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0o600)
+}
+
+// invalidateCacheFile removes a cache file. Returns nil if the file
+// does not exist.
+func invalidateCacheFile(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// loadCache reads cached cookies from the default cache location.
+func loadCache() (map[string]string, error) {
+	path, err := cachePath()
+	if err != nil {
+		return nil, err
+	}
+	return loadCacheFile(path)
+}
+
+// saveCache writes cookies to the default cache location.
+func saveCache(cookies map[string]string) error {
+	path, err := cachePath()
+	if err != nil {
+		return err
+	}
+	return saveCacheFile(path, cookies)
+}
+
+// InvalidateCache removes cached authentication cookies so the next
+// ExtractCookies call reads directly from browser stores.
+func InvalidateCache() error {
+	path, err := cachePath()
+	if err != nil {
+		return err
+	}
+	return invalidateCacheFile(path)
+}

--- a/internal/auth/cache_test.go
+++ b/internal/auth/cache_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCacheRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cookies.json")
+	cookies := map[string]string{
+		"ASP.NET_SessionId": "session-value",
+		".ASPXAUTH":         "auth-value",
+	}
+
+	if err := saveCacheFile(path, cookies); err != nil {
+		t.Fatalf("saveCacheFile: %v", err)
+	}
+
+	got, err := loadCacheFile(path)
+	if err != nil {
+		t.Fatalf("loadCacheFile: %v", err)
+	}
+
+	for name, want := range cookies {
+		if got[name] != want {
+			t.Errorf("cookie %s: got %q, want %q", name, got[name], want)
+		}
+	}
+}
+
+func TestCacheFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "subdir", "cookies.json")
+	cookies := map[string]string{
+		"ASP.NET_SessionId": "session-value",
+		".ASPXAUTH":         "auth-value",
+	}
+
+	if err := saveCacheFile(path, cookies); err != nil {
+		t.Fatalf("saveCacheFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat cache file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("cache file permissions: got %o, want 0600", perm)
+	}
+
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat cache directory: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("cache directory permissions: got %o, want 0700", perm)
+	}
+}
+
+func TestLoadCacheMissingFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	_, err := loadCacheFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing cache file")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected os.ErrNotExist, got: %v", err)
+	}
+}
+
+func TestLoadCacheCorruptJSON(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cookies.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+
+	_, err := loadCacheFile(path)
+	if err == nil {
+		t.Fatal("expected error for corrupt JSON")
+	}
+	if !strings.Contains(err.Error(), "decode cookie cache") {
+		t.Fatalf("expected decode error, got: %v", err)
+	}
+}
+
+func TestLoadCacheMissingRequiredCookies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cookies map[string]string
+	}{
+		{
+			name:    "missing both",
+			cookies: map[string]string{"other": "value"},
+		},
+		{
+			name:    "missing session ID",
+			cookies: map[string]string{".ASPXAUTH": "auth"},
+		},
+		{
+			name:    "missing auth cookie",
+			cookies: map[string]string{"ASP.NET_SessionId": "session"},
+		},
+		{
+			name:    "empty session ID value",
+			cookies: map[string]string{"ASP.NET_SessionId": "", ".ASPXAUTH": "auth"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "cookies.json")
+			if err := saveCacheFile(path, tt.cookies); err != nil {
+				t.Fatalf("saveCacheFile: %v", err)
+			}
+
+			_, err := loadCacheFile(path)
+			if err == nil {
+				t.Fatal("expected error for missing required cookies")
+			}
+			if !strings.Contains(err.Error(), "missing required values") {
+				t.Fatalf("expected missing values error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestInvalidateExistingCache(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cookies.json")
+	cookies := map[string]string{
+		"ASP.NET_SessionId": "session-value",
+		".ASPXAUTH":         "auth-value",
+	}
+	if err := saveCacheFile(path, cookies); err != nil {
+		t.Fatalf("saveCacheFile: %v", err)
+	}
+
+	if err := invalidateCacheFile(path); err != nil {
+		t.Fatalf("invalidateCacheFile: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected cache file to be removed")
+	}
+}
+
+func TestInvalidateMissingCache(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	if err := invalidateCacheFile(path); err != nil {
+		t.Fatalf("invalidateCacheFile should be no-op for missing file: %v", err)
+	}
+}
+
+func TestCachePreservesExtraCookies(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cookies.json")
+	cookies := map[string]string{
+		"ASP.NET_SessionId":            "session-value",
+		".ASPXAUTH":                    "auth-value",
+		"__RequestVerificationToken":   "xsrf-cookie",
+	}
+
+	if err := saveCacheFile(path, cookies); err != nil {
+		t.Fatalf("saveCacheFile: %v", err)
+	}
+
+	got, err := loadCacheFile(path)
+	if err != nil {
+		t.Fatalf("loadCacheFile: %v", err)
+	}
+
+	if len(got) != len(cookies) {
+		t.Errorf("expected %d cookies, got %d", len(cookies), len(got))
+	}
+	for name, want := range cookies {
+		if got[name] != want {
+			t.Errorf("cookie %s: got %q, want %q", name, got[name], want)
+		}
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -60,22 +60,20 @@ func NewForTesting(httpClient *http.Client, baseURL string) *Client {
 }
 
 // New creates an authenticated VolumeLeaders client from browser cookies.
+//
+// Cached cookies are tried first. If the XSRF token fetch detects a
+// session expiry, the cache is invalidated and fresh cookies are
+// extracted from browser stores before failing.
 func New(ctx context.Context) (*Client, error) {
-	cookies, err := auth.ExtractCookies(ctx)
+	cookies, xsrfToken, err := authenticate(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("extract cookies: %w", err)
+		return nil, err
 	}
 
 	restyClient := resty.New()
 	restyClient.SetTimeout(60 * time.Second)
-	restyClient.SetCookies(buildCookies(cookies))
-
-	xsrfToken, err := auth.FetchXSRFToken(ctx, restyClient)
-	if err != nil {
-		return nil, fmt.Errorf("fetch XSRF token: %w", err)
-	}
-
 	configureClient(restyClient, BaseURL, xsrfToken)
+	restyClient.SetCookies(buildCookies(cookies))
 
 	noRedirectClient := resty.New()
 	noRedirectClient.SetTimeout(60 * time.Second)
@@ -90,6 +88,49 @@ func New(ctx context.Context) (*Client, error) {
 		cookies:          cookies,
 		xsrfToken:        xsrfToken,
 	}, nil
+}
+
+// authenticate extracts cookies and fetches an XSRF token. When the
+// first attempt uses cached cookies that turn out to be stale, the
+// cache is cleared and a second attempt reads fresh cookies directly
+// from browser stores.
+func authenticate(ctx context.Context) (cookies map[string]string, xsrfToken string, err error) {
+	cookies, err = auth.ExtractCookies(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("extract cookies: %w", err)
+	}
+
+	xsrfToken, err = probeXSRFToken(ctx, cookies)
+	if err != nil && auth.IsSessionExpired(err) {
+		// Cached cookies may be stale. Clear cache and retry with
+		// fresh browser cookies.
+		_ = auth.InvalidateCache()
+
+		cookies, err = auth.ExtractCookies(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("extract fresh cookies: %w", err)
+		}
+
+		xsrfToken, err = probeXSRFToken(ctx, cookies)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("fetch XSRF token: %w", err)
+	}
+
+	return cookies, xsrfToken, nil
+}
+
+// probeXSRFToken creates a temporary resty client to fetch the XSRF
+// token without configuring the full request middleware. The throwaway
+// client avoids resty's append-only cookie behavior that would cause
+// duplicates on retry.
+func probeXSRFToken(ctx context.Context, cookies map[string]string) (string, error) {
+	probe := resty.New()
+	probe.SetTimeout(60 * time.Second)
+	probe.SetCookies(buildCookies(cookies))
+	defer probe.Close()
+
+	return auth.FetchXSRFToken(ctx, probe)
 }
 
 // Close releases resources held by both resty clients.


### PR DESCRIPTION
## Summary

- Cache extracted browser cookies to `os.UserCacheDir()/volumeleaders-agent/cookies.json` so subsequent runs skip browser store reads entirely
- Surface kooky read errors in `cookieDiagnostic` instead of discarding them with `_`, giving actionable error messages when cookie extraction fails
- Add retry-with-cache-invalidation in `client.New()`: on session expiry, invalidate cache, re-extract cookies, and re-fetch XSRF token before failing

## Problem

On Windows, Firefox holds mandatory SQLite byte-range locks on `cookies.sqlite` while running. Kooky's SQLite reader fails to read locked pages, but `ExtractCookies` discarded those errors, producing a misleading "required browser cookies unavailable" message with zero diagnostic context.

Linux/macOS use cooperative `fcntl()` advisory locks that allow concurrent reads, so the same code works fine there.

## Changes

| File | Change |
|---|---|
| `internal/auth/cache.go` (new) | Cookie cache: load/save/invalidate with path-parameterized internals for testability. 0o600 file perms, 0o700 dir perms. Validates required cookies on load. |
| `internal/auth/cache_test.go` (new) | 8 test cases: roundtrip, file permissions, missing file, corrupt JSON, missing required cookies (table-driven), invalidate existing/missing, extra cookie preservation. |
| `internal/auth/auth.go` | Check cache before browser stores. Capture kooky errors instead of `_`. Pass errors to `cookieDiagnostic`. Save on successful extraction. |
| `internal/auth/auth_test.go` | Two new `TestCookieDiagnostic` cases for single and joined browser read errors. |
| `internal/client/client.go` | Extract `authenticate()` helper with retry logic. Uses throwaway resty client for XSRF probe to avoid append-only cookie behavior on retry. |

Closes #80