### PR TITLE
chore: tune automated review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,7 +30,8 @@ reviews:
       mode: warning
 
   auto_review:
-    enabled: true
+    # Keep automatic reviews off so maintainers can request CodeRabbit manually when quota is available.
+    enabled: false
     drafts: false
     auto_pause_after_reviewed_commits: 0
     base_branches:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+# volumeleaders-agent review instructions
+
+Review this repository as a Go CLI for querying institutional trade data from VolumeLeaders. It uses browser cookie extraction for authentication, compact JSON stdout by default, generated LLM discovery files, JSON Schema discovery, output schema discovery, and MCP for local trusted clients.
+
+Focus on correctness, credential safety, stdout and stderr discipline, CLI compatibility, output contracts, and repository conventions. Do not nitpick formatting or style that gofmt, go vet, or golangci-lint already handles.
+
+## Project invariants
+
+- Commands emit compact JSON to stdout by default. Diagnostics and errors belong on stderr through `slog`.
+- Use `volumeleaders-agent --jsonschema=tree` as the command contract and `volumeleaders-agent outputschema` as the success output contract.
+- Generated discovery files come from `make docs` or `make generate-discovery` and should stay in sync with command changes.
+- Browser cookies, XSRF tokens, session values, and API responses containing credentials must never leak in logs, errors, docs, or MCP results.
+- Keep `AGENTS.md`, nested AGENTS files, README, CodeRabbit, and Copilot review guidance aligned when review priorities or behavior change.
+
+## Behavior checks
+
+- Treat broken stdout and stderr discipline as P1.
+- Treat CLI compatibility breaks as P1 unless the PR clearly documents an intentional breaking change.
+- Check flag names, positional args, date handling, boolean toggle values, pagination limits, and default output fields.
+- MCP output must keep JSON-RPC protocol data on stdout and must not expose shell completion or parent routing commands as tools.

--- a/.github/instructions/auth.instructions.md
+++ b/.github/instructions/auth.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "internal/auth/**/*.go"
+---
+
+# Auth review instructions
+
+- Check cookie extraction, browser profile handling, and token lookup paths for credential safety.
+- Authentication failures must degrade gracefully and provide useful error messages.
+- Never expose browser cookies, XSRF tokens, session values, or API credentials in logs or errors.

--- a/.github/instructions/automation.instructions.md
+++ b/.github/instructions/automation.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: ".github/workflows/**"
+---
+
+# GitHub Actions review instructions
+
+- Treat unpinned third-party actions, excessive permissions, unsafe `pull_request_target` usage, or secret exposure in logs as P1.
+- Workflows should keep least-privilege permissions and must not expose tokens or credentials to untrusted pull request code.
+- CI should continue to run linting, tests with race detection, vulnerability checks, and build verification for Go changes.

--- a/.github/instructions/cli-discovery.instructions.md
+++ b/.github/instructions/cli-discovery.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "internal/{cli,discovery}/**/*.go"
+---
+
+# CLI and discovery review instructions
+
+- Command behavior should match README, `volumeleaders-agent --jsonschema=tree`, `volumeleaders-agent outputschema`, and root help conventions.
+- If commands, flags, aliases, defaults, or examples change, verify JSON Schema output reflects the changes and run `make generate-discovery`.
+- If workflows, behavior, models, output formats, or output fields change, update relevant command Long descriptions and output contracts.
+- Generated files should be deterministic and must not overwrite the root `AGENTS.md`.
+- MCP must keep JSON-RPC protocol output on stdout and never leak credentials in tool results or errors.

--- a/.github/instructions/client.instructions.md
+++ b/.github/instructions/client.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "internal/client/**/*.go"
+---
+
+# Client review instructions
+
+- Check HTTP status handling, request context propagation, and response body closure.
+- DataTables encoding should preserve expected column and pagination semantics.
+- Errors should explain the endpoint or operation that failed without leaking credentials.

--- a/.github/instructions/coderabbit.instructions.md
+++ b/.github/instructions/coderabbit.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".coderabbit.yaml"
+---
+
+# CodeRabbit review instructions
+
+- CodeRabbit automatic reviews should stay disabled so reviews are requested manually when quota is available.
+- Preserve `chat.auto_reply: true` so maintainers can request manual reviews from GitHub comments.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "internal/**/*.go"
+---
+
+# Go review instructions
+
+- Wrap errors with useful context and `%w` when returning underlying errors.
+- Use `errors.As()` for typed error matching.
+- Preserve context cancellation through HTTP and DataTables requests.
+- Command behavior should match README, `--jsonschema=tree`, `outputschema`, and root help conventions.
+- Do not suggest style-only changes handled by gofmt, go vet, or golangci-lint.

--- a/.github/instructions/makefile.instructions.md
+++ b/.github/instructions/makefile.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "Makefile"
+---
+
+# Makefile review instructions
+
+- Non-file targets should have `.PHONY` declarations.
+- Avoid flags that duplicate tool defaults.
+- Keep docs, discovery generation, smoke, build, test, and lint targets aligned with README and `AGENTS.md`.

--- a/.github/instructions/models.instructions.md
+++ b/.github/instructions/models.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "internal/models/**/*.go"
+---
+
+# Model review instructions
+
+- JSON tags should match VolumeLeaders response fields.
+- Model changes must not silently drop data needed by commands, summaries, CSV or TSV output, MCP tools, or output schemas.
+- Prefer observable output tests when model changes affect command results.

--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".goreleaser.yml"
+---
+
+# Release review instructions
+
+- Verify GoReleaser v2 compatibility, CGO settings, signing, release behavior, and platform matrix.
+- Release changes should preserve published binary and provenance expectations.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "**/*_test.go"
+---
+
+# Test review instructions
+
+- Prefer table-driven subtests with `t.Run()`.
+- Use parallelization where safe.
+- Use `t.TempDir()` for filesystem work.
+- Keep fixtures deterministic.
+- Assert observable behavior rather than implementation details.
+- Do not request arbitrary coverage percentage changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Go CLI tool for querying institutional trade data from [VolumeLeaders](https://w
 When modifying CLI commands, flags, models, or behavior:
 
 - Update `AGENTS.md` if the change affects project structure, build process, or conventions.
+- Keep `.coderabbit.yaml` and `.github/copilot-instructions.md` plus `.github/instructions/*.instructions.md` aligned with current repo conventions when review-relevant behavior changes.
 - Use `volumeleaders-agent --jsonschema=tree` as the source of truth for command names, flags, aliases, defaults, and examples. Use `volumeleaders-agent outputschema` as the source of truth for success stdout contracts, formats, fields, and variants. Command Long descriptions contain embedded domain knowledge (workflows, recovery steps, conventions, gotchas).
 - Run `make docs` or `make generate-discovery` when commands, flags, defaults, examples, or Long descriptions change. The generated `SKILL.md` lives at the repository root for consistent tool discovery; extended generated LLM discovery files live in `docs/llm/` so they do not overwrite this hand-maintained root `AGENTS.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ Fork the repo, create a branch, and open a PR against `main`.
 - All CI checks (tests and linting) must pass before merge.
 - Add tests for any new functionality.
 
+### Automated review tools
+
+CodeRabbit automatic PR reviews are disabled to preserve quota. Maintainers can still request a manual CodeRabbit review in GitHub when needed.
+
+GitHub Copilot code review uses the repository instructions in `.github/copilot-instructions.md` and the path-specific files in `.github/instructions/`. Automatic Copilot review requests are managed by a GitHub branch ruleset rather than a workflow file.
+
 ## Code Style
 
 Follow the patterns already in the codebase. `make lint` catches most issues. When in doubt, look at how existing commands in `internal/cli/` are structured and match that style.


### PR DESCRIPTION
## Summary
- Disable automatic CodeRabbit reviews so maintainers can request them manually when quota is available.
- Add repository and path-specific GitHub Copilot review instructions based on the existing CodeRabbit guidance.
- Document how automated review tooling is configured for contributors.

## Validation
- Parsed `.coderabbit.yaml` with PyYAML.
- Confirmed Copilot instruction files include frontmatter where needed and stay under 4,000 characters.
- Checked changed Markdown for em dashes and unlabeled fenced code blocks.
- Checked `.coderabbit.yaml` with LSP diagnostics.