### PR TITLE
fix(cli): show git sha for dev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 .PHONY: build test lint clean install smoke smoke-all release
 
+GIT_SHA := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+LDFLAGS := $(if $(GIT_SHA),-X main.revision=$(GIT_SHA),)
+
 build:
-	go build -o volumeleaders-agent ./cmd/volumeleaders-agent
+	go build $(if $(LDFLAGS),-ldflags "$(LDFLAGS)") -o volumeleaders-agent ./cmd/volumeleaders-agent
 
 test:
 	go test -v ./...
@@ -15,7 +18,7 @@ clean:
 	rm -rf dist/
 
 install:
-	go install ./cmd/volumeleaders-agent
+	go install $(if $(LDFLAGS),-ldflags "$(LDFLAGS)") ./cmd/volumeleaders-agent
 
 smoke: build
 	go run ./cmd/smoke-test

--- a/cmd/volumeleaders-agent/main.go
+++ b/cmd/volumeleaders-agent/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/major/volumeleaders-agent/internal/auth"
@@ -12,8 +13,11 @@ import (
 // version is set at build time via ldflags (see .goreleaser.yml).
 var version = "dev"
 
+// revision is set by local builds so dev binaries identify their source commit.
+var revision = ""
+
 func main() {
-	rootCmd := cli.NewRootCmd(version)
+	rootCmd := cli.NewRootCmd(displayVersion(version, buildRevision()))
 	cli.SetupCLI(rootCmd)
 	cli.ConfigureCompletions(rootCmd)
 	_, err := rootCmd.ExecuteC()
@@ -21,6 +25,41 @@ func main() {
 		fmt.Fprintln(os.Stderr, userFacingError(err))
 		os.Exit(exitCode(err))
 	}
+}
+
+func buildRevision() string {
+	if revision != "" {
+		return revision
+	}
+	return vcsRevision()
+}
+
+func displayVersion(version, revision string) string {
+	if version != "dev" || revision == "" {
+		return version
+	}
+	return fmt.Sprintf("dev-%s", shortRevision(revision))
+}
+
+func shortRevision(revision string) string {
+	const shortLength = 7
+	if len(revision) <= shortLength {
+		return revision
+	}
+	return revision[:shortLength]
+}
+
+func vcsRevision() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
+		}
+	}
+	return ""
 }
 
 func userFacingError(err error) string {

--- a/cmd/volumeleaders-agent/main_test.go
+++ b/cmd/volumeleaders-agent/main_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/major/volumeleaders-agent/internal/auth"
 )
 
+func TestDisplayVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		version  string
+		revision string
+		want     string
+	}{
+		{name: "release version", version: "0.8.1", revision: "1234567890abcdef", want: "0.8.1"},
+		{name: "dev without revision", version: "dev", want: "dev"},
+		{name: "dev with long revision", version: "dev", revision: "1234567890abcdef", want: "dev-1234567"},
+		{name: "dev with short revision", version: "dev", revision: "abc123", want: "dev-abc123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := displayVersion(tt.version, tt.revision); got != tt.want {
+				t.Fatalf("displayVersion(%q, %q) = %q, want %q", tt.version, tt.revision, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUserFacingError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -51,7 +51,7 @@ func NotifyIfDue(ctx context.Context, currentVersion, commandPath string) {
 }
 
 func shouldSkipNotification(currentVersion, commandPath string) bool {
-	if currentVersion == "" || currentVersion == "dev" {
+	if currentVersion == "" || currentVersion == "dev" || strings.HasPrefix(currentVersion, "dev-") {
 		return true
 	}
 	if os.Getenv("CI") != "" {

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -14,6 +14,7 @@ func TestShouldSkipNotification(t *testing.T) {
 		want        bool
 	}{
 		{name: "dev version", version: "dev", commandPath: "volumeleaders-agent trade list", want: true},
+		{name: "dev version with revision", version: "dev-1234567", commandPath: "volumeleaders-agent trade list", want: true},
 		{name: "empty version", version: "", commandPath: "volumeleaders-agent trade list", want: true},
 		{name: "ci", version: "0.8.1", commandPath: "volumeleaders-agent trade list", ci: "true", want: true},
 		{name: "update command", version: "0.8.1", commandPath: "volumeleaders-agent update check", want: true},


### PR DESCRIPTION
## Summary
- Show local dev builds as `dev-<short git sha>` while keeping release versions unchanged.
- Inject the short revision through `make build` and `make install`.
- Keep update notifications skipped for `dev-*` versions.

## Tests
- `go test ./cmd/volumeleaders-agent ./internal/update`
- `make build` (`volumeleaders-agent version dev-5aeaad4` before commit)
- `make test`
- LSP diagnostics on touched Go files
- Read-only Oracle/review pass