### PR TITLE
docs: update project layout and client package comment after datatables removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,8 @@ Command documentation mapping:
 cmd/volumeleaders-agent/main.go    Entry point
 cmd/smoke-test/main.go             Local-only live smoke test harness
 internal/auth/                     Browser cookie + XSRF token extraction
-internal/client/                   HTTP client (DataTables + JSON requests)
+internal/client/                   Auth session bootstrap and HTTP client bridge to volumeleaders-go
 internal/cli/                      CLI command definitions, MCP surface, and output contracts
-internal/datatables/               DataTables protocol encoding + column definitions
 internal/models/                   Response type definitions
 internal/update/                   GitHub release update checks, updater settings, and self-update logic
 ```

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,7 +1,6 @@
 // Package client provides an authenticated HTTP client for the VolumeLeaders
 // API. It handles browser cookie extraction, XSRF token probing, and
-// constructs a configured resty client used as the foundation for the
-// volumeleaders-go library client.
+// builds session material plus an HTTP client consumed by volumeleaders-go.
 package client
 
 import (


### PR DESCRIPTION
## Summary

Follow-up to #100. Addresses two valid review findings:

- Remove deleted `internal/datatables/` from `AGENTS.md` project layout, update `internal/client/` description
- Fix `client.go` package comment to accurately describe the vlgo bridge (session material + HTTP client, not resty wrapper)