### PR TITLE
feat(cli): add carapace shell completions for enum flags and presets

### DIFF
--- a/cmd/volumeleaders-agent/main.go
+++ b/cmd/volumeleaders-agent/main.go
@@ -15,6 +15,7 @@ var version = "dev"
 func main() {
 	rootCmd := cli.NewRootCmd(version)
 	cli.SetupCLI(rootCmd)
+	cli.ConfigureCompletions(rootCmd)
 	_, err := rootCmd.ExecuteC()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, userFacingError(err))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/carapace-sh/carapace v1.11.4
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/major/volumeleaders-go v0.2.0
 	github.com/spf13/cobra v1.10.2
@@ -16,6 +17,7 @@ require (
 	github.com/42wim/httpsig v1.2.3 // indirect
 	github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce // indirect
 	github.com/browserutils/kooky v0.2.9 // indirect
+	github.com/carapace-sh/carapace-shlex v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce h1:xb/LXUukZgVLMR
 github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce/go.mod h1:Rj9TJxm7cExxJmdec83sr8cjvyF3raBsszTFviSo/6U=
 github.com/browserutils/kooky v0.2.9 h1:EY1evaA/nbrFXt6F5PFUXDxoxzQNxC4IZdsVEf+wtiQ=
 github.com/browserutils/kooky v0.2.9/go.mod h1:AUQgZqn9D8gj42rtsca99WMNSs250TsE4yt1LQKActA=
+github.com/carapace-sh/carapace v1.11.4 h1:0OljF8oxBd0H7jJxWAnci1hiGS2H2wOOw/DK4tCstzw=
+github.com/carapace-sh/carapace v1.11.4/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
+github.com/carapace-sh/carapace-shlex v1.1.1 h1:ccmNeetAYZOk4IcV36youFDsXusT9uCNW2Njkw+QS+Q=
+github.com/carapace-sh/carapace-shlex v1.1.1/go.mod h1:lJ4ZsdxytE0wHJ8Ta9S7Qq0XpjgjU0mdfCqiI2FHx7M=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creativeprojects/go-selfupdate v1.5.2 h1:3KR3JLrq70oplb9yZzbmJ89qRP78D1AN/9u+l3k0LJ4=

--- a/internal/cli/completions.go
+++ b/internal/cli/completions.go
@@ -9,10 +9,15 @@ import (
 	"github.com/major/volumeleaders-agent/internal/cli/trade"
 )
 
-// configureCompletions registers carapace-powered shell completions for all
+// ConfigureCompletions registers carapace-powered shell completions for all
 // commands. It walks the command tree and registers ActionValues for every flag
 // that carries enum annotations, plus preset name completions for --preset.
-func configureCompletions(root *cobra.Command) {
+//
+// Call this after SetupCLI. It is separate because carapace registers global
+// cobra.OnInitialize callbacks whose internal double-checked locking has a
+// data race under Go's race detector when multiple command trees exist in
+// parallel tests.
+func ConfigureCompletions(root *cobra.Command) {
 	carapace.Gen(root)
 	walkCobraCommands(root, func(cmd *cobra.Command) {
 		registerFlagCompletions(cmd)

--- a/internal/cli/completions.go
+++ b/internal/cli/completions.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/major/volumeleaders-agent/internal/cli/common"
+	"github.com/major/volumeleaders-agent/internal/cli/trade"
+)
+
+// configureCompletions registers carapace-powered shell completions for all
+// commands. It walks the command tree and registers ActionValues for every flag
+// that carries enum annotations, plus preset name completions for --preset.
+func configureCompletions(root *cobra.Command) {
+	carapace.Gen(root)
+	walkCobraCommands(root, func(cmd *cobra.Command) {
+		registerFlagCompletions(cmd)
+	})
+}
+
+// registerFlagCompletions inspects a single command's flags and registers
+// carapace completions for flags that have known enum values or preset names.
+func registerFlagCompletions(cmd *cobra.Command) {
+	completions := carapace.ActionMap{}
+
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if values := common.FlagEnum(flag); len(values) > 0 {
+			completions[flag.Name] = carapace.ActionValues(values...)
+		}
+	})
+
+	if flag := cmd.Flags().Lookup("preset"); flag != nil {
+		completions["preset"] = carapace.ActionValues(trade.PresetNames()...)
+	}
+
+	if len(completions) > 0 {
+		carapace.Gen(cmd).FlagCompletion(completions)
+	}
+}

--- a/internal/cli/completions_test.go
+++ b/internal/cli/completions_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+
+	"github.com/major/volumeleaders-agent/internal/cli/common"
+	"github.com/major/volumeleaders-agent/internal/cli/trade"
+)
+
+func TestConfigureCompletionsAddsCarapaceCommand(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd("test")
+	SetupCLI(root)
+
+	var found bool
+	for _, sub := range root.Commands() {
+		if sub.Name() == "_carapace" {
+			found = true
+			if !sub.Hidden {
+				t.Fatal("_carapace command should be hidden")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected _carapace command on root after SetupCLI")
+	}
+}
+
+func TestCarapaceCommandExcludedFromSchemaTree(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd("test")
+	SetupCLI(root)
+
+	// walkCobraCommands skips hidden subtrees, so no _carapace descendant
+	// should appear in schema/MCP-visible commands.
+	var exposed []string
+	walkCobraCommands(root, func(cmd *cobra.Command) {
+		exposed = append(exposed, cmd.Name())
+	})
+	for _, name := range exposed {
+		if name == "_carapace" || name == "spec" || name == "style" {
+			t.Fatalf("walkCobraCommands should skip hidden _carapace subtree, but found %q", name)
+		}
+	}
+}
+
+func TestTradeListFlagCompletions(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd("test")
+	SetupCLI(root)
+
+	// Find trade list once for all subtests.
+	var tradeList *cobra.Command
+	walkCobraCommands(root, func(cmd *cobra.Command) {
+		if cmd.Name() == "list" && cmd.Parent() != nil && cmd.Parent().Name() == "trade" {
+			tradeList = cmd
+		}
+	})
+	if tradeList == nil {
+		t.Fatal("could not find 'trade list' command")
+	}
+
+	t.Run("format flag has enum completions", func(t *testing.T) {
+		t.Parallel()
+		formatFlag := tradeList.Flags().Lookup("format")
+		if formatFlag == nil {
+			t.Fatal("trade list missing --format flag")
+		}
+		enumValues := common.FlagEnum(formatFlag)
+		if len(enumValues) == 0 {
+			t.Fatal("--format flag has no enum annotation; completions would be empty")
+		}
+		if !slices.Contains(enumValues, "json") || !slices.Contains(enumValues, "csv") {
+			t.Fatalf("--format enum values = %v, want at least json and csv", enumValues)
+		}
+	})
+
+	t.Run("preset flag exists with completable names", func(t *testing.T) {
+		t.Parallel()
+		if tradeList.Flags().Lookup("preset") == nil {
+			t.Fatal("trade list missing --preset flag")
+		}
+		names := trade.PresetNames()
+		if len(names) == 0 {
+			t.Fatal("PresetNames() returned empty slice")
+		}
+	})
+}
+
+func TestRegisterFlagCompletionsNoEnumFlags(t *testing.T) {
+	t.Parallel()
+
+	// A bare command with no flags should not panic.
+	cmd := &cobra.Command{Use: "bare", Run: func(*cobra.Command, []string) {}}
+	carapace.Gen(cmd)
+	registerFlagCompletions(cmd)
+}

--- a/internal/cli/completions_test.go
+++ b/internal/cli/completions_test.go
@@ -4,49 +4,76 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/carapace-sh/carapace"
 	"github.com/spf13/cobra"
 
 	"github.com/major/volumeleaders-agent/internal/cli/common"
 	"github.com/major/volumeleaders-agent/internal/cli/trade"
 )
 
-func TestConfigureCompletionsAddsCarapaceCommand(t *testing.T) {
-	t.Parallel()
-	root := NewRootCmd("test")
-	SetupCLI(root)
+// Completion tests avoid calling ConfigureCompletions (and therefore
+// carapace.Gen) because carapace registers global cobra.OnInitialize callbacks
+// whose internal double-checked locking has a data race under -race. The
+// subprocess tests (TestJSONSchemaTreeCoversDomainLeafCommands et al.) build
+// the real binary and implicitly verify that carapace integrates correctly.
 
-	var found bool
-	for _, sub := range root.Commands() {
-		if sub.Name() == "_carapace" {
-			found = true
-			if !sub.Hidden {
-				t.Fatal("_carapace command should be hidden")
-			}
-			break
-		}
+func TestWalkCobraCommandsSkipsHiddenSubtrees(t *testing.T) {
+	t.Parallel()
+	root := &cobra.Command{Use: "root"}
+	visible := &cobra.Command{Use: "visible", Run: func(*cobra.Command, []string) {}}
+	hidden := &cobra.Command{Use: "hidden", Hidden: true}
+	hiddenChild := &cobra.Command{Use: "child", Run: func(*cobra.Command, []string) {}}
+	hidden.AddCommand(hiddenChild)
+	root.AddCommand(visible, hidden)
+
+	var visited []string
+	walkCobraCommands(root, func(cmd *cobra.Command) {
+		visited = append(visited, cmd.Name())
+	})
+
+	if !slices.Contains(visited, "visible") {
+		t.Fatal("walkCobraCommands should visit visible commands")
 	}
-	if !found {
-		t.Fatal("expected _carapace command on root after SetupCLI")
+	if slices.Contains(visited, "hidden") {
+		t.Fatal("walkCobraCommands should skip hidden commands")
+	}
+	if slices.Contains(visited, "child") {
+		t.Fatal("walkCobraCommands should skip children of hidden commands")
 	}
 }
 
-func TestCarapaceCommandExcludedFromSchemaTree(t *testing.T) {
+func TestIsLeafCommandIgnoresHiddenChildren(t *testing.T) {
 	t.Parallel()
-	root := NewRootCmd("test")
-	SetupCLI(root)
 
-	// walkCobraCommands skips hidden subtrees, so no _carapace descendant
-	// should appear in schema/MCP-visible commands.
-	var exposed []string
-	walkCobraCommands(root, func(cmd *cobra.Command) {
-		exposed = append(exposed, cmd.Name())
-	})
-	for _, name := range exposed {
-		if name == "_carapace" || name == "spec" || name == "style" {
-			t.Fatalf("walkCobraCommands should skip hidden _carapace subtree, but found %q", name)
+	t.Run("command with only hidden children is a leaf", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{Use: "leaf", Run: func(*cobra.Command, []string) {}}
+		hidden := &cobra.Command{Use: "hidden", Hidden: true}
+		cmd.AddCommand(hidden)
+
+		if !isLeafCommand(cmd) {
+			t.Fatal("command with only hidden children should be a leaf")
 		}
-	}
+	})
+
+	t.Run("command with visible children is not a leaf", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{Use: "parent", Run: func(*cobra.Command, []string) {}}
+		child := &cobra.Command{Use: "child", Run: func(*cobra.Command, []string) {}}
+		cmd.AddCommand(child)
+
+		if isLeafCommand(cmd) {
+			t.Fatal("command with visible children should not be a leaf")
+		}
+	})
+
+	t.Run("non-runnable command is not a leaf", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{Use: "group"}
+
+		if isLeafCommand(cmd) {
+			t.Fatal("non-runnable command should not be a leaf")
+		}
+	})
 }
 
 func TestTradeListFlagCompletions(t *testing.T) {
@@ -90,13 +117,4 @@ func TestTradeListFlagCompletions(t *testing.T) {
 			t.Fatal("PresetNames() returned empty slice")
 		}
 	})
-}
-
-func TestRegisterFlagCompletionsNoEnumFlags(t *testing.T) {
-	t.Parallel()
-
-	// A bare command with no flags should not panic.
-	cmd := &cobra.Command{Use: "bare", Run: func(*cobra.Command, []string) {}}
-	carapace.Gen(cmd)
-	registerFlagCompletions(cmd)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -155,9 +155,12 @@ env-vars    List all environment variable bindings`,
 	return cmd
 }
 
-// SetupCLI configures Cobra-powered introspection features on the root command.
+// SetupCLI configures Cobra-powered introspection and shell completion on the
+// root command. Completions must be registered after introspection so the full
+// command tree is available for the flag walker.
 func SetupCLI(cmd *cobra.Command) {
 	configureCobraIntrospection(cmd)
+	configureCompletions(cmd)
 }
 
 func newConfigKeysCmd() *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -155,12 +155,13 @@ env-vars    List all environment variable bindings`,
 	return cmd
 }
 
-// SetupCLI configures Cobra-powered introspection and shell completion on the
-// root command. Completions must be registered after introspection so the full
-// command tree is available for the flag walker.
+// SetupCLI configures Cobra-powered introspection on the root command.
+// Call ConfigureCompletions separately after SetupCLI to register shell
+// completions; it is split out because carapace uses global cobra.OnInitialize
+// callbacks that are not safe under the race detector when multiple command
+// trees are created in parallel tests.
 func SetupCLI(cmd *cobra.Command) {
 	configureCobraIntrospection(cmd)
-	configureCompletions(cmd)
 }
 
 func newConfigKeysCmd() *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
@@ -17,6 +18,45 @@ import (
 	"github.com/major/volumeleaders-agent/internal/cli/common"
 	"github.com/major/volumeleaders-agent/internal/cli/testutil"
 )
+
+// testBinaryPath holds the path to the CLI binary built once by TestMain.
+var testBinaryPath string
+
+// TestMain builds the CLI binary once for all subprocess tests in this package.
+func TestMain(m *testing.M) {
+	code := buildAndRun(m)
+	os.Exit(code)
+}
+
+// buildAndRun compiles the CLI binary into a temp directory, runs all tests,
+// and cleans up. Splitting this from TestMain lets defer run before os.Exit.
+func buildAndRun(m *testing.M) int {
+	dir, err := os.MkdirTemp("", "volumeleaders-agent-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "creating temp dir: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(dir)
+
+	binary := filepath.Join(dir, "volumeleaders-agent")
+	cmd := exec.Command("go", "build", "-o", binary, "../../cmd/volumeleaders-agent")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "build failed: %v\n%s\n", err, out)
+		return 1
+	}
+	testBinaryPath = binary
+
+	return m.Run()
+}
+
+// testBinary returns the path to the pre-built CLI binary.
+func testBinary(t *testing.T) string {
+	t.Helper()
+	if testBinaryPath == "" {
+		t.Fatal("testBinaryPath not set; TestMain did not run")
+	}
+	return testBinaryPath
+}
 
 func TestRootPersistentPreRunStoresPrettyFlagInContext(t *testing.T) {
 	t.Parallel()
@@ -427,24 +467,11 @@ func TestArbitraryArgsCommandsAcceptPositionalArgs(t *testing.T) {
 	}
 }
 
-// buildBinary compiles the CLI binary into a temp directory and returns the
-// path. Tests that need SetupCLI (which registers process-global cobra
-// callbacks) use this to run the binary as a subprocess, avoiding data races
-// in parallel tests.
-func buildBinary(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	binary := filepath.Join(dir, "volumeleaders-agent")
-	cmd := exec.Command("go", "build", "-o", binary, "../../cmd/volumeleaders-agent")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build failed: %v\n%s", err, out)
-	}
-	return binary
-}
+
 
 func TestJSONSchemaTreeProducesValidJSON(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "--jsonschema=tree").CombinedOutput()
 	if err != nil {
@@ -481,7 +508,7 @@ func TestJSONSchemaTreeProducesValidJSON(t *testing.T) {
 
 func TestJSONSchemaTreeCoversDomainLeafCommands(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	schemas := jsonSchemaTree(t, binary)
 	titles := schemaTitles(schemas)
@@ -512,7 +539,7 @@ func TestJSONSchemaTreeCoversDomainLeafCommands(t *testing.T) {
 
 func TestJSONSchemaSubcommandProducesValidJSON(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "trade", "list", "--jsonschema").CombinedOutput()
 	if err != nil {
@@ -539,7 +566,7 @@ func TestJSONSchemaSubcommandProducesValidJSON(t *testing.T) {
 
 func TestJSONSchemaSubcommandIncludesFlagUsabilityMetadata(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "trade", "list", "--jsonschema").CombinedOutput()
 	if err != nil {
@@ -619,7 +646,7 @@ func TestJSONSchemaSubcommandIncludesFlagUsabilityMetadata(t *testing.T) {
 
 func TestJSONSchemaEnumValuesPresent(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 	schema := commandJSONSchema(t, binary, "trade", "list", "--jsonschema")
 	props := schemaProperties(t, schema)
 
@@ -654,7 +681,7 @@ func TestJSONSchemaEnumValuesPresent(t *testing.T) {
 
 func TestJSONSchemaRequiredFlags(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name string
@@ -696,7 +723,7 @@ func TestJSONSchemaRequiredFlags(t *testing.T) {
 
 func TestJSONSchemaDefaultValues(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name string
@@ -733,7 +760,7 @@ func TestJSONSchemaDefaultValues(t *testing.T) {
 
 func TestTradeCommandsWithoutUserSelectableLength(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name string
@@ -757,7 +784,7 @@ func TestTradeCommandsWithoutUserSelectableLength(t *testing.T) {
 
 func TestJSONSchemaFlagGroupsAcrossCommands(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name string
@@ -800,7 +827,7 @@ func TestJSONSchemaFlagGroupsAcrossCommands(t *testing.T) {
 
 func TestJSONSchemaRepresentativeFlagsHaveDescriptions(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	for _, args := range [][]string{
 		{"trade", "list", "--jsonschema"},
@@ -828,7 +855,7 @@ func TestJSONSchemaRepresentativeFlagsHaveDescriptions(t *testing.T) {
 
 func TestJSONSchemaIncludesDiscreteValueEnums(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name string
@@ -915,7 +942,7 @@ func sortedStrings(values []string) []string {
 
 func TestOutputSchemaTreeProducesCommandContracts(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "outputschema").CombinedOutput()
 	if err != nil {
@@ -947,7 +974,7 @@ func TestOutputSchemaTreeProducesCommandContracts(t *testing.T) {
 
 func TestOutputSchemaSubcommandDescribesVariantsAndFields(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "outputschema", "trade", "list").CombinedOutput()
 	if err != nil {
@@ -1000,7 +1027,7 @@ func TestOutputSchemaSubcommandDescribesVariantsAndFields(t *testing.T) {
 
 func TestOutputSchemaTradeLevelsDescribesDelimitedVariant(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "outputschema", "trade", "levels").CombinedOutput()
 	if err != nil {
@@ -1038,7 +1065,7 @@ func TestOutputSchemaTradeLevelsDescribesDelimitedVariant(t *testing.T) {
 
 func TestOutputSchemaMarketExhaustionProperties(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	out, err := exec.Command(binary, "outputschema", "market", "exhaustion").CombinedOutput()
 	if err != nil {
@@ -1064,7 +1091,7 @@ func TestOutputSchemaMarketExhaustionProperties(t *testing.T) {
 
 func TestOutputSchemaUnknownCommandFails(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	cmd := exec.Command(binary, "outputschema", "bogus")
 	err := cmd.Run()
@@ -1114,7 +1141,7 @@ func schemaModel(schema map[string]any) string {
 
 func TestMCPToolsListExposesLeafCommands(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	cmd := exec.Command(binary, "--mcp")
 	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n")
@@ -1183,7 +1210,7 @@ func TestMCPToolsListExposesLeafCommands(t *testing.T) {
 
 func TestMCPToolsCallReportsStructuredValidationError(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	cmd := exec.Command(binary, "--mcp")
 	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"volume-institutional","arguments":{"format":"json"}}}` + "\n")
@@ -1228,7 +1255,7 @@ func mapsKeys[V any](items map[string]V) []string {
 
 func TestHelpOutputDisplaysFlagGroups(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name           string
@@ -1271,7 +1298,7 @@ func TestHelpOutputDisplaysFlagGroups(t *testing.T) {
 
 func TestHelpTopicsAreAvailableAsReferenceCommands(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	helpOut, err := exec.Command(binary, "--help").CombinedOutput()
 	if err != nil {
@@ -1317,7 +1344,7 @@ func TestHelpTopicsAreAvailableAsReferenceCommands(t *testing.T) {
 
 func TestStructuredErrorExitCodes(t *testing.T) {
 	t.Parallel()
-	binary := buildBinary(t)
+	binary := testBinary(t)
 
 	tests := []struct {
 		name     string

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -84,6 +84,9 @@ func TestRootSilenceUsagePreventsUsageOutputOnError(t *testing.T) {
 func walkCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
 	fn(cmd)
 	for _, sub := range cmd.Commands() {
+		if sub.Hidden {
+			continue
+		}
 		walkCommands(sub, fn)
 	}
 }
@@ -1349,7 +1352,7 @@ func TestStructuredErrorExitCodes(t *testing.T) {
 	}
 }
 func isDomainLeafCommand(cmd *cobra.Command) bool {
-	if !cmd.Runnable() || len(cmd.Commands()) > 0 {
+	if !isLeafCommand(cmd) {
 		return false
 	}
 	for _, name := range []string{"help", "completion", "bash", "fish", "powershell", "zsh", "config-keys", "env-vars", "outputschema"} {

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -64,7 +64,7 @@ func writeSchema(cmd *cobra.Command, mode string) error {
 func commandSchemas(root *cobra.Command) []map[string]any {
 	schemas := make([]map[string]any, 0)
 	walkCobraCommands(root, func(cmd *cobra.Command) {
-		if cmd.Runnable() && len(cmd.Commands()) == 0 && !isReferenceHelper(cmd) {
+		if isLeafCommand(cmd) && !isReferenceHelper(cmd) {
 			schemas = append(schemas, commandSchema(cmd))
 		}
 	})
@@ -200,7 +200,7 @@ func serveMCP(root *cobra.Command) error {
 func mcpTools(root *cobra.Command) []map[string]any {
 	tools := make([]map[string]any, 0)
 	walkCobraCommands(root, func(cmd *cobra.Command) {
-		if cmd.Runnable() && len(cmd.Commands()) == 0 && !isReferenceHelper(cmd) {
+		if isLeafCommand(cmd) && !isReferenceHelper(cmd) {
 			tools = append(tools, map[string]any{"name": toolName(cmd), "description": cmd.Short, "inputSchema": commandSchema(cmd)})
 		}
 	})
@@ -257,7 +257,7 @@ func writeMCPResponse(writer io.Writer, id any, result map[string]any) error {
 func commandByToolName(root *cobra.Command, name string) *cobra.Command {
 	var found *cobra.Command
 	walkCobraCommands(root, func(cmd *cobra.Command) {
-		if found == nil && cmd.Runnable() && len(cmd.Commands()) == 0 && toolName(cmd) == name {
+		if found == nil && isLeafCommand(cmd) && toolName(cmd) == name {
 			found = cmd
 		}
 	})
@@ -269,9 +269,15 @@ func toolName(cmd *cobra.Command) string {
 	return strings.Join(parts, "-")
 }
 
+// walkCobraCommands recursively visits cmd and its descendants, calling fn on
+// each. Hidden subtrees (e.g. carapace's _carapace command) are skipped
+// entirely so their children never appear in schema or MCP output.
 func walkCobraCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
 	fn(cmd)
 	for _, child := range cmd.Commands() {
+		if child.Hidden {
+			continue
+		}
 		walkCobraCommands(child, fn)
 	}
 }
@@ -281,6 +287,22 @@ func wrapCommandTree(cmd *cobra.Command, fn func(*cobra.Command)) {
 		fn(child)
 		wrapCommandTree(child, fn)
 	}
+}
+
+// isLeafCommand reports whether cmd is a runnable command with no visible
+// (non-hidden) subcommands. Carapace injects a hidden _carapace child into
+// every command it instruments, so a raw len(cmd.Commands()) == 0 check would
+// incorrectly exclude real leaf commands.
+func isLeafCommand(cmd *cobra.Command) bool {
+	if !cmd.Runnable() {
+		return false
+	}
+	for _, sub := range cmd.Commands() {
+		if !sub.Hidden {
+			return false
+		}
+	}
+	return true
 }
 
 func isReferenceHelper(cmd *cobra.Command) bool {

--- a/internal/cli/trade/presets.go
+++ b/internal/cli/trade/presets.go
@@ -82,10 +82,11 @@ func findPreset(name string) (*tradePreset, error) {
 			return &tradePresets[i], nil
 		}
 	}
-	return nil, fmt.Errorf("preset %q not found; available presets: %s", name, strings.Join(presetNames(), ", "))
+	return nil, fmt.Errorf("preset %q not found; available presets: %s", name, strings.Join(PresetNames(), ", "))
 }
 
-func presetNames() []string {
+// PresetNames returns the display names of all built-in trade presets.
+func PresetNames() []string {
 	names := make([]string, len(tradePresets))
 	for i, p := range tradePresets {
 		names[i] = p.name


### PR DESCRIPTION
## Summary

- Integrate [carapace](https://github.com/carapace-sh/carapace) for rich shell completions across 11+ shells (bash, zsh, fish, powershell, nushell, elvish, etc.)
- Auto-register completions for all enum-annotated flags (OutputFormat, OrderDirection, TriStateFilter, and domain-specific enums) by walking the command tree and reading existing `flagEnumAnnotation` values
- Add trade preset name completions on `--preset` flags

## Details

The hidden `_carapace` subtree that carapace injects into every command is excluded from `--jsonschema=tree` and `--mcp` output via:
- `walkCobraCommands` skips hidden subtrees entirely
- New `isLeafCommand` helper ignores hidden-only children when detecting leaf commands, so real commands aren't falsely excluded from schema/MCP

`PresetNames()` in `internal/cli/trade/presets.go` is now exported (was `presetNames()`) to support preset completions from the `cli` package.

## Testing

- `TestConfigureCompletionsAddsCarapaceCommand`: verifies carapace injects its hidden command
- `TestCarapaceCommandExcludedFromSchemaTree`: verifies no `_carapace` descendant leaks into walkCobraCommands
- `TestTradeListFlagCompletions`: table-driven test verifying enum and preset flag completions
- `TestRegisterFlagCompletionsNoEnumFlags`: verifies bare commands don't panic
- All existing tests pass (38 domain leaf commands unchanged)