### PR TITLE
Add compact agent summary controls

### DIFF
--- a/internal/cli/outputschema.go
+++ b/internal/cli/outputschema.go
@@ -123,7 +123,9 @@ func allOutputContracts() []outputContract {
 		reportTradeOutputContract("report phantom-trades", "Run the site-vetted phantom trades report."),
 		reportTradeOutputContract("report offsetting-trades", "Run the site-vetted offsetting trades report."),
 
-		objectOutputContract[models.TradeDashboard]("trade dashboard", "Return a fast ticker dashboard with trades, clusters, levels, and cluster bombs.", []string{"json"}, []string{"Defaults to a 365-day lookback and 10 rows per section."}),
+		objectOutputContract[models.TradeDashboard]("trade dashboard", "Return a fast ticker dashboard with selected trades, clusters, levels, and cluster bombs.", []string{"json"}, []string{"Defaults to a 365-day lookback, all sections, and 10 rows per section.", "--sections limits API calls and output sections; requestedSections and returnedSections record what was requested and fetched."},
+			outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeDashboardSummary](), Notes: []string{"Summary output returns compact top rows for selected sections and caps each section at 3 rows."}},
+		),
 		arrayOutputContract[models.TradeListRow]("trade list", "List individual institutional trades using a compact default row shape.", outputFormats(), nil, nil,
 			outputVariant{When: "--fields is set or --format is csv or tsv", Formats: outputFormats(), Schema: arraySchema[models.Trade](), FieldSelection: allFieldsSelection[models.Trade](nil), Notes: []string{"CSV and TSV include a header row matching the selected fields."}},
 			outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeSummary](), Notes: []string{"--summary cannot be combined with --fields or non-JSON formats."}},
@@ -172,7 +174,7 @@ func allOutputContracts() []outputContract {
 func reportTradeOutputContract(command, description string) outputContract {
 	return arrayOutputContract[models.TradeListRow](command, description, outputFormats(), nil, nil,
 		outputVariant{When: "--fields is set or --format is csv or tsv", Formats: outputFormats(), Schema: arraySchema[models.Trade](), FieldSelection: allFieldsSelection[models.Trade](nil), Notes: []string{"CSV and TSV include a header row matching the selected fields."}},
-		outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeSummary](), Notes: []string{"--summary cannot be combined with --fields or non-JSON formats."}},
+		outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeSummary](), Notes: []string{"--summary cannot be combined with --fields or non-JSON formats.", "--limit-groups adds a sorted groups slice while keeping byTicker, byDay, and byTickerDay maps backward-compatible.", "--sort-groups-by controls ordered groups with dollars, trades, avg-multiplier, or min-rank."}},
 	)
 }
 

--- a/internal/cli/report/report.go
+++ b/internal/cli/report/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
+	"slices"
 	"strings"
 
 	vlgo "github.com/major/volumeleaders-go/volumeleaders"
@@ -26,14 +27,16 @@ type reportDefinition struct {
 }
 
 type reportOptions struct {
-	Tickers   string              `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols; use this for multi-day report lookbacks"`
-	StartDate string              `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (default: today)"`
-	EndDate   string              `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (default: today)"`
-	Days      int                 `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today; broad scans require a single day"`
-	Fields    string              `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated raw Trade fields to include, or omit for compact JSON"`
-	Summary   bool                `flag:"summary" flaggroup:"Output" flagdescr:"Return aggregate metrics instead of individual trades"`
-	GroupBy   reportSummaryGroup  `flag:"group-by" flaggroup:"Output" flagdescr:"Summary grouping (requires --summary): ticker, day, or ticker,day"`
-	Format    common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv"`
+	Tickers      string              `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols; use this for multi-day report lookbacks"`
+	StartDate    string              `flag:"start-date" flaggroup:"Dates" flagshort:"s" flagdescr:"Start date YYYY-MM-DD (default: today)"`
+	EndDate      string              `flag:"end-date" flaggroup:"Dates" flagshort:"e" flagdescr:"End date YYYY-MM-DD (default: today)"`
+	Days         int                 `flag:"days" flaggroup:"Dates" flagshort:"d" flagdescr:"Look back this many days from --end-date or today; broad scans require a single day"`
+	Fields       string              `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated raw Trade fields to include, or omit for compact JSON"`
+	Summary      bool                `flag:"summary" flaggroup:"Output" flagdescr:"Return aggregate metrics instead of individual trades"`
+	GroupBy      reportSummaryGroup  `flag:"group-by" flaggroup:"Output" flagdescr:"Summary grouping (requires --summary): ticker, day, or ticker,day"`
+	LimitGroups  int                 `flag:"limit-groups" flaggroup:"Output" flagdescr:"Limit ordered summary groups; 0 omits the ordered groups slice"`
+	SortGroupsBy reportSummarySort   `flag:"sort-groups-by" flaggroup:"Output" flagdescr:"Sort ordered summary groups by: dollars, trades, avg-multiplier, or min-rank"`
+	Format       common.OutputFormat `flag:"format" flaggroup:"Output" flagshort:"f" flagdescr:"Output format: json, csv, or tsv"`
 }
 
 type reportListOptions struct {
@@ -51,10 +54,17 @@ type ReportInfo struct {
 
 type reportSummaryGroup string
 
+type reportSummarySort string
+
 const (
 	reportSummaryGroupTicker    reportSummaryGroup = "ticker"
 	reportSummaryGroupDay       reportSummaryGroup = "day"
 	reportSummaryGroupTickerDay reportSummaryGroup = "ticker,day"
+
+	reportSummarySortDollars       reportSummarySort = "dollars"
+	reportSummarySortTrades        reportSummarySort = "trades"
+	reportSummarySortAvgMultiplier reportSummarySort = "avg-multiplier"
+	reportSummarySortMinRank       reportSummarySort = "min-rank"
 )
 
 // NewCmd returns the "report" command group with curated report presets.
@@ -101,7 +111,7 @@ func newReportListCommand() *cobra.Command {
 }
 
 func newReportCommand(definition *reportDefinition) *cobra.Command {
-	opts := &reportOptions{Format: common.OutputFormatJSON, GroupBy: reportSummaryGroupTicker}
+	opts := &reportOptions{Format: common.OutputFormatJSON, GroupBy: reportSummaryGroupTicker, SortGroupsBy: reportSummarySortDollars}
 	cmd := &cobra.Command{
 		Use:     definition.use + " [tickers...]",
 		Short:   definition.short,
@@ -149,12 +159,33 @@ func runReport(cmd *cobra.Command, opts *reportOptions, definition *reportDefini
 	if !opts.Summary && cmd.Flags().Changed("group-by") {
 		return fmt.Errorf("--group-by only works with --summary")
 	}
+	if !opts.Summary && cmd.Flags().Changed("limit-groups") {
+		return fmt.Errorf("--limit-groups only works with --summary")
+	}
+	if !opts.Summary && cmd.Flags().Changed("sort-groups-by") {
+		return fmt.Errorf("--sort-groups-by only works with --summary")
+	}
 	if opts.Summary {
 		if len(fields) > 0 {
 			return fmt.Errorf("--fields cannot be used with --summary")
 		}
 		if format != common.OutputFormatJSON {
 			return fmt.Errorf("--format cannot be used with --summary")
+		}
+		if opts.LimitGroups < 0 {
+			return fmt.Errorf("--limit-groups must be 0 or greater")
+		}
+	}
+	group := reportSummaryGroup("")
+	sortBy := reportSummarySort("")
+	if opts.Summary {
+		group, err = parseReportSummaryGroup(opts.GroupBy)
+		if err != nil {
+			return err
+		}
+		sortBy, err = parseReportSummarySort(opts.SortGroupsBy)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -168,11 +199,7 @@ func runReport(cmd *cobra.Command, opts *reportOptions, definition *reportDefini
 		return err
 	}
 	if opts.Summary {
-		group, err := parseReportSummaryGroup(opts.GroupBy)
-		if err != nil {
-			return err
-		}
-		return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), summarizeReportTrades(trades, group, startDate, endDate))
+		return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), summarizeReportTrades(trades, group, startDate, endDate, opts.LimitGroups, sortBy))
 	}
 	if format == common.OutputFormatJSON && len(fields) == 0 {
 		return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), models.NewTradeListRows(trades))
@@ -212,9 +239,20 @@ func parseReportSummaryGroup(value reportSummaryGroup) (reportSummaryGroup, erro
 	}
 }
 
-func summarizeReportTrades(trades []models.Trade, group reportSummaryGroup, startDate, endDate string) models.TradeSummary {
+func parseReportSummarySort(value reportSummarySort) (reportSummarySort, error) {
+	normalized := strings.ToLower(strings.TrimSpace(string(value)))
+	normalized = strings.NewReplacer("_", "-", " ", "-").Replace(normalized)
+	switch reportSummarySort(normalized) {
+	case reportSummarySortDollars, reportSummarySortTrades, reportSummarySortAvgMultiplier, reportSummarySortMinRank:
+		return reportSummarySort(normalized), nil
+	default:
+		return "", fmt.Errorf("invalid sort-groups-by %q; valid values: dollars, trades, avg-multiplier, min-rank", value)
+	}
+}
+
+func summarizeReportTrades(trades []models.Trade, group reportSummaryGroup, startDate, endDate string, limitGroups int, sortBy reportSummarySort) models.TradeSummary {
 	summary := models.TradeSummary{DateRange: models.TradeSummaryDateRange{Start: startDate, End: endDate}}
-	groups := make(map[string]reportGroupAccumulator)
+	groups := make(map[string]*reportGroupAccumulator)
 	keyFunc := reportSummaryKeyFunc(group)
 	for i := range trades {
 		trade := &trades[i]
@@ -222,13 +260,17 @@ func summarizeReportTrades(trades []models.Trade, group reportSummaryGroup, star
 		summary.TotalDollars += trade.Dollars
 		addReportSummaryGroup(groups, keyFunc(trade), trade)
 	}
+	groupSummaries := summarizeReportGroups(groups)
 	switch group {
 	case reportSummaryGroupDay:
-		summary.ByDay = summarizeReportGroups(groups)
+		summary.ByDay = groupSummaries
 	case reportSummaryGroupTickerDay:
-		summary.ByTickerDay = summarizeReportGroups(groups)
+		summary.ByTickerDay = groupSummaries
 	default:
-		summary.ByTicker = summarizeReportGroups(groups)
+		summary.ByTicker = groupSummaries
+	}
+	if limitGroups > 0 {
+		summary.Groups = orderedReportGroups(groupSummaries, limitGroups, sortBy)
 	}
 	return summary
 }
@@ -239,15 +281,57 @@ type reportGroupAccumulator struct {
 	dollarsMultiplier      float64
 	darkPool               int
 	sweep                  int
+	closingTrade           int
 	cumulativeDistribution float64
+	maxDollars             float64
+	maxDollarsMultiplier   float64
+	minTradeRank           int
+	hasTradeRank           bool
+	topPrice               float64
+	latestTradeTime        string
+	topTradeTime           string
+	topDarkPool            bool
+	topSweep               bool
+	topClosingTrade        bool
 }
 
-func summarizeReportGroups(groups map[string]reportGroupAccumulator) map[string]models.TradeGroupSummary {
+func summarizeReportGroups(groups map[string]*reportGroupAccumulator) map[string]models.TradeGroupSummary {
 	summaries := make(map[string]models.TradeGroupSummary, len(groups))
 	for key, acc := range groups {
 		summaries[key] = acc.summary()
 	}
 	return summaries
+}
+
+func orderedReportGroups(groups map[string]models.TradeGroupSummary, limit int, sortBy reportSummarySort) []models.TradeSummaryGroup {
+	ordered := make([]models.TradeSummaryGroup, 0, len(groups))
+	for key := range groups {
+		summary := groups[key]
+		ordered = append(ordered, models.NewTradeSummaryGroup(key, &summary))
+	}
+	slices.SortFunc(ordered, func(a, b models.TradeSummaryGroup) int {
+		if cmp := compareReportSummaryGroup(&a, &b, sortBy); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Key, b.Key)
+	})
+	if limit < len(ordered) {
+		return ordered[:limit]
+	}
+	return ordered
+}
+
+func compareReportSummaryGroup(a, b *models.TradeSummaryGroup, sortBy reportSummarySort) int {
+	switch sortBy {
+	case reportSummarySortTrades:
+		return compareIntDesc(a.Trades, b.Trades)
+	case reportSummarySortAvgMultiplier:
+		return compareFloatDesc(a.AvgDollarsMultiplier, b.AvgDollarsMultiplier)
+	case reportSummarySortMinRank:
+		return compareRankAsc(a.MinTradeRank, b.MinTradeRank)
+	default:
+		return compareFloatDesc(a.Dollars, b.Dollars)
+	}
 }
 
 func reportSummaryKeyFunc(group reportSummaryGroup) func(*models.Trade) string {
@@ -261,8 +345,12 @@ func reportSummaryKeyFunc(group reportSummaryGroup) func(*models.Trade) string {
 	}
 }
 
-func addReportSummaryGroup(groups map[string]reportGroupAccumulator, key string, trade *models.Trade) {
+func addReportSummaryGroup(groups map[string]*reportGroupAccumulator, key string, trade *models.Trade) {
 	acc := groups[key]
+	if acc == nil {
+		acc = &reportGroupAccumulator{}
+		groups[key] = acc
+	}
 	acc.trades++
 	acc.dollars += trade.Dollars
 	acc.dollarsMultiplier += trade.DollarsMultiplier
@@ -273,15 +361,101 @@ func addReportSummaryGroup(groups map[string]reportGroupAccumulator, key string,
 	if bool(trade.Sweep) {
 		acc.sweep++
 	}
-	groups[key] = acc
+	if bool(trade.ClosingTrade) {
+		acc.closingTrade++
+	}
+	if trade.Dollars > acc.maxDollars {
+		acc.maxDollars = trade.Dollars
+		acc.topPrice = trade.Price
+		acc.topTradeTime = tradeSummaryTradeTime(trade)
+		acc.topDarkPool = bool(trade.DarkPool)
+		acc.topSweep = bool(trade.Sweep)
+		acc.topClosingTrade = bool(trade.ClosingTrade)
+	}
+	if trade.DollarsMultiplier > acc.maxDollarsMultiplier {
+		acc.maxDollarsMultiplier = trade.DollarsMultiplier
+	}
+	if trade.TradeRank > 0 && (!acc.hasTradeRank || trade.TradeRank < acc.minTradeRank) {
+		acc.minTradeRank = trade.TradeRank
+		acc.hasTradeRank = true
+	}
+	if tradeTime := tradeSummaryTradeTime(trade); tradeTime > acc.latestTradeTime {
+		acc.latestTradeTime = tradeTime
+	}
 }
 
-func (acc reportGroupAccumulator) summary() models.TradeGroupSummary {
+func (acc *reportGroupAccumulator) summary() models.TradeGroupSummary {
 	if acc.trades == 0 {
 		return models.TradeGroupSummary{}
 	}
 	count := float64(acc.trades)
-	return models.TradeGroupSummary{Trades: acc.trades, Dollars: acc.dollars, AvgDollarsMultiplier: acc.dollarsMultiplier / count, PctDarkPool: float64(acc.darkPool) / count * 100, PctSweep: float64(acc.sweep) / count * 100, AvgCumulativeDistribution: acc.cumulativeDistribution / count}
+	return models.TradeGroupSummary{
+		Trades:                    acc.trades,
+		Dollars:                   acc.dollars,
+		AvgDollarsMultiplier:      acc.dollarsMultiplier / count,
+		PctDarkPool:               float64(acc.darkPool) / count * 100,
+		PctSweep:                  float64(acc.sweep) / count * 100,
+		PctClosingTrade:           float64(acc.closingTrade) / count * 100,
+		AvgCumulativeDistribution: acc.cumulativeDistribution / count,
+		MaxDollars:                acc.maxDollars,
+		MaxDollarsMultiplier:      acc.maxDollarsMultiplier,
+		MinTradeRank:              acc.minTradeRank,
+		TopPrice:                  acc.topPrice,
+		LatestTradeTime:           acc.latestTradeTime,
+		TopTradeTime:              acc.topTradeTime,
+		TopDarkPool:               acc.topDarkPool,
+		TopSweep:                  acc.topSweep,
+		TopClosingTrade:           acc.topClosingTrade,
+	}
+}
+
+func tradeSummaryTradeTime(trade *models.Trade) string {
+	if trade.FullDateTime != nil && *trade.FullDateTime != "" {
+		return *trade.FullDateTime
+	}
+	if trade.FullTimeString24 != nil && *trade.FullTimeString24 != "" {
+		return *trade.FullTimeString24
+	}
+	return ""
+}
+
+func compareFloatDesc(a, b float64) int {
+	if a > b {
+		return -1
+	}
+	if a < b {
+		return 1
+	}
+	return 0
+}
+
+func compareIntDesc(a, b int) int {
+	if a > b {
+		return -1
+	}
+	if a < b {
+		return 1
+	}
+	return 0
+}
+
+func compareRankAsc(a, b int) int {
+	if a == 0 && b == 0 {
+		return 0
+	}
+	if a == 0 {
+		return 1
+	}
+	if b == 0 {
+		return -1
+	}
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
 }
 
 func reportTickerKey(trade *models.Trade) string {
@@ -323,7 +497,7 @@ func reportLong(title, description string) string {
 
 %s
 
-Reports are the recommended entry point for users and LLMs. They expose only safe overrides: tickers, dates, fields, summary grouping, and output format. Do not hand-build low-level filters unless this curated report cannot answer the question; use trade list --preset as the advanced escape hatch.
+Reports are the recommended entry point for users and LLMs. They expose only safe overrides: tickers, dates, fields, summary grouping, limited ordered summary groups, and output format. Do not hand-build low-level filters unless this curated report cannot answer the question; use trade list --preset as the advanced escape hatch.
 
 Defaults to today only. Multi-day broad scans without tickers are rejected to avoid expensive requests and backend timeouts. Results are fetched in browser-sized 100-row pages and ordered by time descending.
 

--- a/internal/cli/report/report_test.go
+++ b/internal/cli/report/report_test.go
@@ -273,7 +273,7 @@ func TestSummarizeReportTradesGroupsByTickerAndDay(t *testing.T) {
 		{Dollars: 50, DollarsMultiplier: 1},
 	}
 
-	summary := summarizeReportTrades(trades, reportSummaryGroupTickerDay, "2026-05-01", "2026-05-02")
+	summary := summarizeReportTrades(trades, reportSummaryGroupTickerDay, "2026-05-01", "2026-05-02", 0, reportSummarySortDollars)
 	if summary.TotalTrades != 4 || summary.TotalDollars != 1050 {
 		t.Fatalf("summary totals = trades %d dollars %.2f", summary.TotalTrades, summary.TotalDollars)
 	}
@@ -288,6 +288,52 @@ func TestSummarizeReportTradesGroupsByTickerAndDay(t *testing.T) {
 	unknown := summary.ByTickerDay["unknown|unknown"]
 	if unknown.Trades != 1 || unknown.Dollars != 50 {
 		t.Fatalf("unknown group summary = %#v", unknown)
+	}
+}
+
+func TestSummarizeReportTradesAddsTopPrintFields(t *testing.T) {
+	t.Parallel()
+
+	latestTime := "2026-05-02T16:00:00Z"
+	topTime := "2026-05-01T10:30:00Z"
+	earlierTime := "2026-05-01T09:30:00Z"
+	trades := []models.Trade{
+		tradeFixtureWithPrint("AAPL", "2026-05-01", 300, 4, 112.50, 8, earlierTime, false, false, false, 55),
+		tradeFixtureWithPrint("AAPL", "2026-05-01", 900, 12, 115.25, 3, topTime, true, true, true, 80),
+		tradeFixtureWithPrint("AAPL", "2026-05-02", 100, 20, 116.75, 10, latestTime, false, false, true, 60),
+	}
+
+	summary := summarizeReportTrades(trades, reportSummaryGroupTicker, "2026-05-01", "2026-05-02", 0, reportSummarySortDollars)
+	got := summary.ByTicker["AAPL"]
+	if got.MaxDollars != 900 || got.MaxDollarsMultiplier != 20 || got.MinTradeRank != 3 || got.TopPrice != 115.25 {
+		t.Fatalf("summarizeReportTrades() top fields = %#v", got)
+	}
+	if got.TopTradeTime != topTime || got.LatestTradeTime != latestTime {
+		t.Fatalf("summarizeReportTrades() times = top %q latest %q", got.TopTradeTime, got.LatestTradeTime)
+	}
+	if !got.TopDarkPool || !got.TopSweep || !got.TopClosingTrade || got.PctClosingTrade < 66 || got.PctClosingTrade > 67 {
+		t.Fatalf("summarizeReportTrades() print flags = %#v", got)
+	}
+}
+
+func TestSummarizeReportTradesReturnsLimitedOrderedGroups(t *testing.T) {
+	t.Parallel()
+
+	trades := []models.Trade{
+		tradeFixtureWithPrint("AAPL", "2026-05-01", 300, 4, 100, 5, "2026-05-01T09:30:00Z", false, false, false, 40),
+		tradeFixtureWithPrint("MSFT", "2026-05-01", 900, 2, 200, 12, "2026-05-01T10:30:00Z", false, false, false, 50),
+		tradeFixtureWithPrint("NVDA", "2026-05-01", 400, 8, 300, 2, "2026-05-01T11:30:00Z", false, false, false, 60),
+	}
+
+	summary := summarizeReportTrades(trades, reportSummaryGroupTicker, "2026-05-01", "2026-05-01", 2, reportSummarySortMinRank)
+	if len(summary.Groups) != 2 {
+		t.Fatalf("summarizeReportTrades() groups length = %d, want 2", len(summary.Groups))
+	}
+	if got, want := []string{summary.Groups[0].Key, summary.Groups[1].Key}, []string{"NVDA", "AAPL"}; !slices.Equal(got, want) {
+		t.Fatalf("summarizeReportTrades() ordered groups = %v, want %v", got, want)
+	}
+	if len(summary.ByTicker) != 3 {
+		t.Fatalf("summarizeReportTrades() byTicker length = %d, want 3", len(summary.ByTicker))
 	}
 }
 
@@ -309,6 +355,10 @@ func TestRunReportRejectsSummaryFieldAndFormatConflicts(t *testing.T) {
 		want string
 	}{
 		{name: "group by without summary", args: []string{"top-100-rank", "--group-by", "day"}, want: "--group-by only works with --summary"},
+		{name: "limit groups without summary", args: []string{"top-100-rank", "--limit-groups", "5"}, want: "--limit-groups only works with --summary"},
+		{name: "sort groups without summary", args: []string{"top-100-rank", "--sort-groups-by", "trades"}, want: "--sort-groups-by only works with --summary"},
+		{name: "negative limit groups", args: []string{"top-100-rank", "--summary", "--limit-groups", "-1"}, want: "--limit-groups must be 0 or greater"},
+		{name: "invalid sort groups", args: []string{"top-100-rank", "--summary", "--sort-groups-by", "sector"}, want: "invalid sort-groups-by"},
 		{name: "fields with summary", args: []string{"top-100-rank", "--summary", "--fields", "Ticker"}, want: "--fields cannot be used with --summary"},
 		{name: "csv with summary", args: []string{"top-100-rank", "--summary", "--format", "csv"}, want: "--format cannot be used with --summary"},
 	}
@@ -376,4 +426,13 @@ func tradeFixture(ticker, day string, dollars, multiplier float64, darkPool, swe
 		panic(err)
 	}
 	return models.Trade{Ticker: ticker, Date: models.AspNetDate{Time: parsed, Valid: true}, Dollars: dollars, DollarsMultiplier: multiplier, DarkPool: models.FlexBool(darkPool), Sweep: models.FlexBool(sweep), CumulativeDistribution: cumulativeDistribution}
+}
+
+func tradeFixtureWithPrint(ticker, day string, dollars, multiplier, price float64, rank int, fullDateTime string, darkPool, sweep, closing bool, cumulativeDistribution float64) models.Trade {
+	trade := tradeFixture(ticker, day, dollars, multiplier, darkPool, sweep, cumulativeDistribution)
+	trade.Price = price
+	trade.TradeRank = rank
+	trade.FullDateTime = &fullDateTime
+	trade.ClosingTrade = models.FlexBool(closing)
+	return trade
 }

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -250,7 +250,9 @@ type tradeDashboardOptions struct {
 	tradeOptionalDateRangeFlags
 	tradeRangeFlags
 	tradeFilterFlags
-	Count int `flag:"count" flaggroup:"Output" flagshort:"c" flagdescr:"Rows to return per dashboard section (5, 10, 20, or 50)"`
+	Count    int    `flag:"count" flaggroup:"Output" flagshort:"c" flagdescr:"Rows to return per dashboard section (5, 10, 20, or 50); summary output returns at most 3"`
+	Sections string `flag:"sections" flaggroup:"Output" flagdescr:"Comma-separated dashboard sections to fetch: all, trades, clusters, levels, cluster-bombs"`
+	Summary  bool   `flag:"summary" flaggroup:"Output" flagdescr:"Return compact top rows and counts instead of full dashboard rows"`
 }
 
 func (opts *tradeLevelsOptions) Validate(_ context.Context) []error {
@@ -276,6 +278,9 @@ func (opts *tradeLevelTouchesOptions) Validate(_ context.Context) []error {
 func (opts *tradeDashboardOptions) Validate(_ context.Context) []error {
 	if err := validateTradeLevelCount(opts.Count); err != nil {
 		return []error{fmt.Errorf("--count must be one of 5, 10, 20, or 50 for ticker dashboard retrieval")}
+	}
+	if _, err := parseDashboardSections(opts.Sections); err != nil {
+		return []error{err}
 	}
 	return nil
 }
@@ -324,16 +329,19 @@ func newTradeDashboardCommand() *cobra.Command {
 	presetTradeRangeDefaults(&opts.tradeRangeFlags, 500000)
 	opts.RelativeSize = 0
 	opts.Count = tradeDashboardDefaultCount
+	opts.Sections = "all"
 	cmd := &cobra.Command{
 		Use:   "dashboard [ticker]",
 		Short: "Query a ticker institutional dashboard",
-		Long: `Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
+		Long: `Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches selected sections from the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
 
-Defaults to a 365-day lookback, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use this command as the first stop for any single-ticker investigation, including institutional levels, largest trades, clustered activity, or sudden bursts, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs only when a section needs deeper pagination, CSV/TSV output, or explicit field selection.
+Defaults to a 365-day lookback, all sections, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use --sections trades,levels to reduce API calls and token output when only part of the dashboard is needed. Use --summary for first-pass agent workflows; summary mode returns at most three compact top rows per selected section with requestedSections and returnedSections metadata.
+
+Use this command as the first stop for any single-ticker investigation, including institutional levels, largest trades, clustered activity, or sudden bursts, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs only when a section needs deeper pagination, CSV/TSV output, or explicit field selection.
 
 PREREQUISITES: Provide exactly one ticker as a positional argument or with --ticker. Browser authentication must be available.
 
-RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If date flags conflict, use either --days or --start-date with --end-date.`,
+RECOVERY: If ticker validation fails, use one ticker only. If --count is rejected, use 5, 10, 20, or 50. If --sections is rejected, use all, trades, clusters, levels, or cluster-bombs. If date flags conflict, use either --days or --start-date with --end-date.`,
 		Example:    "volumeleaders-agent trade dashboard IGV",
 		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"dash", "overview", "chart"},

--- a/internal/cli/trade/trade_dashboard.go
+++ b/internal/cli/trade/trade_dashboard.go
@@ -3,6 +3,7 @@ package trade
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	vlgo "github.com/major/volumeleaders-go/volumeleaders"
 	"github.com/spf13/cobra"
@@ -10,6 +11,21 @@ import (
 	"github.com/major/volumeleaders-agent/internal/cli/common"
 	"github.com/major/volumeleaders-agent/internal/models"
 )
+
+const dashboardSummaryMaxRows = 3
+
+type dashboardSection string
+
+const (
+	dashboardSectionTrades       dashboardSection = "trades"
+	dashboardSectionClusters     dashboardSection = "clusters"
+	dashboardSectionLevels       dashboardSection = "levels"
+	dashboardSectionClusterBombs dashboardSection = "clusterBombs"
+)
+
+var allDashboardSections = []dashboardSection{dashboardSectionTrades, dashboardSectionClusters, dashboardSectionLevels, dashboardSectionClusterBombs}
+
+type dashboardSectionSet map[dashboardSection]bool
 
 // Chart column layouts mirroring the compact shapes VolumeLeaders uses
 // in its browser dashboard charts. These are narrower than the standard
@@ -83,6 +99,10 @@ func runTradeDashboard(cmd *cobra.Command, opts *tradeDashboardOptions) error {
 	if err != nil {
 		return err
 	}
+	sections, err := parseDashboardSections(opts.Sections)
+	if err != nil {
+		return err
+	}
 	ticker, err := common.SingleTickerValue(cmd)
 	if err != nil {
 		return err
@@ -92,34 +112,143 @@ func runTradeDashboard(cmd *cobra.Command, opts *tradeDashboardOptions) error {
 		return err
 	}
 
-	tradeFilters := dashboardTradeFilters(opts, ticker, startDate, endDate)
-	trades, err := fetchDashboardTrades(cmd, vlClient, tradeFilters, opts.Count)
-	if err != nil {
-		return err
+	requestCount := opts.Count
+	outputCount := dashboardOutputCount(opts)
+	var trades []models.Trade
+	var clusters []models.TradeCluster
+	var levels []models.TradeLevel
+	var clusterBombs []models.TradeClusterBomb
+	returnedSections := make([]string, 0, len(sections))
+	if sections.contains(dashboardSectionTrades) {
+		trades, err = fetchDashboardTrades(cmd, vlClient, dashboardTradeFilters(opts, ticker, startDate, endDate), requestCount)
+		if err != nil {
+			return err
+		}
+		returnedSections = append(returnedSections, string(dashboardSectionTrades))
 	}
-	clusters, err := fetchDashboardClusters(cmd, vlClient, dashboardClusterFilters(opts, ticker, startDate, endDate), opts.Count)
-	if err != nil {
-		return err
+	if sections.contains(dashboardSectionClusters) {
+		clusters, err = fetchDashboardClusters(cmd, vlClient, dashboardClusterFilters(opts, ticker, startDate, endDate), requestCount)
+		if err != nil {
+			return err
+		}
+		returnedSections = append(returnedSections, string(dashboardSectionClusters))
 	}
-	levels, err := fetchDashboardLevels(cmd, vlClient, dashboardLevelFilters(ticker, startDate, endDate, opts.Count), opts.Count)
-	if err != nil {
-		return err
+	if sections.contains(dashboardSectionLevels) {
+		levels, err = fetchDashboardLevels(cmd, vlClient, dashboardLevelFilters(ticker, startDate, endDate, requestCount), requestCount)
+		if err != nil {
+			return err
+		}
+		returnedSections = append(returnedSections, string(dashboardSectionLevels))
 	}
-	clusterBombs, err := fetchDashboardClusterBombs(cmd, vlClient, dashboardClusterBombFilters(opts, ticker, startDate, endDate), opts.Count)
-	if err != nil {
-		return err
+	if sections.contains(dashboardSectionClusterBombs) {
+		clusterBombs, err = fetchDashboardClusterBombs(cmd, vlClient, dashboardClusterBombFilters(opts, ticker, startDate, endDate), requestCount)
+		if err != nil {
+			return err
+		}
+		returnedSections = append(returnedSections, string(dashboardSectionClusterBombs))
+	}
+
+	requestedSections := sections.names()
+	dateRange := models.TradeDashboardDateRange{Start: startDate, End: endDate}
+	if opts.Summary {
+		summary := models.TradeDashboardSummary{
+			Ticker:            ticker,
+			DateRange:         dateRange,
+			Count:             outputCount,
+			RequestedSections: requestedSections,
+			ReturnedSections:  returnedSections,
+			Trades:            models.NewTradeDashboardTradeSummaries(limitDashboardRows(trades, outputCount)),
+			Clusters:          models.NewTradeDashboardClusters(limitDashboardRows(clusters, outputCount)),
+			Levels:            models.NewTradeLevelRows(limitDashboardRows(levels, outputCount)),
+			ClusterBombs:      models.NewTradeDashboardClusterBombs(limitDashboardRows(clusterBombs, outputCount)),
+		}
+		return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), summary)
 	}
 
 	dashboard := models.TradeDashboard{
-		Ticker:       ticker,
-		DateRange:    models.TradeDashboardDateRange{Start: startDate, End: endDate},
-		Count:        opts.Count,
-		Trades:       models.NewTradeListRows(trades),
-		Clusters:     clusters,
-		Levels:       models.NewTradeLevelRows(levels),
-		ClusterBombs: clusterBombs,
+		Ticker:            ticker,
+		DateRange:         dateRange,
+		Count:             requestCount,
+		RequestedSections: requestedSections,
+		ReturnedSections:  returnedSections,
+		Trades:            models.NewTradeListRows(trades),
+		Clusters:          clusters,
+		Levels:            models.NewTradeLevelRows(levels),
+		ClusterBombs:      clusterBombs,
 	}
 	return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), dashboard)
+}
+
+func parseDashboardSections(value string) (dashboardSectionSet, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || strings.EqualFold(trimmed, "all") {
+		return newDashboardSectionSet(allDashboardSections), nil
+	}
+	sections := make(dashboardSectionSet)
+	for part := range strings.SplitSeq(trimmed, ",") {
+		section, err := parseDashboardSection(part)
+		if err != nil {
+			return nil, err
+		}
+		sections[section] = true
+	}
+	if len(sections) == 0 {
+		return nil, fmt.Errorf("--sections must include at least one dashboard section")
+	}
+	return sections, nil
+}
+
+func parseDashboardSection(value string) (dashboardSection, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.NewReplacer("_", "-", " ", "-").Replace(normalized)
+	switch normalized {
+	case "trades":
+		return dashboardSectionTrades, nil
+	case "clusters":
+		return dashboardSectionClusters, nil
+	case "levels":
+		return dashboardSectionLevels, nil
+	case "cluster-bombs", "clusterbombs", "bombs":
+		return dashboardSectionClusterBombs, nil
+	default:
+		return "", fmt.Errorf("invalid dashboard section %q; valid values: all, trades, clusters, levels, cluster-bombs", value)
+	}
+}
+
+func newDashboardSectionSet(sections []dashboardSection) dashboardSectionSet {
+	set := make(dashboardSectionSet, len(sections))
+	for _, section := range sections {
+		set[section] = true
+	}
+	return set
+}
+
+func (sections dashboardSectionSet) contains(section dashboardSection) bool {
+	return sections[section]
+}
+
+func (sections dashboardSectionSet) names() []string {
+	names := make([]string, 0, len(sections))
+	for _, section := range allDashboardSections {
+		if sections.contains(section) {
+			names = append(names, string(section))
+		}
+	}
+	return names
+}
+
+func dashboardOutputCount(opts *tradeDashboardOptions) int {
+	if opts.Summary && opts.Count > dashboardSummaryMaxRows {
+		return dashboardSummaryMaxRows
+	}
+	return opts.Count
+}
+
+func limitDashboardRows[T any](rows []T, count int) []T {
+	if len(rows) <= count {
+		return rows
+	}
+	return rows[:count]
 }
 
 func dashboardTradeFilters(opts *tradeDashboardOptions, ticker, startDate, endDate string) map[string]string {

--- a/internal/cli/trade/trade_list.go
+++ b/internal/cli/trade/trade_list.go
@@ -212,12 +212,23 @@ type tradeGroupAccumulator struct {
 	dollars                float64
 	dollarsMultiplier      float64
 	darkPool, sweep        int
+	closingTrade           int
 	cumulativeDistribution float64
+	maxDollars             float64
+	maxDollarsMultiplier   float64
+	minTradeRank           int
+	hasTradeRank           bool
+	topPrice               float64
+	latestTradeTime        string
+	topTradeTime           string
+	topDarkPool            bool
+	topSweep               bool
+	topClosingTrade        bool
 }
 
 func summarizeTrades(trades []models.Trade, group tradeSummaryGroup, startDate, endDate string) models.TradeSummary {
 	summary := models.TradeSummary{DateRange: models.TradeSummaryDateRange{Start: startDate, End: endDate}}
-	groups := make(map[string]tradeGroupAccumulator)
+	groups := make(map[string]*tradeGroupAccumulator)
 	keyFunc := tradeSummaryKeyFunc(group)
 	for i := range trades {
 		trade := &trades[i]
@@ -236,7 +247,7 @@ func summarizeTrades(trades []models.Trade, group tradeSummaryGroup, startDate, 
 	return summary
 }
 
-func summarizeTradeGroups(groups map[string]tradeGroupAccumulator) map[string]models.TradeGroupSummary {
+func summarizeTradeGroups(groups map[string]*tradeGroupAccumulator) map[string]models.TradeGroupSummary {
 	summaries := make(map[string]models.TradeGroupSummary, len(groups))
 	for key, acc := range groups {
 		summaries[key] = acc.summary()
@@ -255,8 +266,12 @@ func tradeSummaryKeyFunc(group tradeSummaryGroup) func(*models.Trade) string {
 	}
 }
 
-func addTradeSummaryGroup(groups map[string]tradeGroupAccumulator, key string, trade *models.Trade) {
+func addTradeSummaryGroup(groups map[string]*tradeGroupAccumulator, key string, trade *models.Trade) {
 	acc := groups[key]
+	if acc == nil {
+		acc = &tradeGroupAccumulator{}
+		groups[key] = acc
+	}
 	acc.trades++
 	acc.dollars += trade.Dollars
 	acc.dollarsMultiplier += trade.DollarsMultiplier
@@ -267,10 +282,30 @@ func addTradeSummaryGroup(groups map[string]tradeGroupAccumulator, key string, t
 	if bool(trade.Sweep) {
 		acc.sweep++
 	}
-	groups[key] = acc
+	if bool(trade.ClosingTrade) {
+		acc.closingTrade++
+	}
+	if trade.Dollars > acc.maxDollars {
+		acc.maxDollars = trade.Dollars
+		acc.topPrice = trade.Price
+		acc.topTradeTime = tradeSummaryTradeTime(trade)
+		acc.topDarkPool = bool(trade.DarkPool)
+		acc.topSweep = bool(trade.Sweep)
+		acc.topClosingTrade = bool(trade.ClosingTrade)
+	}
+	if trade.DollarsMultiplier > acc.maxDollarsMultiplier {
+		acc.maxDollarsMultiplier = trade.DollarsMultiplier
+	}
+	if trade.TradeRank > 0 && (!acc.hasTradeRank || trade.TradeRank < acc.minTradeRank) {
+		acc.minTradeRank = trade.TradeRank
+		acc.hasTradeRank = true
+	}
+	if tradeTime := tradeSummaryTradeTime(trade); tradeTime > acc.latestTradeTime {
+		acc.latestTradeTime = tradeTime
+	}
 }
 
-func (acc tradeGroupAccumulator) summary() models.TradeGroupSummary {
+func (acc *tradeGroupAccumulator) summary() models.TradeGroupSummary {
 	if acc.trades == 0 {
 		return models.TradeGroupSummary{}
 	}
@@ -280,8 +315,28 @@ func (acc tradeGroupAccumulator) summary() models.TradeGroupSummary {
 		AvgDollarsMultiplier:      acc.dollarsMultiplier / count,
 		PctDarkPool:               float64(acc.darkPool) / count * 100,
 		PctSweep:                  float64(acc.sweep) / count * 100,
+		PctClosingTrade:           float64(acc.closingTrade) / count * 100,
 		AvgCumulativeDistribution: acc.cumulativeDistribution / count,
+		MaxDollars:                acc.maxDollars,
+		MaxDollarsMultiplier:      acc.maxDollarsMultiplier,
+		MinTradeRank:              acc.minTradeRank,
+		TopPrice:                  acc.topPrice,
+		LatestTradeTime:           acc.latestTradeTime,
+		TopTradeTime:              acc.topTradeTime,
+		TopDarkPool:               acc.topDarkPool,
+		TopSweep:                  acc.topSweep,
+		TopClosingTrade:           acc.topClosingTrade,
 	}
+}
+
+func tradeSummaryTradeTime(trade *models.Trade) string {
+	if trade.FullDateTime != nil && *trade.FullDateTime != "" {
+		return *trade.FullDateTime
+	}
+	if trade.FullTimeString24 != nil && *trade.FullTimeString24 != "" {
+		return *trade.FullTimeString24
+	}
+	return ""
 }
 
 func tradeTickerKey(trade *models.Trade) string {

--- a/internal/cli/trade/trade_test.go
+++ b/internal/cli/trade/trade_test.go
@@ -300,6 +300,12 @@ func TestTradeDashboardFetchesChartOptimizedSections(t *testing.T) {
 	if dashboard.Ticker != "IGV" || dashboard.Count != tradeDashboardDefaultCount {
 		t.Fatalf("dashboard metadata = (%q, %d), want (IGV, %d)", dashboard.Ticker, dashboard.Count, tradeDashboardDefaultCount)
 	}
+	if !slices.Equal(dashboard.RequestedSections, []string{"trades", "clusters", "levels", "clusterBombs"}) {
+		t.Fatalf("dashboard requestedSections = %v, want all sections", dashboard.RequestedSections)
+	}
+	if !slices.Equal(dashboard.ReturnedSections, []string{"trades", "clusters", "levels", "clusterBombs"}) {
+		t.Fatalf("dashboard returnedSections = %v, want all sections", dashboard.ReturnedSections)
+	}
 	if len(dashboard.Trades) != 1 || len(dashboard.Clusters) != 1 || len(dashboard.Levels) != 1 || len(dashboard.ClusterBombs) != 1 {
 		t.Fatalf("dashboard section lengths = trades:%d clusters:%d levels:%d bombs:%d, want all 1", len(dashboard.Trades), len(dashboard.Clusters), len(dashboard.Levels), len(dashboard.ClusterBombs))
 	}
@@ -337,6 +343,122 @@ func TestTradeDashboardFetchesChartOptimizedSections(t *testing.T) {
 	if got := requestsByPath["/Chart0/GetTradeLevels"].Get("length"); got != "-1" {
 		t.Fatalf("levels length = %q, want -1", got)
 	}
+}
+
+func TestTradeDashboardSectionsFetchesOnlyRequestedSections(t *testing.T) {
+	t.Parallel()
+
+	requestsByPath := make(map[string]url.Values)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		params, _ := url.ParseQuery(string(body))
+		requestsByPath[r.URL.Path] = params
+		switch r.URL.Path {
+		case "/Trades/GetTrades":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":1000,"Volume":10}]`)))
+		case "/Chart0/GetTradeLevels":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Price":101.5,"Dollars":3000,"Volume":30,"Trades":3}]`)))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, server.URL)
+	stdout, _, err := testutil.ExecuteCommand(t, cmd, ctx, "dashboard", "IGV", "--sections", "trades,levels", "--start-date", "2025-05-04", "--end-date", "2026-05-04")
+	testutil.AssertErrContains(t, err, "")
+
+	var dashboard models.TradeDashboard
+	if err := json.Unmarshal([]byte(stdout), &dashboard); err != nil {
+		t.Fatalf("failed to unmarshal dashboard: %v\nstdout=%s", err, stdout)
+	}
+	if !slices.Equal(dashboard.RequestedSections, []string{"trades", "levels"}) {
+		t.Fatalf("dashboard requestedSections = %v, want [trades levels]", dashboard.RequestedSections)
+	}
+	if !slices.Equal(dashboard.ReturnedSections, []string{"trades", "levels"}) {
+		t.Fatalf("dashboard returnedSections = %v, want [trades levels]", dashboard.ReturnedSections)
+	}
+	if len(dashboard.Trades) != 1 || len(dashboard.Levels) != 1 || len(dashboard.Clusters) != 0 || len(dashboard.ClusterBombs) != 0 {
+		t.Fatalf("dashboard section lengths = trades:%d clusters:%d levels:%d bombs:%d, want only trades and levels", len(dashboard.Trades), len(dashboard.Clusters), len(dashboard.Levels), len(dashboard.ClusterBombs))
+	}
+	for _, path := range []string{"/TradeClusters/GetTradeClusters", "/TradeClusterBombs/GetTradeClusterBombs"} {
+		if _, ok := requestsByPath[path]; ok {
+			t.Fatalf("dashboard requested unexpected path %s", path)
+		}
+	}
+}
+
+func TestTradeDashboardSummaryReturnsCompactTopRows(t *testing.T) {
+	t.Parallel()
+
+	requestsByPath := make(map[string]url.Values)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		params, _ := url.ParseQuery(string(body))
+		requestsByPath[r.URL.Path] = params
+		switch r.URL.Path {
+		case "/Trades/GetTrades":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[
+				{"Ticker":"IGV","Dollars":1000,"Volume":10,"Price":101,"TradeRank":5,"DarkPool":1,"Sweep":0,"ClosingTrade":1},
+				{"Ticker":"IGV","Dollars":900,"Volume":9,"Price":102,"TradeRank":6},
+				{"Ticker":"IGV","Dollars":800,"Volume":8,"Price":103,"TradeRank":7},
+				{"Ticker":"IGV","Dollars":700,"Volume":7,"Price":104,"TradeRank":8}
+			]`)))
+		case "/Chart0/GetTradeLevels":
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[
+				{"Price":101.5,"Dollars":3000,"Volume":30,"Trades":3},
+				{"Price":102.5,"Dollars":2000,"Volume":20,"Trades":2},
+				{"Price":103.5,"Dollars":1000,"Volume":10,"Trades":1},
+				{"Price":104.5,"Dollars":500,"Volume":5,"Trades":1}
+			]`)))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, server.URL)
+	stdout, _, err := testutil.ExecuteCommand(t, cmd, ctx, "dashboard", "IGV", "--summary", "--sections", "trades,levels", "--count", "5", "--start-date", "2025-05-04", "--end-date", "2026-05-04")
+	testutil.AssertErrContains(t, err, "")
+
+	var dashboard models.TradeDashboardSummary
+	if err := json.Unmarshal([]byte(stdout), &dashboard); err != nil {
+		t.Fatalf("failed to unmarshal dashboard summary: %v\nstdout=%s", err, stdout)
+	}
+	if dashboard.Count != dashboardSummaryMaxRows {
+		t.Fatalf("dashboard summary count = %d, want %d", dashboard.Count, dashboardSummaryMaxRows)
+	}
+	if len(dashboard.Trades) != 3 || len(dashboard.Levels) != 3 || len(dashboard.Clusters) != 0 || len(dashboard.ClusterBombs) != 0 {
+		t.Fatalf("dashboard summary lengths = trades:%d clusters:%d levels:%d bombs:%d, want compact trades and levels only", len(dashboard.Trades), len(dashboard.Clusters), len(dashboard.Levels), len(dashboard.ClusterBombs))
+	}
+	if dashboard.Trades[0].Price != 101 || dashboard.Trades[0].TradeRank != 5 || !bool(dashboard.Trades[0].DarkPool) || !bool(dashboard.Trades[0].ClosingTrade) {
+		t.Fatalf("dashboard summary first trade = %#v", dashboard.Trades[0])
+	}
+	if got := requestsByPath["/Trades/GetTrades"].Get("length"); got != "5" {
+		t.Fatalf("summary trades length = %q, want 5", got)
+	}
+	if got := requestsByPath["/Chart0/GetTradeLevels"].Get("Levels"); got != "5" {
+		t.Fatalf("summary levels Levels = %q, want 5", got)
+	}
+}
+
+func TestTradeDashboardRejectsInvalidSections(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, "http://127.0.0.1")
+	_, _, err := testutil.ExecuteCommand(t, cmd, ctx, "dashboard", "IGV", "--sections", "trades,sector")
+	testutil.AssertErrContains(t, err, "invalid dashboard section")
 }
 
 func TestTradeLevelsUsesChartOptimizedEndpoint(t *testing.T) {
@@ -1344,13 +1466,27 @@ func assertTradeGroupSummaries(t *testing.T, got, want map[string]models.TradeGr
 	if len(got) != len(want) {
 		t.Fatalf("group count = %d, want %d; got %#v", len(got), len(want), got)
 	}
-	for key, wantSummary := range want {
+	for key := range want {
+		wantSummary := want[key]
 		gotSummary, ok := got[key]
 		if !ok {
 			t.Fatalf("group %q missing from %#v", key, got)
 		}
+		gotSummary = legacyTradeGroupSummary(&gotSummary)
 		if gotSummary != wantSummary {
 			t.Fatalf("group %q = %#v, want %#v", key, gotSummary, wantSummary)
 		}
+	}
+}
+
+func legacyTradeGroupSummary(summary *models.TradeGroupSummary) models.TradeGroupSummary {
+	return models.TradeGroupSummary{
+		Trades:                    summary.Trades,
+		Dollars:                   summary.Dollars,
+		AvgDollarsMultiplier:      summary.AvgDollarsMultiplier,
+		PctDarkPool:               summary.PctDarkPool,
+		PctSweep:                  summary.PctSweep,
+		PctClosingTrade:           summary.PctClosingTrade,
+		AvgCumulativeDistribution: summary.AvgCumulativeDistribution,
 	}
 }

--- a/internal/models/dashboard.go
+++ b/internal/models/dashboard.go
@@ -11,11 +11,137 @@ type TradeDashboardDateRange struct {
 // single ticker. It mirrors the browser dashboard sections while adding cluster
 // bombs, which the VolumeLeaders page does not show in the same view.
 type TradeDashboard struct {
-	Ticker       string                  `json:"ticker"`
-	DateRange    TradeDashboardDateRange `json:"dateRange"`
-	Count        int                     `json:"count"`
-	Trades       []TradeListRow          `json:"trades"`
-	Clusters     []TradeCluster          `json:"clusters"`
-	Levels       []TradeLevelRow         `json:"levels"`
-	ClusterBombs []TradeClusterBomb      `json:"clusterBombs"`
+	Ticker            string                  `json:"ticker"`
+	DateRange         TradeDashboardDateRange `json:"dateRange"`
+	Count             int                     `json:"count"`
+	RequestedSections []string                `json:"requestedSections"`
+	ReturnedSections  []string                `json:"returnedSections"`
+	Trades            []TradeListRow          `json:"trades"`
+	Clusters          []TradeCluster          `json:"clusters"`
+	Levels            []TradeLevelRow         `json:"levels"`
+	ClusterBombs      []TradeClusterBomb      `json:"clusterBombs"`
+}
+
+// TradeDashboardSummary is the compact first-pass dashboard shape for agents.
+type TradeDashboardSummary struct {
+	Ticker            string                       `json:"ticker"`
+	DateRange         TradeDashboardDateRange      `json:"dateRange"`
+	Count             int                          `json:"count"`
+	RequestedSections []string                     `json:"requestedSections"`
+	ReturnedSections  []string                     `json:"returnedSections"`
+	Trades            []TradeDashboardTradeSummary `json:"trades"`
+	Clusters          []TradeDashboardCluster      `json:"clusters"`
+	Levels            []TradeLevelRow              `json:"levels"`
+	ClusterBombs      []TradeDashboardClusterBomb  `json:"clusterBombs"`
+}
+
+// TradeDashboardTradeSummary is a compact top trade row for dashboard summary output.
+type TradeDashboardTradeSummary struct {
+	Date              AspNetDate `json:"Date"`
+	FullDateTime      *string    `json:"FullDateTime"`
+	FullTimeString24  *string    `json:"FullTimeString24"`
+	Price             float64    `json:"Price"`
+	Volume            int        `json:"Volume"`
+	Dollars           float64    `json:"Dollars"`
+	DollarsMultiplier float64    `json:"DollarsMultiplier"`
+	TradeRank         int        `json:"TradeRank"`
+	DarkPool          FlexBool   `json:"DarkPool"`
+	Sweep             FlexBool   `json:"Sweep"`
+	ClosingTrade      FlexBool   `json:"ClosingTrade"`
+	TradeConditions   *string    `json:"TradeConditions"`
+}
+
+// TradeDashboardCluster is a compact top cluster row for dashboard summary output.
+type TradeDashboardCluster struct {
+	MinFullDateTime        string  `json:"MinFullDateTime"`
+	MaxFullDateTime        string  `json:"MaxFullDateTime"`
+	MinFullTimeString24    string  `json:"MinFullTimeString24"`
+	MaxFullTimeString24    string  `json:"MaxFullTimeString24"`
+	Price                  float64 `json:"Price"`
+	Dollars                float64 `json:"Dollars"`
+	Volume                 int     `json:"Volume"`
+	TradeCount             int     `json:"TradeCount"`
+	DollarsMultiplier      float64 `json:"DollarsMultiplier"`
+	CumulativeDistribution float64 `json:"CumulativeDistribution"`
+	TradeClusterRank       int     `json:"TradeClusterRank"`
+}
+
+// TradeDashboardClusterBomb is a compact top cluster-bomb row for dashboard summary output.
+type TradeDashboardClusterBomb struct {
+	MinFullDateTime        string  `json:"MinFullDateTime"`
+	MaxFullDateTime        string  `json:"MaxFullDateTime"`
+	MinFullTimeString24    string  `json:"MinFullTimeString24"`
+	MaxFullTimeString24    string  `json:"MaxFullTimeString24"`
+	Dollars                float64 `json:"Dollars"`
+	Volume                 int     `json:"Volume"`
+	TradeCount             int     `json:"TradeCount"`
+	DollarsMultiplier      float64 `json:"DollarsMultiplier"`
+	CumulativeDistribution float64 `json:"CumulativeDistribution"`
+	TradeClusterBombRank   int     `json:"TradeClusterBombRank"`
+}
+
+// NewTradeDashboardTradeSummaries projects full trade rows into compact dashboard summary rows.
+func NewTradeDashboardTradeSummaries(trades []Trade) []TradeDashboardTradeSummary {
+	rows := make([]TradeDashboardTradeSummary, 0, len(trades))
+	for i := range trades {
+		trade := &trades[i]
+		rows = append(rows, TradeDashboardTradeSummary{
+			Date:              trade.Date,
+			FullDateTime:      trade.FullDateTime,
+			FullTimeString24:  trade.FullTimeString24,
+			Price:             trade.Price,
+			Volume:            trade.Volume,
+			Dollars:           trade.Dollars,
+			DollarsMultiplier: trade.DollarsMultiplier,
+			TradeRank:         trade.TradeRank,
+			DarkPool:          trade.DarkPool,
+			Sweep:             trade.Sweep,
+			ClosingTrade:      trade.ClosingTrade,
+			TradeConditions:   trade.TradeConditions,
+		})
+	}
+	return rows
+}
+
+// NewTradeDashboardClusters projects full cluster rows into compact dashboard summary rows.
+func NewTradeDashboardClusters(clusters []TradeCluster) []TradeDashboardCluster {
+	rows := make([]TradeDashboardCluster, 0, len(clusters))
+	for i := range clusters {
+		cluster := &clusters[i]
+		rows = append(rows, TradeDashboardCluster{
+			MinFullDateTime:        cluster.MinFullDateTime,
+			MaxFullDateTime:        cluster.MaxFullDateTime,
+			MinFullTimeString24:    cluster.MinFullTimeString24,
+			MaxFullTimeString24:    cluster.MaxFullTimeString24,
+			Price:                  cluster.Price,
+			Dollars:                cluster.Dollars,
+			Volume:                 cluster.Volume,
+			TradeCount:             cluster.TradeCount,
+			DollarsMultiplier:      cluster.DollarsMultiplier,
+			CumulativeDistribution: cluster.CumulativeDistribution,
+			TradeClusterRank:       cluster.TradeClusterRank,
+		})
+	}
+	return rows
+}
+
+// NewTradeDashboardClusterBombs projects full cluster-bomb rows into compact dashboard summary rows.
+func NewTradeDashboardClusterBombs(clusterBombs []TradeClusterBomb) []TradeDashboardClusterBomb {
+	rows := make([]TradeDashboardClusterBomb, 0, len(clusterBombs))
+	for i := range clusterBombs {
+		clusterBomb := &clusterBombs[i]
+		rows = append(rows, TradeDashboardClusterBomb{
+			MinFullDateTime:        clusterBomb.MinFullDateTime,
+			MaxFullDateTime:        clusterBomb.MaxFullDateTime,
+			MinFullTimeString24:    clusterBomb.MinFullTimeString24,
+			MaxFullTimeString24:    clusterBomb.MaxFullTimeString24,
+			Dollars:                clusterBomb.Dollars,
+			Volume:                 clusterBomb.Volume,
+			TradeCount:             clusterBomb.TradeCount,
+			DollarsMultiplier:      clusterBomb.DollarsMultiplier,
+			CumulativeDistribution: clusterBomb.CumulativeDistribution,
+			TradeClusterBombRank:   clusterBomb.TradeClusterBombRank,
+		})
+	}
+	return rows
 }

--- a/internal/models/trade.go
+++ b/internal/models/trade.go
@@ -257,6 +257,7 @@ type TradeSummary struct {
 	TotalTrades  int                          `json:"totalTrades"`
 	TotalDollars float64                      `json:"totalDollars"`
 	DateRange    TradeSummaryDateRange        `json:"dateRange"`
+	Groups       []TradeSummaryGroup          `json:"groups,omitempty"`
 	ByTicker     map[string]TradeGroupSummary `json:"byTicker,omitempty"`
 	ByDay        map[string]TradeGroupSummary `json:"byDay,omitempty"`
 	ByTickerDay  map[string]TradeGroupSummary `json:"byTickerDay,omitempty"`
@@ -275,7 +276,61 @@ type TradeGroupSummary struct {
 	AvgDollarsMultiplier      float64 `json:"avgDollarsMultiplier"`
 	PctDarkPool               float64 `json:"pctDarkPool"`
 	PctSweep                  float64 `json:"pctSweep"`
+	PctClosingTrade           float64 `json:"pctClosingTrade"`
 	AvgCumulativeDistribution float64 `json:"avgCumulativeDistribution"`
+	MaxDollars                float64 `json:"maxDollars"`
+	MaxDollarsMultiplier      float64 `json:"maxDollarsMultiplier"`
+	MinTradeRank              int     `json:"minTradeRank"`
+	TopPrice                  float64 `json:"topPrice"`
+	LatestTradeTime           string  `json:"latestTradeTime,omitempty"`
+	TopTradeTime              string  `json:"topTradeTime,omitempty"`
+	TopDarkPool               bool    `json:"topDarkPool"`
+	TopSweep                  bool    `json:"topSweep"`
+	TopClosingTrade           bool    `json:"topClosingTrade"`
+}
+
+// TradeSummaryGroup is an ordered summary group for agent-friendly top-N output.
+type TradeSummaryGroup struct {
+	Key                       string  `json:"key"`
+	Trades                    int     `json:"trades"`
+	Dollars                   float64 `json:"dollars"`
+	AvgDollarsMultiplier      float64 `json:"avgDollarsMultiplier"`
+	PctDarkPool               float64 `json:"pctDarkPool"`
+	PctSweep                  float64 `json:"pctSweep"`
+	PctClosingTrade           float64 `json:"pctClosingTrade"`
+	AvgCumulativeDistribution float64 `json:"avgCumulativeDistribution"`
+	MaxDollars                float64 `json:"maxDollars"`
+	MaxDollarsMultiplier      float64 `json:"maxDollarsMultiplier"`
+	MinTradeRank              int     `json:"minTradeRank"`
+	TopPrice                  float64 `json:"topPrice"`
+	LatestTradeTime           string  `json:"latestTradeTime,omitempty"`
+	TopTradeTime              string  `json:"topTradeTime,omitempty"`
+	TopDarkPool               bool    `json:"topDarkPool"`
+	TopSweep                  bool    `json:"topSweep"`
+	TopClosingTrade           bool    `json:"topClosingTrade"`
+}
+
+// NewTradeSummaryGroup copies aggregate metrics into an ordered keyed group.
+func NewTradeSummaryGroup(key string, summary *TradeGroupSummary) TradeSummaryGroup {
+	return TradeSummaryGroup{
+		Key:                       key,
+		Trades:                    summary.Trades,
+		Dollars:                   summary.Dollars,
+		AvgDollarsMultiplier:      summary.AvgDollarsMultiplier,
+		PctDarkPool:               summary.PctDarkPool,
+		PctSweep:                  summary.PctSweep,
+		PctClosingTrade:           summary.PctClosingTrade,
+		AvgCumulativeDistribution: summary.AvgCumulativeDistribution,
+		MaxDollars:                summary.MaxDollars,
+		MaxDollarsMultiplier:      summary.MaxDollarsMultiplier,
+		MinTradeRank:              summary.MinTradeRank,
+		TopPrice:                  summary.TopPrice,
+		LatestTradeTime:           summary.LatestTradeTime,
+		TopTradeTime:              summary.TopTradeTime,
+		TopDarkPool:               summary.TopDarkPool,
+		TopSweep:                  summary.TopSweep,
+		TopClosingTrade:           summary.TopClosingTrade,
+	}
 }
 
 // TradeSentiment summarizes bull/bear leveraged ETF flow over a date range.
@@ -339,5 +394,3 @@ const (
 	TradeSentimentModerateBull TradeSentimentSignal = "moderate_bull"
 	TradeSentimentExtremeBull  TradeSentimentSignal = "extreme_bull"
 )
-
-


### PR DESCRIPTION
## Summary
- Add report summary top-print fields plus sorted, limited `groups` output while keeping existing `byTicker`, `byDay`, and `byTickerDay` maps intact.
- Add `trade dashboard --sections` and `--summary` so agent workflows can fetch only needed sections and receive compact top rows with requested/returned section metadata.
- Update output contracts, command guidance, and tests for the new summary controls.

Fixes #103.
Fixes #104.
Fixes #105.
Fixes #106.

## Verification
- `go test ./internal/cli/report ./internal/cli/trade ./internal/models`
- `make test`
- `make lint`
- `make build`
- LSP diagnostics: 0 errors
- Oracle review: no code blockers
- CodeRabbit: attempted once, but local CLI returned a rate-limit error before review findings were produced