### PR TITLE
Add ticker dashboard command

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -317,6 +317,57 @@ Results are fetched in browser-sized 100-row pages to match VolumeLeaders' front
 volumeleaders-agent trade clusters AAPL --days 7
 ```
 
+#### `volumeleaders-agent trade dashboard`
+
+Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
+
+Defaults to a 365-day lookback, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use this command as the first stop when asking broad questions such as institutional levels for IGV, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs when a section needs deeper pagination or CSV/TSV output.
+
+PREREQUISITES: Provide exactly one ticker as a positional argument or with --ticker. Browser authentication must be available.
+
+RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If date flags conflict, use either --days or --start-date with --end-date.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--ah` | string | 1 | no | After-hours session filter (-1=all, 0=exclude, 1=include) |
+| `--closing` | string | 1 | no | Closing trade filter (-1=all, 0=exclude, 1=include) |
+| `--conditions` | int | -1 | no | Trade conditions filter |
+| `--count` | int | 10 | no | Rows to return per dashboard section (5, 10, 20, or 50) |
+| `--dark-pools` | string | -1 | no | Dark pool filter (-1=all, 0=exclude, 1=only) |
+| `--days` | int | 0 | no | Look back this many days from --end-date or today |
+| `--end-date` | string | - | no | End date YYYY-MM-DD (default: today) |
+| `--even-shared` | string | -1 | no | Even shared filter (-1=all, 0=exclude, 1=only) |
+| `--late-prints` | string | -1 | no | Late print filter (-1=all, 0=exclude, 1=only) |
+| `--market-cap` | int | 0 | no | Market cap filter |
+| `--max-dollars` | float64 | 30000000000 | no | Maximum dollar value |
+| `--max-price` | float64 | 100000 | no | Maximum price |
+| `--max-volume` | int | 2000000000 | no | Maximum volume |
+| `--min-dollars` | float64 | 500000 | no | Minimum dollar value |
+| `--min-price` | float64 | 0 | no | Minimum price |
+| `--min-volume` | int | 0 | no | Minimum volume |
+| `--offsetting` | string | 1 | no | Offsetting trade filter (-1=all, 0=exclude, 1=include) |
+| `--opening` | string | 1 | no | Opening trade filter (-1=all, 0=exclude, 1=include) |
+| `--phantom` | string | 1 | no | Phantom print filter (-1=all, 0=exclude, 1=include) |
+| `--premarket` | string | 1 | no | Premarket session filter (-1=all, 0=exclude, 1=include) |
+| `--rank-snapshot` | int | -1 | no | Trade rank snapshot filter |
+| `--relative-size` | int | 0 | no | Relative size threshold |
+| `--rth` | string | 1 | no | Regular trading hours filter (-1=all, 0=exclude, 1=include) |
+| `--security-type` | int | -1 | no | Security type key |
+| `--sig-prints` | string | -1 | no | Signature print filter (-1=all, 0=exclude, 1=only) |
+| `--start-date` | string | - | no | Start date YYYY-MM-DD (default: auto) |
+| `--sweeps` | string | -1 | no | Sweep filter (-1=all, 0=exclude, 1=only) |
+| `--ticker` | string | - | no | Ticker symbol |
+| `--trade-rank` | int | -1 | no | Trade rank filter |
+| `--vcd` | int | 0 | no | VCD filter |
+
+**Example:**
+
+```bash
+volumeleaders-agent trade dashboard IGV
+```
+
 #### `volumeleaders-agent trade level-touches`
 
 Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
@@ -877,6 +928,12 @@ volumeleaders-agent trade cluster-bombs TSLA --days 3
 
 ```bash
 volumeleaders-agent trade clusters AAPL --days 7
+```
+
+#### volumeleaders-agent trade dashboard
+
+```bash
+volumeleaders-agent trade dashboard IGV
 ```
 
 #### volumeleaders-agent trade level-touches

--- a/docs/llm/AGENTS.md
+++ b/docs/llm/AGENTS.md
@@ -11,6 +11,7 @@ COMMAND CHOOSER
 Goal                                          Start with                              Notes
 --------------------------------------------  --------------------------------------  -----------------------------------------------
 Find individual institutional prints          trade list X --days N                   Use ticker filters, presets, or watchlists
+Get comprehensive ticker overview            trade dashboard X --days N              Fast chart-style trades, clusters, levels, bombs
 Compare leveraged ETF bull/bear flow          trade sentiment --days N                Fixed leveraged ETF universe, not buy/sell flow
 Find converging price-level activity          trade clusters --days N                 Cluster conviction around similar prices
 Find sudden aggressive bursts                 trade cluster-bombs --days N            Burst detection, different defaults than clusters
@@ -30,10 +31,11 @@ Get watchlist tickers                         watchlist tickers --watchlist-key 
 ANALYSIS WORKFLOW
 
 1. volume institutional --date D for top dollar movers.
-2. trade list X --days N for individual prints.
-3. trade levels X --days N for support/resistance.
-4. trade clusters X --days N when prints appear concentrated around a price.
-5. market earnings --days N and market exhaustion --date D for event and reversal context.
+2. trade dashboard X --days N for a fast ticker overview before deeper drilling.
+3. trade list X --days N for individual prints.
+4. trade levels X --days N for support/resistance.
+5. trade clusters X --days N when prints appear concentrated around a price.
+6. market earnings --days N and market exhaustion --date D for event and reversal context.
 
 GLOBAL CONVENTIONS
 
@@ -63,7 +65,9 @@ Empty or too broad output: add tickers, explicit dates, min dollar filters, or a
 
 COMMAND SEQUENCES
 
-Broad scan: volume institutional --date D, then trade list TICKER --days N, then trade levels TICKER --days N.
+Broad scan: volume institutional --date D, then trade dashboard TICKER --days N, then trade list TICKER --days N, then trade levels TICKER --days N.
+
+Ticker drilldown: trade dashboard TICKER --days N, then trade list TICKER --days N, then trade clusters TICKER --days N.
 
 Event context: market earnings --days N, then trade list TICKER --start-date D --end-date D, then market exhaustion --date D.
 

--- a/docs/llm/AGENTS.md
+++ b/docs/llm/AGENTS.md
@@ -100,6 +100,13 @@ Results are fetched in browser-sized 100-row pages to match VolumeLeaders' front
 
 
 Results are fetched in browser-sized 100-row pages to match VolumeLeaders' frontend behavior. Use clusters when the question is about price-level concentration, not single prints. This command uses larger default dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price. |  |
+| `volumeleaders-agent trade dashboard` | Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
+
+Defaults to a 365-day lookback, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use this command as the first stop when asking broad questions such as institutional levels for IGV, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs when a section needs deeper pagination or CSV/TSV output.
+
+PREREQUISITES: Provide exactly one ticker as a positional argument or with --ticker. Browser authentication must be available.
+
+RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If date flags conflict, use either --days or --start-date with --end-date. |  |
 | `volumeleaders-agent trade level-touches` | Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
 
 Defaults to --trade-level-rank 5 and --length 50, rejects --length -1, --length 0, and values above 50, and only allows --trade-level-count values of 5, 10, 20, or 50. Use trade levels first to identify significant price zones, then use this command to find events where price revisited those levels.
@@ -345,6 +352,41 @@ Ratio is bull dollars divided by bear dollars and is null when bear flow is zero
 | `--start-date` | string | - | Start date YYYY-MM-DD (required unless --days is set) |
 | `--tickers` | string | - | Comma-separated ticker symbols |
 | `--trade-cluster-rank` | int | -1 | Trade cluster rank filter |
+| `--vcd` | int | 0 | VCD filter |
+
+#### `volumeleaders-agent trade dashboard`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ah` | string | 1 | After-hours session filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--closing` | string | 1 | Closing trade filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--conditions` | int | -1 | Trade conditions filter |
+| `--count` | int | 10 | Rows to return per dashboard section (5, 10, 20, or 50) |
+| `--dark-pools` | string | -1 | Dark pool filter (-1=all, 0=exclude, 1=only) (-1, 0, 1) |
+| `--days` | int | 0 | Look back this many days from --end-date or today |
+| `--end-date` | string | - | End date YYYY-MM-DD (default: today) |
+| `--even-shared` | string | -1 | Even shared filter (-1=all, 0=exclude, 1=only) (-1, 0, 1) |
+| `--late-prints` | string | -1 | Late print filter (-1=all, 0=exclude, 1=only) (-1, 0, 1) |
+| `--market-cap` | int | 0 | Market cap filter |
+| `--max-dollars` | float64 | 30000000000 | Maximum dollar value |
+| `--max-price` | float64 | 100000 | Maximum price |
+| `--max-volume` | int | 2000000000 | Maximum volume |
+| `--min-dollars` | float64 | 500000 | Minimum dollar value |
+| `--min-price` | float64 | 0 | Minimum price |
+| `--min-volume` | int | 0 | Minimum volume |
+| `--offsetting` | string | 1 | Offsetting trade filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--opening` | string | 1 | Opening trade filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--phantom` | string | 1 | Phantom print filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--premarket` | string | 1 | Premarket session filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--rank-snapshot` | int | -1 | Trade rank snapshot filter |
+| `--relative-size` | int | 0 | Relative size threshold |
+| `--rth` | string | 1 | Regular trading hours filter (-1=all, 0=exclude, 1=include) (-1, 0, 1) |
+| `--security-type` | int | -1 | Security type key |
+| `--sig-prints` | string | -1 | Signature print filter (-1=all, 0=exclude, 1=only) (-1, 0, 1) |
+| `--start-date` | string | - | Start date YYYY-MM-DD (default: auto) |
+| `--sweeps` | string | -1 | Sweep filter (-1=all, 0=exclude, 1=only) (-1, 0, 1) |
+| `--ticker` | string | - | Ticker symbol |
+| `--trade-rank` | int | -1 | Trade rank filter |
 | `--vcd` | int | 0 | VCD filter |
 
 #### `volumeleaders-agent trade level-touches`

--- a/docs/llm/llms.txt
+++ b/docs/llm/llms.txt
@@ -13,6 +13,7 @@ COMMAND CHOOSER
 Goal                                          Start with                              Notes
 --------------------------------------------  --------------------------------------  -----------------------------------------------
 Find individual institutional prints          trade list X --days N                   Use ticker filters, presets, or watchlists
+Get comprehensive ticker overview            trade dashboard X --days N              Fast chart-style trades, clusters, levels, bombs
 Compare leveraged ETF bull/bear flow          trade sentiment --days N                Fixed leveraged ETF universe, not buy/sell flow
 Find converging price-level activity          trade clusters --days N                 Cluster conviction around similar prices
 Find sudden aggressive bursts                 trade cluster-bombs --days N            Burst detection, different defaults than clusters
@@ -32,10 +33,11 @@ Get watchlist tickers                         watchlist tickers --watchlist-key 
 ANALYSIS WORKFLOW
 
 1. volume institutional --date D for top dollar movers.
-2. trade list X --days N for individual prints.
-3. trade levels X --days N for support/resistance.
-4. trade clusters X --days N when prints appear concentrated around a price.
-5. market earnings --days N and market exhaustion --date D for event and reversal context.
+2. trade dashboard X --days N for a fast ticker overview before deeper drilling.
+3. trade list X --days N for individual prints.
+4. trade levels X --days N for support/resistance.
+5. trade clusters X --days N when prints appear concentrated around a price.
+6. market earnings --days N and market exhaustion --date D for event and reversal context.
 
 GLOBAL CONVENTIONS
 
@@ -65,7 +67,9 @@ Empty or too broad output: add tickers, explicit dates, min dollar filters, or a
 
 COMMAND SEQUENCES
 
-Broad scan: volume institutional --date D, then trade list TICKER --days N, then trade levels TICKER --days N.
+Broad scan: volume institutional --date D, then trade dashboard TICKER --days N, then trade list TICKER --days N, then trade levels TICKER --days N.
+
+Ticker drilldown: trade dashboard TICKER --days N, then trade list TICKER --days N, then trade clusters TICKER --days N.
 
 Event context: market earnings --days N, then trade list TICKER --start-date D --end-date D, then market exhaustion --date D.
 

--- a/docs/llm/llms.txt
+++ b/docs/llm/llms.txt
@@ -94,6 +94,13 @@ Results are fetched in browser-sized 100-row pages to match VolumeLeaders' front
 
 
 Results are fetched in browser-sized 100-row pages to match VolumeLeaders' frontend behavior. Use clusters when the question is about price-level concentration, not single prints. This command uses larger default dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price.
+- [volumeleaders-agent trade dashboard](#volumeleaders-agent-trade-dashboard): Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
+
+Defaults to a 365-day lookback, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use this command as the first stop when asking broad questions such as institutional levels for IGV, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs when a section needs deeper pagination or CSV/TSV output.
+
+PREREQUISITES: Provide exactly one ticker as a positional argument or with --ticker. Browser authentication must be available.
+
+RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If date flags conflict, use either --days or --start-date with --end-date.
 - [volumeleaders-agent trade level-touches](#volumeleaders-agent-trade-level-touches): Query institutional trade events that occurred at notable price levels for a ticker, showing how the market interacted with key support and resistance zones. Accepts a ticker as positional argument or via --ticker flag. Requires --start-date and --end-date (or --days).
 
 Defaults to --trade-level-rank 5 and --length 50, rejects --length -1, --length 0, and values above 50, and only allows --trade-level-count values of 5, 10, 20, or 50. Use trade levels first to identify significant price zones, then use this command to find events where price revisited those levels.
@@ -372,6 +379,49 @@ Results are fetched in browser-sized 100-row pages to match VolumeLeaders' front
 - `--start-date` (string): Start date YYYY-MM-DD (required unless --days is set)
 - `--tickers` (string): Comma-separated ticker symbols
 - `--trade-cluster-rank` (int, default: -1): Trade cluster rank filter
+- `--vcd` (int, default: 0): VCD filter
+
+## volumeleaders-agent trade dashboard
+
+Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
+
+Defaults to a 365-day lookback, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use this command as the first stop when asking broad questions such as institutional levels for IGV, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs when a section needs deeper pagination or CSV/TSV output.
+
+PREREQUISITES: Provide exactly one ticker as a positional argument or with --ticker. Browser authentication must be available.
+
+RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If date flags conflict, use either --days or --start-date with --end-date.
+
+### Flags
+
+- `--ah` (string, default: 1): After-hours session filter (-1=all, 0=exclude, 1=include)
+- `--closing` (string, default: 1): Closing trade filter (-1=all, 0=exclude, 1=include)
+- `--conditions` (int, default: -1): Trade conditions filter
+- `--count` (int, default: 10): Rows to return per dashboard section (5, 10, 20, or 50)
+- `--dark-pools` (string, default: -1): Dark pool filter (-1=all, 0=exclude, 1=only)
+- `--days` (int, default: 0): Look back this many days from --end-date or today
+- `--end-date` (string): End date YYYY-MM-DD (default: today)
+- `--even-shared` (string, default: -1): Even shared filter (-1=all, 0=exclude, 1=only)
+- `--late-prints` (string, default: -1): Late print filter (-1=all, 0=exclude, 1=only)
+- `--market-cap` (int, default: 0): Market cap filter
+- `--max-dollars` (float64, default: 30000000000): Maximum dollar value
+- `--max-price` (float64, default: 100000): Maximum price
+- `--max-volume` (int, default: 2000000000): Maximum volume
+- `--min-dollars` (float64, default: 500000): Minimum dollar value
+- `--min-price` (float64, default: 0): Minimum price
+- `--min-volume` (int, default: 0): Minimum volume
+- `--offsetting` (string, default: 1): Offsetting trade filter (-1=all, 0=exclude, 1=include)
+- `--opening` (string, default: 1): Opening trade filter (-1=all, 0=exclude, 1=include)
+- `--phantom` (string, default: 1): Phantom print filter (-1=all, 0=exclude, 1=include)
+- `--premarket` (string, default: 1): Premarket session filter (-1=all, 0=exclude, 1=include)
+- `--rank-snapshot` (int, default: -1): Trade rank snapshot filter
+- `--relative-size` (int, default: 0): Relative size threshold
+- `--rth` (string, default: 1): Regular trading hours filter (-1=all, 0=exclude, 1=include)
+- `--security-type` (int, default: -1): Security type key
+- `--sig-prints` (string, default: -1): Signature print filter (-1=all, 0=exclude, 1=only)
+- `--start-date` (string): Start date YYYY-MM-DD (default: auto)
+- `--sweeps` (string, default: -1): Sweep filter (-1=all, 0=exclude, 1=only)
+- `--ticker` (string): Ticker symbol
+- `--trade-rank` (int, default: -1): Trade rank filter
 - `--vcd` (int, default: 0): VCD filter
 
 ## volumeleaders-agent trade level-touches

--- a/internal/cli/outputschema.go
+++ b/internal/cli/outputschema.go
@@ -108,6 +108,7 @@ func outputContractByCommand(contracts []outputContract, commandPath string) (ou
 
 func allOutputContracts() []outputContract {
 	contracts := []outputContract{
+		objectOutputContract[models.TradeDashboard]("trade dashboard", "Return a fast ticker dashboard with trades, clusters, levels, and cluster bombs.", []string{"json"}, []string{"Defaults to a 365-day lookback and 10 rows per section."}),
 		arrayOutputContract[models.TradeListRow]("trade list", "List individual institutional trades using a compact default row shape.", outputFormats(), nil, nil,
 			outputVariant{When: "--fields is set or --format is csv or tsv", Formats: outputFormats(), Schema: arraySchema[models.Trade](), FieldSelection: allFieldsSelection[models.Trade](nil), Notes: []string{"CSV and TSV include a header row matching the selected fields."}},
 			outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeSummary](), Notes: []string{"--summary cannot be combined with --fields or non-JSON formats."}},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -42,6 +42,7 @@ COMMAND CHOOSER
 Goal                                          Start with                              Notes
 --------------------------------------------  --------------------------------------  -----------------------------------------------
 Find individual institutional prints          trade list X --days N                   Use ticker filters, presets, or watchlists
+Get comprehensive ticker overview            trade dashboard X --days N              Fast chart-style trades, clusters, levels, bombs
 Compare leveraged ETF bull/bear flow          trade sentiment --days N                Fixed leveraged ETF universe, not buy/sell flow
 Find converging price-level activity          trade clusters --days N                 Cluster conviction around similar prices
 Find sudden aggressive bursts                 trade cluster-bombs --days N            Burst detection, different defaults than clusters
@@ -61,10 +62,11 @@ Get watchlist tickers                         watchlist tickers --watchlist-key 
 ANALYSIS WORKFLOW
 
 1. volume institutional --date D for top dollar movers.
-2. trade list X --days N for individual prints.
-3. trade levels X --days N for support/resistance.
-4. trade clusters X --days N when prints appear concentrated around a price.
-5. market earnings --days N and market exhaustion --date D for event and reversal context.
+2. trade dashboard X --days N for a fast ticker overview before deeper drilling.
+3. trade list X --days N for individual prints.
+4. trade levels X --days N for support/resistance.
+5. trade clusters X --days N when prints appear concentrated around a price.
+6. market earnings --days N and market exhaustion --date D for event and reversal context.
 
 GLOBAL CONVENTIONS
 
@@ -94,7 +96,9 @@ Empty or too broad output: add tickers, explicit dates, min dollar filters, or a
 
 COMMAND SEQUENCES
 
-Broad scan: volume institutional --date D, then trade list TICKER --days N, then trade levels TICKER --days N.
+Broad scan: volume institutional --date D, then trade dashboard TICKER --days N, then trade list TICKER --days N, then trade levels TICKER --days N.
+
+Ticker drilldown: trade dashboard TICKER --days N, then trade list TICKER --days N, then trade clusters TICKER --days N.
 
 Event context: market earnings --days N, then trade list TICKER --start-date D --end-date D, then market exhaustion --date D.
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -486,7 +486,7 @@ func TestJSONSchemaTreeCoversDomainLeafCommands(t *testing.T) {
 	titles := schemaTitles(schemas)
 
 	root := NewRootCmd("volumeleaders-agent")
-	expectedTitles := make([]string, 0, 26)
+	expectedTitles := make([]string, 0, 27)
 	walkCommands(root, func(c *cobra.Command) {
 		if !isDomainLeafCommand(c) {
 			return
@@ -494,8 +494,8 @@ func TestJSONSchemaTreeCoversDomainLeafCommands(t *testing.T) {
 		expectedTitles = append(expectedTitles, c.CommandPath())
 	})
 	slices.Sort(expectedTitles)
-	if len(expectedTitles) != 26 {
-		t.Fatalf("expected current command tree to have 26 domain leaf commands, got %d: %v", len(expectedTitles), expectedTitles)
+	if len(expectedTitles) != 27 {
+		t.Fatalf("expected current command tree to have 27 domain leaf commands, got %d: %v", len(expectedTitles), expectedTitles)
 	}
 
 	missing := make([]string, 0)
@@ -926,8 +926,8 @@ func TestOutputSchemaTreeProducesCommandContracts(t *testing.T) {
 	if jsonErr := json.Unmarshal(out, &contracts); jsonErr != nil {
 		t.Fatalf("outputschema output is not valid JSON array: %v\nOutput: %s", jsonErr, out)
 	}
-	if len(contracts) != 26 {
-		t.Fatalf("expected 26 output contracts, got %d", len(contracts))
+	if len(contracts) != 27 {
+		t.Fatalf("expected 27 output contracts, got %d", len(contracts))
 	}
 
 	byCommand := make(map[string]map[string]any, len(contracts))

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -14,6 +14,7 @@ import (
 const (
 	tradeBrowserPageLength      = 100
 	tradeListLongTermLength     = 10
+	tradeDashboardDefaultCount  = 10
 	maxTradeRequestLength       = 50
 	maxTradeLevelRequestLength  = 50
 	tradeListTickerLookbackDays = 365
@@ -210,6 +211,14 @@ type tradeLevelTouchesOptions struct {
 	tradePaginationFlags
 }
 
+type tradeDashboardOptions struct {
+	tradeTickerFlag
+	tradeOptionalDateRangeFlags
+	tradeRangeFlags
+	tradeFilterFlags
+	Count int `flag:"count" flaggroup:"Output" flagshort:"c" flagdescr:"Rows to return per dashboard section (5, 10, 20, or 50)"`
+}
+
 func (opts *tradeLevelsOptions) Validate(_ context.Context) []error {
 	if err := validateTradeLevelCount(opts.TradeLevelCount); err != nil {
 		return []error{err}
@@ -226,6 +235,13 @@ func (opts *tradeLevelTouchesOptions) Validate(_ context.Context) []error {
 	}
 	if opts.TradeLevelRank < 5 {
 		return []error{fmt.Errorf("--trade-level-rank must be 5 or higher for trade level touch retrieval")}
+	}
+	return nil
+}
+
+func (opts *tradeDashboardOptions) Validate(_ context.Context) []error {
+	if err := validateTradeLevelCount(opts.Count); err != nil {
+		return []error{fmt.Errorf("--count must be one of 5, 10, 20, or 50 for ticker dashboard retrieval")}
 	}
 	return nil
 }
@@ -253,6 +269,7 @@ func NewCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		newTradeListCommand(),
+		newTradeDashboardCommand(),
 		newTradeSentimentCommand(),
 		newTradePresetsCommand(),
 		newTradePresetTickersCommand(),
@@ -268,6 +285,34 @@ func NewCmd() *cobra.Command {
 
 // NewTradeCommand returns the "trade" command group with all subcommands.
 func NewTradeCommand() *cobra.Command { return NewCmd() }
+
+func newTradeDashboardCommand() *cobra.Command {
+	opts := &tradeDashboardOptions{}
+	presetTradeFilterDefaults(&opts.tradeFilterFlags, 0)
+	presetTradeRangeDefaults(&opts.tradeRangeFlags, 500000)
+	opts.RelativeSize = 0
+	opts.Count = tradeDashboardDefaultCount
+	cmd := &cobra.Command{
+		Use:   "dashboard [ticker]",
+		Short: "Query a ticker institutional dashboard",
+		Long: `Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
+
+Defaults to a 365-day lookback, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use this command as the first stop when asking broad questions such as institutional levels for IGV, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs when a section needs deeper pagination or CSV/TSV output.
+
+PREREQUISITES: Provide exactly one ticker as a positional argument or with --ticker. Browser authentication must be available.
+
+RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If date flags conflict, use either --days or --start-date with --end-date.`,
+		Example:    "volumeleaders-agent trade dashboard IGV",
+		Args:       cobra.ArbitraryArgs,
+		SuggestFor: []string{"dash", "overview", "chart"},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTradeDashboard(cmd, opts)
+		},
+	}
+	common.BindOrPanic(cmd, opts, "dashboard")
+	setTradeRangeFlagDefValues(cmd, opts.MinDollars)
+	return cmd
+}
 
 func newTradeListCommand() *cobra.Command {
 	opts := &tradeListOptions{}

--- a/internal/cli/trade/trade_dashboard.go
+++ b/internal/cli/trade/trade_dashboard.go
@@ -1,0 +1,137 @@
+package trade
+
+import (
+	"fmt"
+	"log/slog"
+	"maps"
+
+	"github.com/spf13/cobra"
+
+	"github.com/major/volumeleaders-agent/internal/cli/common"
+	"github.com/major/volumeleaders-agent/internal/client"
+	"github.com/major/volumeleaders-agent/internal/datatables"
+	"github.com/major/volumeleaders-agent/internal/models"
+)
+
+func runTradeDashboard(cmd *cobra.Command, opts *tradeDashboardOptions) error {
+	startDate, endDate, err := common.ResolveDateRange(cmd, tradeListTickerLookbackDays, false)
+	if err != nil {
+		return err
+	}
+	ticker, err := common.SingleTickerValue(cmd)
+	if err != nil {
+		return err
+	}
+	vlClient, err := common.NewCommandClient(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	tradeFilters := dashboardTradeFilters(opts, ticker, startDate, endDate)
+	trades, err := fetchDashboardTrades(cmd, vlClient, tradeFilters, opts.Count)
+	if err != nil {
+		return err
+	}
+	clusters, err := fetchDashboardClusters(cmd, vlClient, dashboardClusterFilters(opts, ticker, startDate, endDate), opts.Count)
+	if err != nil {
+		return err
+	}
+	levels, err := fetchDashboardLevels(cmd, vlClient, dashboardLevelFilters(ticker, startDate, endDate, opts.Count), opts.Count)
+	if err != nil {
+		return err
+	}
+	clusterBombs, err := fetchDashboardClusterBombs(cmd, vlClient, dashboardClusterBombFilters(opts, ticker, startDate, endDate), opts.Count)
+	if err != nil {
+		return err
+	}
+
+	dashboard := models.TradeDashboard{
+		Ticker:       ticker,
+		DateRange:    models.TradeDashboardDateRange{Start: startDate, End: endDate},
+		Count:        opts.Count,
+		Trades:       models.NewTradeListRows(trades),
+		Clusters:     clusters,
+		Levels:       models.NewTradeLevelRows(levels),
+		ClusterBombs: clusterBombs,
+	}
+	return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), dashboard)
+}
+
+func dashboardTradeFilters(opts *tradeDashboardOptions, ticker, startDate, endDate string) map[string]string {
+	filters := buildTradeFilters(&tradesOptions{tickers: ticker, startDate: startDate, endDate: endDate, minVolume: opts.MinVolume, maxVolume: opts.MaxVolume, minPrice: opts.MinPrice, maxPrice: opts.MaxPrice, minDollars: opts.MinDollars, maxDollars: opts.MaxDollars, conditions: opts.Conditions, vcd: opts.VCD, relativeSize: opts.RelativeSize, darkPools: opts.DarkPools.Int(), sweeps: opts.Sweeps.Int(), latePrints: opts.LatePrints.Int(), sigPrints: opts.SigPrints.Int(), tradeRank: opts.TradeRank, premarket: opts.Premarket.Int(), rth: opts.RTH.Int(), ah: opts.AH.Int(), opening: opts.Opening.Int(), closing: opts.Closing.Int(), phantom: opts.Phantom.Int(), offsetting: opts.Offsetting.Int()})
+	filters["Sort"] = "Dollars"
+	delete(filters, "SecurityTypeKey")
+	delete(filters, "EvenShared")
+	delete(filters, "TradeRankSnapshot")
+	delete(filters, "MarketCap")
+	return filters
+}
+
+func dashboardClusterFilters(opts *tradeDashboardOptions, ticker, startDate, endDate string) map[string]string {
+	return map[string]string{"Tickers": ticker, "StartDate": startDate, "EndDate": endDate, "MinVolume": common.IntStr(opts.MinVolume), "MaxVolume": common.IntStr(opts.MaxVolume), "MinPrice": common.FormatFloat(opts.MinPrice), "MaxPrice": common.FormatFloat(opts.MaxPrice), "MinDollars": common.FormatFloat(opts.MinDollars), "MaxDollars": common.FormatFloat(opts.MaxDollars), "VCD": common.IntStr(opts.VCD), "RelativeSize": common.IntStr(opts.RelativeSize), "TradeClusterRank": "-1", "Sort": "Dollars"}
+}
+
+func dashboardClusterBombFilters(opts *tradeDashboardOptions, ticker, startDate, endDate string) map[string]string {
+	filters := dashboardClusterFilters(opts, ticker, startDate, endDate)
+	delete(filters, "MinPrice")
+	delete(filters, "MaxPrice")
+	delete(filters, "TradeClusterRank")
+	filters["TradeClusterBombRank"] = "-1"
+	return filters
+}
+
+func dashboardLevelFilters(ticker, startDate, endDate string, count int) map[string]string {
+	return map[string]string{"Ticker": ticker, "StartDate": startDate, "EndDate": endDate, "Levels": common.IntStr(count)}
+}
+
+func fetchDashboardTrades(cmd *cobra.Command, vlClient *client.Client, filters map[string]string, count int) ([]models.Trade, error) {
+	request := dashboardRequest(datatables.TradeChartColumns, 0, "FullTimeString24", count, filters)
+	var result []models.Trade
+	if err := postDashboardDataTables(cmd, vlClient, "/Trades/GetTrades", &request, &result, "query dashboard trades"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func fetchDashboardClusters(cmd *cobra.Command, vlClient *client.Client, filters map[string]string, count int) ([]models.TradeCluster, error) {
+	request := dashboardRequest(datatables.TradeClusterChartColumns, 3, "Sh", count, filters)
+	var result []models.TradeCluster
+	if err := postDashboardDataTables(cmd, vlClient, "/TradeClusters/GetTradeClusters", &request, &result, "query dashboard trade clusters"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func fetchDashboardLevels(cmd *cobra.Command, vlClient *client.Client, filters map[string]string, count int) ([]models.TradeLevel, error) {
+	request := dashboardRequest(datatables.TradeLevelChartColumns, 0, "Price", count, filters)
+	request.Length = -1
+	var result []models.TradeLevel
+	if err := postDashboardDataTables(cmd, vlClient, "/Chart0/GetTradeLevels", &request, &result, "query dashboard trade levels"); err != nil {
+		return nil, err
+	}
+	if len(result) > count {
+		result = result[:count]
+	}
+	return result, nil
+}
+
+func fetchDashboardClusterBombs(cmd *cobra.Command, vlClient *client.Client, filters map[string]string, count int) ([]models.TradeClusterBomb, error) {
+	request := dashboardRequest(datatables.TradeClusterBombChartColumns, 2, "Sh", count, filters)
+	var result []models.TradeClusterBomb
+	if err := postDashboardDataTables(cmd, vlClient, "/TradeClusterBombs/GetTradeClusterBombs", &request, &result, "query dashboard trade cluster bombs"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func dashboardRequest(columns []datatables.Column, orderColumn int, orderName string, count int, filters map[string]string) datatables.Request {
+	return datatables.Request{ColumnDefs: columns, Start: 0, Length: count, OrderColumnIndex: orderColumn, OrderDirection: "DESC", OrderName: orderName, IncludeSearch: true, CustomFilters: maps.Clone(filters), Draw: 1}
+}
+
+func postDashboardDataTables[T any](cmd *cobra.Command, vlClient *client.Client, path string, request *datatables.Request, result *[]T, label string) error {
+	if err := vlClient.PostDataTables(cmd.Context(), path, request.Encode(), result); err != nil {
+		slog.Error("failed to "+label, "error", err)
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	return nil
+}

--- a/internal/cli/trade/trade_test.go
+++ b/internal/cli/trade/trade_test.go
@@ -2,6 +2,7 @@ package trade
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -26,12 +27,12 @@ func minimalJSONArray(n int) string {
 	return "[" + strings.Repeat("{},", n-1) + "{}]"
 }
 
-func TestNewCmdRegistersTenRunESubcommands(t *testing.T) {
+func TestNewCmdRegistersElevenRunESubcommands(t *testing.T) {
 	t.Parallel()
 
 	cmd := NewCmd()
-	if len(cmd.Commands()) != 10 {
-		t.Fatalf("subcommand count = %d, want 10", len(cmd.Commands()))
+	if len(cmd.Commands()) != 11 {
+		t.Fatalf("subcommand count = %d, want 11", len(cmd.Commands()))
 	}
 	for _, subcmd := range cmd.Commands() {
 		if subcmd.RunE == nil {
@@ -202,6 +203,84 @@ func TestTradeListFetchesBrowserSizedPages(t *testing.T) {
 	testutil.AssertErrContains(t, err, "")
 	if !slices.Equal(gotLengths, []string{"100", "100"}) {
 		t.Fatalf("lengths = %v, want [100 100]", gotLengths)
+	}
+}
+
+func TestTradeDashboardFetchesChartOptimizedSections(t *testing.T) {
+	t.Parallel()
+
+	requestsByPath := make(map[string]url.Values)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		params, _ := url.ParseQuery(string(body))
+		requestsByPath[r.URL.Path] = params
+		switch r.URL.Path {
+		case "/Trades/GetTrades":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":1000,"Volume":10}]`)))
+		case "/TradeClusters/GetTradeClusters":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":2000,"Volume":20,"TradeCount":2}]`)))
+		case "/Chart0/GetTradeLevels":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Price":101.5,"Dollars":3000,"Volume":30,"Trades":3}]`)))
+		case "/TradeClusterBombs/GetTradeClusterBombs":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":4000,"Volume":40,"TradeCount":4,"TradeClusterBombRank":1}]`)))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, server.URL)
+	stdout, _, err := testutil.ExecuteCommand(t, cmd, ctx, "dashboard", "IGV", "--start-date", "2025-05-04", "--end-date", "2026-05-04")
+	testutil.AssertErrContains(t, err, "")
+
+	var dashboard models.TradeDashboard
+	if err := json.Unmarshal([]byte(stdout), &dashboard); err != nil {
+		t.Fatalf("failed to unmarshal dashboard: %v\nstdout=%s", err, stdout)
+	}
+	if dashboard.Ticker != "IGV" || dashboard.Count != tradeDashboardDefaultCount {
+		t.Fatalf("dashboard metadata = (%q, %d), want (IGV, %d)", dashboard.Ticker, dashboard.Count, tradeDashboardDefaultCount)
+	}
+	if len(dashboard.Trades) != 1 || len(dashboard.Clusters) != 1 || len(dashboard.Levels) != 1 || len(dashboard.ClusterBombs) != 1 {
+		t.Fatalf("dashboard section lengths = trades:%d clusters:%d levels:%d bombs:%d, want all 1", len(dashboard.Trades), len(dashboard.Clusters), len(dashboard.Levels), len(dashboard.ClusterBombs))
+	}
+
+	for _, path := range []string{"/Trades/GetTrades", "/TradeClusters/GetTradeClusters", "/Chart0/GetTradeLevels", "/TradeClusterBombs/GetTradeClusterBombs"} {
+		params, ok := requestsByPath[path]
+		if !ok {
+			t.Fatalf("missing dashboard request for %s", path)
+		}
+		if got := params.Get("StartDate"); got != "2025-05-04" {
+			t.Fatalf("%s StartDate = %q, want 2025-05-04", path, got)
+		}
+		if got := params.Get("EndDate"); got != "2026-05-04" {
+			t.Fatalf("%s EndDate = %q, want 2026-05-04", path, got)
+		}
+	}
+	if got := requestsByPath["/Trades/GetTrades"].Get("length"); got != "10" {
+		t.Fatalf("trades length = %q, want 10", got)
+	}
+	if got := requestsByPath["/Trades/GetTrades"].Get("VCD"); got != "0" {
+		t.Fatalf("trades VCD = %q, want 0", got)
+	}
+	if got := requestsByPath["/Trades/GetTrades"].Get("RelativeSize"); got != "0" {
+		t.Fatalf("trades RelativeSize = %q, want 0", got)
+	}
+	if got := requestsByPath["/Trades/GetTrades"].Get("Sort"); got != "Dollars" {
+		t.Fatalf("trades Sort = %q, want Dollars", got)
+	}
+	if got := requestsByPath["/Chart0/GetTradeLevels"].Get("Ticker"); got != "IGV" {
+		t.Fatalf("levels Ticker = %q, want IGV", got)
+	}
+	if got := requestsByPath["/Chart0/GetTradeLevels"].Get("Levels"); got != "10" {
+		t.Fatalf("levels Levels = %q, want 10", got)
+	}
+	if got := requestsByPath["/Chart0/GetTradeLevels"].Get("length"); got != "-1" {
+		t.Fatalf("levels length = %q, want -1", got)
 	}
 }
 

--- a/internal/datatables/datatables.go
+++ b/internal/datatables/datatables.go
@@ -31,6 +31,32 @@ var TradeChartColumns = []Column{
 	{Data: "LastComparibleTradeDate", Name: "Last Comp", Searchable: true, Orderable: false},
 }
 
+// TradeClusterChartColumns contains the compact chart DataTables layout used by
+// the browser dashboard for ticker-specific cluster summaries.
+var TradeClusterChartColumns = []Column{
+	{Data: "MinFullTimeString24", Name: "MinFullTimeString24", Searchable: true, Orderable: false},
+	{Data: "Price", Name: "Price", Searchable: true, Orderable: false},
+	{Data: "TradeCount", Name: "TradeCount", Searchable: true, Orderable: false},
+	{Data: "Volume", Name: "Sh", Searchable: true, Orderable: false},
+	{Data: "Dollars", Name: "$$", Searchable: true, Orderable: false},
+	{Data: "DollarsMultiplier", Name: "RS", Searchable: true, Orderable: false},
+	{Data: "TradeClusterRank", Name: "R", Searchable: true, Orderable: false},
+	{Data: "LastComparibleTradeClusterDate", Name: "Last Comp", Searchable: true, Orderable: false},
+}
+
+// TradeClusterBombChartColumns adapts the browser cluster table shape for the
+// cluster-bomb endpoint so dashboard output can include the same burst context.
+var TradeClusterBombChartColumns = []Column{
+	{Data: "MinFullTimeString24", Name: "MinFullTimeString24", Searchable: true, Orderable: false},
+	{Data: "TradeCount", Name: "TradeCount", Searchable: true, Orderable: false},
+	{Data: "Volume", Name: "Sh", Searchable: true, Orderable: false},
+	{Data: "Dollars", Name: "$$", Searchable: true, Orderable: false},
+	{Data: "DollarsMultiplier", Name: "RS", Searchable: true, Orderable: false},
+	{Data: "CumulativeDistribution", Name: "PCT", Searchable: true, Orderable: false},
+	{Data: "TradeClusterBombRank", Name: "R", Searchable: true, Orderable: false},
+	{Data: "LastComparableTradeClusterBombDate", Name: "Last Comp", Searchable: true, Orderable: false},
+}
+
 // TradeClusterColumns contains the DataTables column names used by the trade clusters endpoint.
 var TradeClusterColumns = []string{
 	"MinFullTimeString24", "MinFullTimeString24", "Ticker", "TradeCount",
@@ -65,6 +91,18 @@ var TotalVolumeColumns = []string{
 var TradeLevelColumns = []string{
 	"Price", "Dollars", "Volume", "Trades", "RelativeSize",
 	"CumulativeDistribution", "TradeLevelRank", "Level Date Range",
+}
+
+// TradeLevelChartColumns contains the chart dashboard layout for level rows.
+var TradeLevelChartColumns = []Column{
+	{Data: "Price", Name: "Price", Searchable: true, Orderable: false},
+	{Data: "Dollars", Name: "$$", Searchable: true, Orderable: false},
+	{Data: "Volume", Name: "Sh", Searchable: true, Orderable: false},
+	{Data: "Trades", Name: "Trades", Searchable: true, Orderable: false},
+	{Data: "RelativeSize", Name: "RS", Searchable: true, Orderable: false},
+	{Data: "CumulativeDistribution", Name: "PCT", Searchable: true, Orderable: false},
+	{Data: "TradeLevelRank", Name: "Rank", Searchable: true, Orderable: false},
+	{Data: "Dates", Name: "Dates", Searchable: true, Orderable: false},
 }
 
 // TradeLevelTouchColumns contains the DataTables column names used by the trade level touches endpoint.

--- a/internal/models/dashboard.go
+++ b/internal/models/dashboard.go
@@ -1,0 +1,21 @@
+package models
+
+// TradeDashboardDateRange describes the inclusive date window used by a ticker
+// dashboard query.
+type TradeDashboardDateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// TradeDashboard collects the fastest chart-style institutional context for a
+// single ticker. It mirrors the browser dashboard sections while adding cluster
+// bombs, which the VolumeLeaders page does not show in the same view.
+type TradeDashboard struct {
+	Ticker       string                  `json:"ticker"`
+	DateRange    TradeDashboardDateRange `json:"dateRange"`
+	Count        int                     `json:"count"`
+	Trades       []TradeListRow          `json:"trades"`
+	Clusters     []TradeCluster          `json:"clusters"`
+	Levels       []TradeLevelRow         `json:"levels"`
+	ClusterBombs []TradeClusterBomb      `json:"clusterBombs"`
+}


### PR DESCRIPTION
## Summary
- Add `trade dashboard [ticker]` for a fast chart-style ticker overview with trades, clusters, levels, and cluster bombs.
- Add the aggregate dashboard output contract and regenerated LLM discovery docs.
- Cover the dashboard request flow with tests for chart endpoints and key DataTables parameters.

## Verification
- `go test ./internal/cli/trade ./internal/models ./internal/datatables ./internal/cli`
- `make lint`
- `make test`
- `make build`
- `./volumeleaders-agent outputschema trade dashboard`
- `./volumeleaders-agent trade dashboard SOXX --days 365`
- `coderabbit review --agent --base origin/main -c .coderabbit.yaml`