### PR TITLE
fix(cli): fix prettyFromCommand flag lookup and aggregate validation errors

### DIFF
--- a/internal/cli/common/bind.go
+++ b/internal/cli/common/bind.go
@@ -147,7 +147,11 @@ func wrapValidation(cmd *cobra.Command, opts any) {
 		if len(errs) == 0 {
 			return nil
 		}
-		return errs[0]
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Error()
+		}
+		return fmt.Errorf("%s", strings.Join(msgs, "; "))
 	}
 }
 

--- a/internal/cli/outputschema.go
+++ b/internal/cli/outputschema.go
@@ -94,7 +94,7 @@ volumeleaders-agent outputschema trade list`,
 }
 
 func prettyFromCommand(cmd *cobra.Command) bool {
-	pretty, _ := cmd.Root().PersistentFlags().GetBool("pretty")
+	pretty, _ := cmd.Root().Flags().GetBool("pretty")
 	return pretty
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #89. Two bugs found during the parallel structcli removal work in #90:

- **prettyFromCommand reads wrong flag set**: `Bind()` registers `--pretty` on `cmd.Flags()`, but `prettyFromCommand` read from `cmd.Root().PersistentFlags()`. This meant `volumeleaders-agent --pretty outputschema` would silently ignore the flag. Fixed to use `Flags()`.
- **wrapValidation drops errors**: When `Validate()` returned multiple errors, only the first was reported. Now all errors are joined with semicolons so users see every validation failure at once.