### PR TITLE
refactor: remove dead DataTables columns and migrate presets to watchlist adapter

### DIFF
--- a/internal/cli/trade/presets.go
+++ b/internal/cli/trade/presets.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/major/volumeleaders-agent/internal/cli/common"
-	"github.com/major/volumeleaders-agent/internal/datatables"
+	"github.com/major/volumeleaders-agent/internal/cli/watchlist"
 	"github.com/major/volumeleaders-agent/internal/models"
 )
 
@@ -121,13 +121,12 @@ func applyExplicitFlags(cmd *cobra.Command, filters map[string]string) {
 }
 
 func fetchWatchlistFilters(ctx context.Context, name string) (map[string]string, error) {
-	vlClient, err := common.NewCommandClient(ctx)
+	svc, err := watchlist.NewService(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create client: %w", err)
+		return nil, fmt.Errorf("create watchlist service: %w", err)
 	}
-	request := common.NewDataTablesRequest(datatables.WatchlistConfigColumns, common.DataTableOptions{Start: 0, Length: -1, OrderCol: 1, OrderDir: "asc"})
-	var configs []models.WatchListConfig
-	if err := vlClient.PostDataTables(ctx, "/WatchListConfigs/GetWatchLists", request.Encode(), &configs); err != nil {
+	configs, err := svc.Configs(ctx, common.DataTableOptions{Start: 0, Length: -1, OrderCol: 1, OrderDir: "asc"})
+	if err != nil {
 		return nil, fmt.Errorf("fetch watchlists: %w", err)
 	}
 	var match *models.WatchListConfig

--- a/internal/cli/watchlist/adapter.go
+++ b/internal/cli/watchlist/adapter.go
@@ -11,7 +11,9 @@ import (
 	"github.com/major/volumeleaders-agent/internal/models"
 )
 
-type watchlistService interface {
+// Service provides access to VolumeLeaders watchlist operations through
+// the volumeleaders-go library.
+type Service interface {
 	Configs(context.Context, common.DataTableOptions) ([]models.WatchListConfig, error)
 	Tickers(context.Context, common.DataTableOptions) ([]models.WatchListTicker, error)
 	Delete(ctx context.Context, key int) error
@@ -23,7 +25,10 @@ type volumeLeadersWatchlistService struct {
 	client *vlgo.Client
 }
 
-func newWatchlistService(ctx context.Context) (watchlistService, error) {
+// NewService creates a Service backed by a volumeleaders-go client. The
+// context is used for authenticated client construction (cookie extraction,
+// XSRF token probing) and test client injection.
+func NewService(ctx context.Context) (Service, error) {
 	commandClient, err := common.NewCommandClient(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/cli/watchlist/adapter_test.go
+++ b/internal/cli/watchlist/adapter_test.go
@@ -38,9 +38,9 @@ func TestVolumeLeadersWatchlistServiceConfigsFetchesAllPages(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := testutil.ContextWithTestClient(t, server.URL)
-	service, err := newWatchlistService(ctx)
+	service, err := NewService(ctx)
 	if err != nil {
-		t.Fatalf("newWatchlistService() error = %v", err)
+		t.Fatalf("NewService() error = %v", err)
 	}
 	configs, err := service.Configs(ctx, common.DataTableOptions{Start: 0, Length: -1, OrderCol: 1, OrderDir: "asc"})
 	if err != nil {
@@ -167,9 +167,9 @@ func TestVolumeLeadersWatchlistServiceTickersFetchesAllPages(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	ctx := testutil.ContextWithTestClient(t, server.URL)
-	svc, err := newWatchlistService(ctx)
+	svc, err := NewService(ctx)
 	if err != nil {
-		t.Fatalf("newWatchlistService() error = %v", err)
+		t.Fatalf("NewService() error = %v", err)
 	}
 
 	tickers, err := svc.Tickers(ctx, common.DataTableOptions{Start: 0, Length: -1})
@@ -249,4 +249,4 @@ func TestMapWatchListTickerNearestLevel(t *testing.T) {
 
 func ptrFloat64(v float64) *float64 { return &v }
 
-var _ watchlistService = (*volumeLeadersWatchlistService)(nil)
+var _ Service = (*volumeLeadersWatchlistService)(nil)

--- a/internal/cli/watchlist/watchlist.go
+++ b/internal/cli/watchlist/watchlist.go
@@ -190,7 +190,7 @@ func runConfigs(cmd *cobra.Command, dtOpts common.DataTableOptions, formatValue 
 		return err
 	}
 	ctx := cmd.Context()
-	service, err := newWatchlistService(ctx)
+	service, err := NewService(ctx)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func runTickers(cmd *cobra.Command, dtOpts common.DataTableOptions, formatValue 
 		return err
 	}
 	ctx := cmd.Context()
-	service, err := newWatchlistService(ctx)
+	service, err := NewService(ctx)
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func newDeleteCmd() *cobra.Command {
 		SuggestFor: []string{"del", "remove"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			service, err := newWatchlistService(ctx)
+			service, err := NewService(ctx)
 			if err != nil {
 				return err
 			}
@@ -288,7 +288,7 @@ func newAddTickerCmd() *cobra.Command {
 		SuggestFor: []string{"addticker", "add-tkr"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			service, err := newWatchlistService(ctx)
+			service, err := NewService(ctx)
 			if err != nil {
 				return err
 			}
@@ -391,7 +391,7 @@ func buildWatchlistConfigFields(opts *watchlistConfigFlags, key int) map[string]
 // indicates a new watchlist; a non-zero key indicates an edit.
 func runCreateEdit(cmd *cobra.Command, opts *watchlistConfigFlags, key int) error {
 	ctx := cmd.Context()
-	service, err := newWatchlistService(ctx)
+	service, err := NewService(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/datatables/datatables.go
+++ b/internal/datatables/datatables.go
@@ -87,12 +87,6 @@ var TotalVolumeColumns = []string{
 	"LastComparibleTradeDate", "LastComparibleTradeDate",
 }
 
-// TradeLevelColumns contains the DataTables column names used by the trade levels endpoint.
-var TradeLevelColumns = []string{
-	"Price", "Dollars", "Volume", "Trades", "RelativeSize",
-	"CumulativeDistribution", "TradeLevelRank", "Level Date Range",
-}
-
 // TradeLevelChartColumns contains the chart dashboard layout for level rows.
 var TradeLevelChartColumns = []Column{
 	{Data: "Price", Name: "Price", Searchable: true, Orderable: false},
@@ -121,17 +115,6 @@ var AlertConfigColumns = []string{
 var EarningsColumns = []string{
 	"Date", "Ticker", "Current", "Sector", "Industry",
 	"TradeCount", "TradeClusterCount", "TradeClusterBombCount", "Ticker",
-}
-
-// WatchlistTickerColumns contains the DataTables column names used by the watchlist tickers endpoint.
-var WatchlistTickerColumns = []string{
-	"Ticker", "Price", "NearestTop10TradeDate",
-	"NearestTop10TradeClusterDate", "NearestTop10TradeLevel", "Charts",
-}
-
-// WatchlistConfigColumns contains the DataTables column names used by the watchlist configs endpoint.
-var WatchlistConfigColumns = []string{
-	"Name", "Name", "Tickers", "Criteria",
 }
 
 // Column describes one DataTables column definition.


### PR DESCRIPTION
## Summary

- Delete `WatchlistTickerColumns`, `WatchlistConfigColumns`, and `TradeLevelColumns` from `datatables.go` (zero references after the watchlist vlgo migration in 8d0ea04)
- Export `watchlist.Service` / `watchlist.NewService` so `trade/presets.go` can fetch configs through the vlgo adapter
- Migrate `fetchWatchlistFilters` from raw DataTables `PostDataTables` path to `watchlist.NewService` + `Configs()`

Net -14 lines. No behavioral changes, no new dependencies.