### PR TITLE
refactor(cli): centralize DataTables request structs

### DIFF
--- a/internal/cli/common/datatables.go
+++ b/internal/cli/common/datatables.go
@@ -83,11 +83,10 @@ func FetchDataTablesPages[T any](ctx context.Context, vlClient *client.Client, p
 	if pageSize == 0 {
 		pageSize = PaginationPageSize
 	}
-	initialStart := opts.Start
-	opts.Length = pageSize
+	pageState := newDataTablePageState(opts, pageSize)
 	all := make([]T, 0)
 	for {
-		request := NewDataTablesRequest(columns, opts)
+		request := NewDataTablesRequest(columns, pageState.options())
 		resp, err := vlClient.PostDataTablesPage(ctx, path, request.Encode())
 		if err != nil {
 			slog.Error("failed to "+label, "error", err)
@@ -101,16 +100,43 @@ func FetchDataTablesPages[T any](ctx context.Context, vlClient *client.Client, p
 			break
 		}
 		all = append(all, page...)
-		if resp.RecordsFiltered > 0 && initialStart+len(all) >= resp.RecordsFiltered {
+		if pageState.fetchedAllRecords(len(all), resp.RecordsFiltered) {
 			break
 		}
-		if len(page) < pageSize {
+		if pageState.isShortPage(len(page)) {
 			break
 		}
-		opts.Start += len(page)
+		pageState.advance(len(page))
 	}
 	return all, nil
 }
+
+// NewDataTableOptions converts the named request config used by command
+// handlers into the lower-level options consumed by DataTables helpers.
+func NewDataTableOptions(config DataTableRequestConfig) DataTableOptions {
+	return DataTableOptions(config)
+}
+
+type dataTablePageState struct {
+	initialStart int
+	pageSize     int
+	optionsValue DataTableOptions
+}
+
+func newDataTablePageState(opts DataTableOptions, pageSize int) dataTablePageState {
+	opts.Length = pageSize
+	return dataTablePageState{initialStart: opts.Start, pageSize: pageSize, optionsValue: opts}
+}
+
+func (state *dataTablePageState) options() DataTableOptions { return state.optionsValue }
+
+func (state *dataTablePageState) fetchedAllRecords(fetched, recordsFiltered int) bool {
+	return recordsFiltered > 0 && state.initialStart+fetched >= recordsFiltered
+}
+
+func (state *dataTablePageState) isShortPage(length int) bool { return length < state.pageSize }
+
+func (state *dataTablePageState) advance(length int) { state.optionsValue.Start += length }
 
 // NewDataTablesRequest builds the common DataTables request shape.
 func NewDataTablesRequest(columns []string, opts DataTableOptions) datatables.Request {

--- a/internal/cli/common/datatables_test.go
+++ b/internal/cli/common/datatables_test.go
@@ -30,6 +30,21 @@ func TestNewDataTablesRequest(t *testing.T) {
 	}
 }
 
+func TestNewDataTableOptions(t *testing.T) {
+	t.Parallel()
+
+	filters := map[string]string{"Ticker": "AAPL"}
+	fields := []string{"Ticker", "Price"}
+	got := NewDataTableOptions(DataTableRequestConfig{Start: 5, Length: 25, OrderCol: 2, OrderDir: OrderDirectionDESC, Filters: filters, Fields: fields})
+
+	if got.Start != 5 || got.Length != 25 || got.OrderCol != 2 || got.OrderDir != OrderDirectionDESC {
+		t.Fatalf("unexpected options: %+v", got)
+	}
+	if got.Filters["Ticker"] != "AAPL" || len(got.Fields) != 2 {
+		t.Fatalf("expected filters and fields to be preserved, got %+v", got)
+	}
+}
+
 func TestRunDataTablesCommand(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/cli/common/types.go
+++ b/internal/cli/common/types.go
@@ -89,6 +89,18 @@ type DataTableOptions struct {
 	Fields   []string
 }
 
+// DataTableRequestConfig names the request assembly fields that most commands
+// pass through to DataTableOptions. Keeping the construction in one shape makes
+// endpoint handlers easier to scan when they mainly differ by filters.
+type DataTableRequestConfig struct {
+	Start    int
+	Length   int
+	OrderCol int
+	OrderDir OrderDirection
+	Filters  map[string]string
+	Fields   []string
+}
+
 // PaginationPageSize is the number of records fetched per page when the user
 // requests all results (--length -1).
 const PaginationPageSize = 1000

--- a/internal/cli/market/market.go
+++ b/internal/cli/market/market.go
@@ -72,17 +72,7 @@ func newEarningsCmd() *cobra.Command {
 				return err
 			}
 
-			dtOpts := common.DataTableOptions{
-				Start:    0,
-				Length:   -1,
-				OrderCol: 0,
-				OrderDir: "asc",
-				Fields:   fields,
-				Filters: map[string]string{
-					"StartDate": startDate,
-					"EndDate":   endDate,
-				},
-			}
+			dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: 0, Length: -1, OrderCol: 0, OrderDir: common.OrderDirectionASC, Fields: fields, Filters: map[string]string{"StartDate": startDate, "EndDate": endDate}})
 			return common.RunDataTablesCommand[models.Earnings](cmd, "/Earnings/GetEarnings", datatables.EarningsColumns, dtOpts, opts.Format, "query earnings")
 		},
 	}

--- a/internal/cli/report/report.go
+++ b/internal/cli/report/report.go
@@ -169,7 +169,7 @@ func runReport(cmd *cobra.Command, opts *reportOptions, definition *reportDefini
 	filters["Tickers"] = tickers
 	filters["StartDate"] = startDate
 	filters["EndDate"] = endDate
-	dtOpts := common.DataTableOptions{Start: 0, Length: -1, OrderCol: 0, OrderDir: common.OrderDirectionDESC, Filters: filters, Fields: fields}
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: 0, Length: -1, OrderCol: 0, OrderDir: common.OrderDirectionDESC, Filters: filters, Fields: fields})
 	trades, err := fetchReportTrades(cmd, dtOpts)
 	if err != nil {
 		return err

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -53,6 +53,63 @@ type tradesOptions struct {
 	minPrice, maxPrice, minDollars, maxDollars     float64
 }
 
+type tradeRangeFilters struct {
+	Tickers    string
+	StartDate  string
+	EndDate    string
+	MinVolume  int
+	MaxVolume  int
+	MinPrice   float64
+	MaxPrice   float64
+	MinDollars float64
+	MaxDollars float64
+	VCD        int
+	Sector     string
+}
+
+func (filters *tradeRangeFilters) baseMap() map[string]string {
+	return map[string]string{
+		"Tickers":    filters.Tickers,
+		"StartDate":  filters.StartDate,
+		"EndDate":    filters.EndDate,
+		"MinVolume":  common.IntStr(filters.MinVolume),
+		"MaxVolume":  common.IntStr(filters.MaxVolume),
+		"MinPrice":   common.FormatFloat(filters.MinPrice),
+		"MaxPrice":   common.FormatFloat(filters.MaxPrice),
+		"MinDollars": common.FormatFloat(filters.MinDollars),
+		"MaxDollars": common.FormatFloat(filters.MaxDollars),
+		"VCD":        common.IntStr(filters.VCD),
+	}
+}
+
+func (filters *tradeRangeFilters) clusterMap(securityType, relativeSize, rank int) map[string]string {
+	values := filters.baseMap()
+	values["SecurityTypeKey"] = common.IntStr(securityType)
+	values["RelativeSize"] = common.IntStr(relativeSize)
+	values["TradeClusterRank"] = common.IntStr(rank)
+	values["SectorIndustry"] = filters.Sector
+	return values
+}
+
+func (filters *tradeRangeFilters) clusterBombMap(securityType, relativeSize, rank int) map[string]string {
+	values := filters.baseMap()
+	delete(values, "MinPrice")
+	delete(values, "MaxPrice")
+	values["SecurityTypeKey"] = common.IntStr(securityType)
+	values["RelativeSize"] = common.IntStr(relativeSize)
+	values["TradeClusterBombRank"] = common.IntStr(rank)
+	values["SectorIndustry"] = filters.Sector
+	return values
+}
+
+func (filters *tradeRangeFilters) levelTouchMap(relativeSize, rank, count int) map[string]string {
+	values := filters.baseMap()
+	values["RelativeSize"] = common.IntStr(relativeSize)
+	values["TradeLevelRank"] = common.IntStr(rank)
+	values["Levels"] = common.IntStr(count)
+	return values
+}
+
 type tradeDateRangeFlags struct {
 	StartDate string `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (required unless --days is set)"`
 	EndDate   string `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (required unless --days is set)"`

--- a/internal/cli/trade/trade_clusters.go
+++ b/internal/cli/trade/trade_clusters.go
@@ -19,7 +19,10 @@ func runTradeClusters(cmd *cobra.Command, opts *tradeClustersOptions) error {
 	if err != nil {
 		return fmt.Errorf("parsing fields flag: %w", err)
 	}
-	return common.RunDataTablesCommandWithPageSize[models.TradeCluster](cmd, "/TradeClusters/GetTradeClusters", datatables.TradeClusterColumns, common.DataTableOptions{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Fields: fields, Filters: map[string]string{"Tickers": common.MultiTickerValue(cmd), "StartDate": startDate, "EndDate": endDate, "MinVolume": common.IntStr(opts.MinVolume), "MaxVolume": common.IntStr(opts.MaxVolume), "MinPrice": common.FormatFloat(opts.MinPrice), "MaxPrice": common.FormatFloat(opts.MaxPrice), "MinDollars": common.FormatFloat(opts.MinDollars), "MaxDollars": common.FormatFloat(opts.MaxDollars), "VCD": common.IntStr(opts.VCD), "SecurityTypeKey": common.IntStr(opts.SecurityType), "RelativeSize": common.IntStr(opts.RelativeSize), "TradeClusterRank": common.IntStr(opts.TradeClusterRank), "SectorIndustry": opts.Sector}}, opts.Format, tradeBrowserPageLength, "query trade clusters")
+	rangeFilters := tradeClusterRangeFilters(cmd, opts, startDate, endDate)
+	filters := rangeFilters.clusterMap(opts.SecurityType, opts.RelativeSize, opts.TradeClusterRank)
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Fields: fields, Filters: filters})
+	return common.RunDataTablesCommandWithPageSize[models.TradeCluster](cmd, "/TradeClusters/GetTradeClusters", datatables.TradeClusterColumns, dtOpts, opts.Format, tradeBrowserPageLength, "query trade clusters")
 }
 
 func runTradeClusterBombs(cmd *cobra.Command, opts *tradeClusterBombsOptions) error {
@@ -27,13 +30,26 @@ func runTradeClusterBombs(cmd *cobra.Command, opts *tradeClusterBombsOptions) er
 	if err != nil {
 		return err
 	}
-	return common.RunDataTablesCommandWithPageSize[models.TradeClusterBomb](cmd, "/TradeClusterBombs/GetTradeClusterBombs", datatables.TradeClusterBombColumns, common.DataTableOptions{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Tickers": common.MultiTickerValue(cmd), "StartDate": startDate, "EndDate": endDate, "MinVolume": common.IntStr(opts.MinVolume), "MaxVolume": common.IntStr(opts.MaxVolume), "MinDollars": common.FormatFloat(opts.MinDollars), "MaxDollars": common.FormatFloat(opts.MaxDollars), "VCD": common.IntStr(opts.VCD), "SecurityTypeKey": common.IntStr(opts.SecurityType), "RelativeSize": common.IntStr(opts.RelativeSize), "TradeClusterBombRank": common.IntStr(opts.TradeClusterBombRank), "SectorIndustry": opts.Sector}}, opts.Format, tradeBrowserPageLength, "query trade cluster bombs")
+	rangeFilters := tradeClusterBombRangeFilters(cmd, opts, startDate, endDate)
+	filters := rangeFilters.clusterBombMap(opts.SecurityType, opts.RelativeSize, opts.TradeClusterBombRank)
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: filters})
+	return common.RunDataTablesCommandWithPageSize[models.TradeClusterBomb](cmd, "/TradeClusterBombs/GetTradeClusterBombs", datatables.TradeClusterBombColumns, dtOpts, opts.Format, tradeBrowserPageLength, "query trade cluster bombs")
 }
 
 func runTradeAlerts(cmd *cobra.Command, opts *tradeAlertsOptions) error {
-	return common.RunDataTablesCommand[models.TradeAlert](cmd, "/TradeAlerts/GetTradeAlerts", datatables.TradeColumns, common.DataTableOptions{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Date": opts.Date}}, opts.Format, "query trade alerts")
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Date": opts.Date}})
+	return common.RunDataTablesCommand[models.TradeAlert](cmd, "/TradeAlerts/GetTradeAlerts", datatables.TradeColumns, dtOpts, opts.Format, "query trade alerts")
 }
 
 func runTradeClusterAlerts(cmd *cobra.Command, opts *tradeClusterAlertsOptions) error {
-	return common.RunDataTablesCommand[models.TradeClusterAlert](cmd, "/TradeClusterAlerts/GetTradeClusterAlerts", datatables.TradeClusterColumns, common.DataTableOptions{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Date": opts.Date}}, opts.Format, "query trade cluster alerts")
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Date": opts.Date}})
+	return common.RunDataTablesCommand[models.TradeClusterAlert](cmd, "/TradeClusterAlerts/GetTradeClusterAlerts", datatables.TradeClusterColumns, dtOpts, opts.Format, "query trade cluster alerts")
+}
+
+func tradeClusterRangeFilters(cmd *cobra.Command, opts *tradeClustersOptions, startDate, endDate string) tradeRangeFilters {
+	return tradeRangeFilters{Tickers: common.MultiTickerValue(cmd), StartDate: startDate, EndDate: endDate, MinVolume: opts.MinVolume, MaxVolume: opts.MaxVolume, MinPrice: opts.MinPrice, MaxPrice: opts.MaxPrice, MinDollars: opts.MinDollars, MaxDollars: opts.MaxDollars, VCD: opts.VCD, Sector: opts.Sector}
+}
+
+func tradeClusterBombRangeFilters(cmd *cobra.Command, opts *tradeClusterBombsOptions, startDate, endDate string) tradeRangeFilters {
+	return tradeRangeFilters{Tickers: common.MultiTickerValue(cmd), StartDate: startDate, EndDate: endDate, MinVolume: opts.MinVolume, MaxVolume: opts.MaxVolume, MinDollars: opts.MinDollars, MaxDollars: opts.MaxDollars, VCD: opts.VCD, Sector: opts.Sector}
 }

--- a/internal/cli/trade/trade_levels.go
+++ b/internal/cli/trade/trade_levels.go
@@ -71,5 +71,12 @@ func runTradeLevelTouches(cmd *cobra.Command, opts *tradeLevelTouchesOptions) er
 	if err != nil {
 		return err
 	}
-	return common.RunDataTablesCommand[models.TradeLevelTouch](cmd, "/TradeLevelTouches/GetTradeLevelTouches", datatables.TradeLevelTouchColumns, common.DataTableOptions{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Tickers": ticker, "StartDate": startDate, "EndDate": endDate, "MinVolume": common.IntStr(opts.MinVolume), "MaxVolume": common.IntStr(opts.MaxVolume), "MinPrice": common.FormatFloat(opts.MinPrice), "MaxPrice": common.FormatFloat(opts.MaxPrice), "MinDollars": common.FormatFloat(opts.MinDollars), "MaxDollars": common.FormatFloat(opts.MaxDollars), "VCD": common.IntStr(opts.VCD), "RelativeSize": common.IntStr(opts.RelativeSize), "TradeLevelRank": common.IntStr(opts.TradeLevelRank), "Levels": common.IntStr(opts.TradeLevelCount)}}, opts.Format, "query trade level touches")
+	rangeFilters := tradeLevelTouchRangeFilters(ticker, opts, startDate, endDate)
+	filters := rangeFilters.levelTouchMap(opts.RelativeSize, opts.TradeLevelRank, opts.TradeLevelCount)
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: filters})
+	return common.RunDataTablesCommand[models.TradeLevelTouch](cmd, "/TradeLevelTouches/GetTradeLevelTouches", datatables.TradeLevelTouchColumns, dtOpts, opts.Format, "query trade level touches")
+}
+
+func tradeLevelTouchRangeFilters(ticker string, opts *tradeLevelTouchesOptions, startDate, endDate string) tradeRangeFilters {
+	return tradeRangeFilters{Tickers: ticker, StartDate: startDate, EndDate: endDate, MinVolume: opts.MinVolume, MaxVolume: opts.MaxVolume, MinPrice: opts.MinPrice, MaxPrice: opts.MaxPrice, MinDollars: opts.MinDollars, MaxDollars: opts.MaxDollars, VCD: opts.VCD}
 }

--- a/internal/cli/trade/trade_list.go
+++ b/internal/cli/trade/trade_list.go
@@ -59,7 +59,7 @@ func runTradeList(cmd *cobra.Command, opts *tradeListOptions) error {
 	filters["StartDate"] = startDate
 	filters["EndDate"] = endDate
 
-	dtOpts := common.DataTableOptions{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: filters, Fields: fields}
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: filters, Fields: fields})
 	if !opts.Summary && cmd.Flags().Changed("group-by") {
 		return fmt.Errorf("--group-by only works with --summary")
 	}

--- a/internal/cli/trade/trade_sentiment.go
+++ b/internal/cli/trade/trade_sentiment.go
@@ -34,7 +34,8 @@ func runTradeSentiment(cmd *cobra.Command, opts *tradeSentimentOptions) error {
 	if err != nil {
 		return err
 	}
-	trades, err := fetchTradeSentimentTrades(cmd, vlClient, common.DataTableOptions{Start: 0, Length: maxTradeRequestLength, OrderCol: 1, OrderDir: "desc", Filters: filters})
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: 0, Length: maxTradeRequestLength, OrderCol: 1, OrderDir: common.OrderDirectionDESC, Filters: filters})
+	trades, err := fetchTradeSentimentTrades(cmd, vlClient, dtOpts)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/trade/trade_test.go
+++ b/internal/cli/trade/trade_test.go
@@ -158,6 +158,54 @@ func TestBuildTradeFiltersPreservesAPIKeys(t *testing.T) {
 	}
 }
 
+func TestTradeRangeFiltersPreserveAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	base := tradeRangeFilters{
+		Tickers:    "AAPL,NVDA",
+		StartDate:  "2026-04-01",
+		EndDate:    "2026-04-24",
+		MinVolume:  100,
+		MaxVolume:  200,
+		MinPrice:   1.5,
+		MaxPrice:   99.25,
+		MinDollars: 500000,
+		MaxDollars: 30000000000,
+		VCD:        0,
+		Sector:     "Technology",
+	}
+	tests := []struct {
+		name string
+		got  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "cluster filters",
+			got:  base.clusterMap(-1, 5, 10),
+			want: map[string]string{"Tickers": "AAPL,NVDA", "StartDate": "2026-04-01", "EndDate": "2026-04-24", "MinVolume": "100", "MaxVolume": "200", "MinPrice": "1.5", "MaxPrice": "99.25", "MinDollars": "500000", "MaxDollars": "30000000000", "VCD": "0", "SecurityTypeKey": "-1", "RelativeSize": "5", "TradeClusterRank": "10", "SectorIndustry": "Technology"},
+		},
+		{
+			name: "cluster bomb filters omit price range",
+			got:  base.clusterBombMap(-1, 5, 10),
+			want: map[string]string{"Tickers": "AAPL,NVDA", "StartDate": "2026-04-01", "EndDate": "2026-04-24", "MinVolume": "100", "MaxVolume": "200", "MinDollars": "500000", "MaxDollars": "30000000000", "VCD": "0", "SecurityTypeKey": "-1", "RelativeSize": "5", "TradeClusterBombRank": "10", "SectorIndustry": "Technology"},
+		},
+		{
+			name: "level touch filters",
+			got:  base.levelTouchMap(5, 10, 20),
+			want: map[string]string{"Tickers": "AAPL,NVDA", "StartDate": "2026-04-01", "EndDate": "2026-04-24", "MinVolume": "100", "MaxVolume": "200", "MinPrice": "1.5", "MaxPrice": "99.25", "MinDollars": "500000", "MaxDollars": "30000000000", "VCD": "0", "RelativeSize": "5", "TradeLevelRank": "10", "Levels": "20"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !maps.Equal(tt.got, tt.want) {
+				t.Fatalf("filters mismatch\nexpected: %#v\ngot:      %#v", tt.want, tt.got)
+			}
+		})
+	}
+}
+
 func TestPresetTradeFilterDefaultsPreserveTriStateValues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/volume/volume.go
+++ b/internal/cli/volume/volume.go
@@ -100,15 +100,6 @@ func newTotalCmd() *cobra.Command {
 func runVolume(cmd *cobra.Command, opts *volumeOptions, path string, columns []string) error {
 	tickers := common.MultiTickerValue(cmd)
 
-	dtOpts := common.DataTableOptions{
-		Start:    opts.Start,
-		Length:   opts.Length,
-		OrderCol: opts.OrderCol,
-		OrderDir: opts.OrderDir,
-		Filters: map[string]string{
-			"Date":    opts.Date,
-			"Tickers": tickers,
-		},
-	}
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: opts.Length, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: map[string]string{"Date": opts.Date, "Tickers": tickers}})
 	return common.RunDataTablesCommand[models.Trade](cmd, path, columns, dtOpts, opts.Format, "query volume data")
 }


### PR DESCRIPTION
## Summary
- Centralize DataTables request option construction behind `DataTableRequestConfig` and `NewDataTableOptions`.
- Move repeated trade cluster, cluster-bomb, and level-touch filter maps into typed helper structs.
- Add tests for DataTables option conversion and trade filter API key preservation.

## Verification
- `make lint`
- `make test`
- `make build`
- `~/bin/coderabbit review --agent --base main -c .coderabbit.yaml` (0 findings)