### PR TITLE
fix(cli): compact trade dashboard metadata

### DIFF
--- a/internal/cli/outputschema.go
+++ b/internal/cli/outputschema.go
@@ -123,7 +123,7 @@ func allOutputContracts() []outputContract {
 		reportTradeOutputContract("report phantom-trades", "Run the site-vetted phantom trades report."),
 		reportTradeOutputContract("report offsetting-trades", "Run the site-vetted offsetting trades report."),
 
-		objectOutputContract[models.TradeDashboard]("trade dashboard", "Return a fast ticker dashboard with selected trades, clusters, levels, and cluster bombs.", []string{"json"}, []string{"Defaults to a 365-day lookback, all sections, and 10 rows per section.", "--sections limits API calls and output sections; requestedSections and returnedSections record what was requested and fetched."},
+		objectOutputContract[models.TradeDashboard]("trade dashboard", "Return a compact ticker dashboard with shared ticker metadata hoisted above selected trades, clusters, levels, and cluster bombs.", []string{"json"}, []string{"Defaults to a 365-day lookback, all sections, and 10 rows per section.", "--sections limits API calls and output sections; requestedSections and returnedSections record what was requested and fetched."},
 			outputVariant{When: "--summary is set", Formats: []string{"json"}, Schema: objectSchema[models.TradeDashboardSummary](), Notes: []string{"Summary output returns compact top rows for selected sections and caps each section at 3 rows."}},
 		),
 		arrayOutputContract[models.TradeListRow]("trade list", "List individual institutional trades using a compact default row shape.", outputFormats(), nil, nil,

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -335,7 +335,7 @@ func newTradeDashboardCommand() *cobra.Command {
 		Short: "Query a ticker institutional dashboard",
 		Long: `Query a fast ticker dashboard with the same chart-optimized institutional context VolumeLeaders shows in the browser. The dashboard fetches selected sections from the largest trades, trade clusters, trade levels, and cluster bombs for one ticker in a single JSON object.
 
-Defaults to a 365-day lookback, all sections, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Use --sections trades,levels to reduce API calls and token output when only part of the dashboard is needed. Use --summary for first-pass agent workflows; summary mode returns at most three compact top rows per selected section with requestedSections and returnedSections metadata.
+Defaults to a 365-day lookback, all sections, 10 rows per section, --vcd 0, --relative-size 0, and the same broad trade/session filters used by the browser chart page. Dashboard JSON hoists ticker, name, sector, and industry metadata onto the envelope so per-section rows stay compact. Use --sections trades,levels to reduce API calls and token output when only part of the dashboard is needed. Use --summary for first-pass agent workflows; summary mode returns at most three compact top rows per selected section with requestedSections and returnedSections metadata.
 
 Use this command as the first stop for any single-ticker investigation, including institutional levels, largest trades, clustered activity, or sudden bursts, then drill into trade list, trade clusters, trade levels, or trade cluster-bombs only when a section needs deeper pagination, CSV/TSV output, or explicit field selection.
 

--- a/internal/cli/trade/trade_dashboard.go
+++ b/internal/cli/trade/trade_dashboard.go
@@ -151,31 +151,31 @@ func runTradeDashboard(cmd *cobra.Command, opts *tradeDashboardOptions) error {
 	requestedSections := sections.names()
 	dateRange := models.TradeDashboardDateRange{Start: startDate, End: endDate}
 	if opts.Summary {
-		summary := models.TradeDashboardSummary{
-			Ticker:            ticker,
-			DateRange:         dateRange,
-			Count:             outputCount,
-			RequestedSections: requestedSections,
-			ReturnedSections:  returnedSections,
-			Trades:            models.NewTradeDashboardTradeSummaries(limitDashboardRows(trades, outputCount)),
-			Clusters:          models.NewTradeDashboardClusters(limitDashboardRows(clusters, outputCount)),
-			Levels:            models.NewTradeLevelRows(limitDashboardRows(levels, outputCount)),
-			ClusterBombs:      models.NewTradeDashboardClusterBombs(limitDashboardRows(clusterBombs, outputCount)),
-		}
+		summary := models.NewTradeDashboardSummary(
+			ticker,
+			dateRange,
+			outputCount,
+			requestedSections,
+			returnedSections,
+			limitDashboardRows(trades, outputCount),
+			limitDashboardRows(clusters, outputCount),
+			limitDashboardRows(levels, outputCount),
+			limitDashboardRows(clusterBombs, outputCount),
+		)
 		return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), summary)
 	}
 
-	dashboard := models.TradeDashboard{
-		Ticker:            ticker,
-		DateRange:         dateRange,
-		Count:             requestCount,
-		RequestedSections: requestedSections,
-		ReturnedSections:  returnedSections,
-		Trades:            models.NewTradeListRows(trades),
-		Clusters:          models.NewTradeClusterRows(clusters),
-		Levels:            models.NewTradeLevelRows(levels),
-		ClusterBombs:      models.NewTradeClusterBombRows(clusterBombs),
-	}
+	dashboard := models.NewTradeDashboard(
+		ticker,
+		dateRange,
+		requestCount,
+		requestedSections,
+		returnedSections,
+		trades,
+		clusters,
+		levels,
+		clusterBombs,
+	)
 	return common.PrintJSON(cmd.OutOrStdout(), cmd.Context(), dashboard)
 }
 

--- a/internal/cli/trade/trade_test.go
+++ b/internal/cli/trade/trade_test.go
@@ -274,13 +274,13 @@ func TestTradeDashboardFetchesChartOptimizedSections(t *testing.T) {
 		requestsByPath[r.URL.Path] = params
 		switch r.URL.Path {
 		case "/Trades/GetTrades":
-			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":1000,"Volume":10}]`)))
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Name":"iShares Expanded Tech-Software Sector ETF","Sector":"Technology","Industry":"Software","Dollars":1000,"Volume":10}]`)))
 		case "/TradeClusters/GetTradeClusters":
-			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":2000,"Volume":20,"TradeCount":2}]`)))
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Name":"iShares Expanded Tech-Software Sector ETF","Sector":"Technology","Industry":"Software","Dollars":2000,"Volume":20,"TradeCount":2}]`)))
 		case "/Chart0/GetTradeLevels":
 			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Price":101.5,"Dollars":3000,"Volume":30,"Trades":3}]`)))
 		case "/TradeClusterBombs/GetTradeClusterBombs":
-			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Dollars":4000,"Volume":40,"TradeCount":4,"TradeClusterBombRank":1}]`)))
+			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[{"Ticker":"IGV","Name":"iShares Expanded Tech-Software Sector ETF","Sector":"Technology","Industry":"Software","Dollars":4000,"Volume":40,"TradeCount":4,"TradeClusterBombRank":1}]`)))
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -309,6 +309,12 @@ func TestTradeDashboardFetchesChartOptimizedSections(t *testing.T) {
 	if len(dashboard.Trades) != 1 || len(dashboard.Clusters) != 1 || len(dashboard.Levels) != 1 || len(dashboard.ClusterBombs) != 1 {
 		t.Fatalf("dashboard section lengths = trades:%d clusters:%d levels:%d bombs:%d, want all 1", len(dashboard.Trades), len(dashboard.Clusters), len(dashboard.Levels), len(dashboard.ClusterBombs))
 	}
+	if dashboard.Name != "iShares Expanded Tech-Software Sector ETF" || dashboard.Sector != "Technology" || dashboard.Industry == nil || *dashboard.Industry != "Software" {
+		t.Fatalf("dashboard company metadata = %#v, want hoisted IGV metadata", dashboard)
+	}
+	assertDashboardOutputRowsOmitIdentityFields(t, stdout, "trades")
+	assertDashboardOutputRowsOmitIdentityFields(t, stdout, "clusters")
+	assertDashboardOutputRowsOmitIdentityFields(t, stdout, "clusterBombs")
 
 	for _, path := range []string{"/Trades/GetTrades", "/TradeClusters/GetTradeClusters", "/Chart0/GetTradeLevels", "/TradeClusterBombs/GetTradeClusterBombs"} {
 		params, ok := requestsByPath[path]
@@ -342,6 +348,27 @@ func TestTradeDashboardFetchesChartOptimizedSections(t *testing.T) {
 	}
 	if got := requestsByPath["/Chart0/GetTradeLevels"].Get("length"); got != "-1" {
 		t.Fatalf("levels length = %q, want -1", got)
+	}
+}
+
+func assertDashboardOutputRowsOmitIdentityFields(t *testing.T, stdout, section string) {
+	t.Helper()
+
+	var dashboard map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &dashboard); err != nil {
+		t.Fatalf("json.Unmarshal(trade dashboard stdout) error = %v", err)
+	}
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal(dashboard[section], &rows); err != nil {
+		t.Fatalf("json.Unmarshal(trade dashboard %s rows) error = %v", section, err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("trade dashboard %s row count = %d, want 1", section, len(rows))
+	}
+	for _, field := range []string{"Ticker", "Name", "Sector", "Industry"} {
+		if _, ok := rows[0][field]; ok {
+			t.Fatalf("trade dashboard %s row includes identity field %q", section, field)
+		}
 	}
 }
 
@@ -407,7 +434,7 @@ func TestTradeDashboardSummaryReturnsCompactTopRows(t *testing.T) {
 		switch r.URL.Path {
 		case "/Trades/GetTrades":
 			_, _ = w.Write([]byte(testutil.DataTablesJSON(`[
-				{"Ticker":"IGV","Dollars":1000,"Volume":10,"Price":101,"TradeRank":5,"DarkPool":1,"Sweep":0,"ClosingTrade":1},
+				{"Ticker":"IGV","Name":"iShares Expanded Tech-Software Sector ETF","Sector":"Technology","Industry":"Software","Dollars":1000,"Volume":10,"Price":101,"TradeRank":5,"DarkPool":1,"Sweep":0,"ClosingTrade":1},
 				{"Ticker":"IGV","Dollars":900,"Volume":9,"Price":102,"TradeRank":6},
 				{"Ticker":"IGV","Dollars":800,"Volume":8,"Price":103,"TradeRank":7},
 				{"Ticker":"IGV","Dollars":700,"Volume":7,"Price":104,"TradeRank":8}
@@ -437,6 +464,9 @@ func TestTradeDashboardSummaryReturnsCompactTopRows(t *testing.T) {
 	}
 	if dashboard.Count != dashboardSummaryMaxRows {
 		t.Fatalf("dashboard summary count = %d, want %d", dashboard.Count, dashboardSummaryMaxRows)
+	}
+	if dashboard.Name != "iShares Expanded Tech-Software Sector ETF" || dashboard.Sector != "Technology" || dashboard.Industry == nil || *dashboard.Industry != "Software" {
+		t.Fatalf("dashboard summary company metadata = %#v, want hoisted IGV metadata", dashboard)
 	}
 	if len(dashboard.Trades) != 3 || len(dashboard.Levels) != 3 || len(dashboard.Clusters) != 0 || len(dashboard.ClusterBombs) != 0 {
 		t.Fatalf("dashboard summary lengths = trades:%d clusters:%d levels:%d bombs:%d, want compact trades and levels only", len(dashboard.Trades), len(dashboard.Clusters), len(dashboard.Levels), len(dashboard.ClusterBombs))

--- a/internal/models/dashboard.go
+++ b/internal/models/dashboard.go
@@ -11,20 +11,26 @@ type TradeDashboardDateRange struct {
 // single ticker. It mirrors the browser dashboard sections while adding cluster
 // bombs, which the VolumeLeaders page does not show in the same view.
 type TradeDashboard struct {
-	Ticker            string                  `json:"ticker"`
-	DateRange         TradeDashboardDateRange `json:"dateRange"`
-	Count             int                     `json:"count"`
-	RequestedSections []string                `json:"requestedSections"`
-	ReturnedSections  []string                `json:"returnedSections"`
-	Trades            []TradeListRow          `json:"trades"`
-	Clusters          []TradeClusterRow       `json:"clusters"`
-	Levels            []TradeLevelRow         `json:"levels"`
-	ClusterBombs      []TradeClusterBombRow   `json:"clusterBombs"`
+	Ticker            string                         `json:"ticker"`
+	Name              string                         `json:"name,omitempty"`
+	Sector            string                         `json:"sector,omitempty"`
+	Industry          *string                        `json:"industry,omitempty"`
+	DateRange         TradeDashboardDateRange        `json:"dateRange"`
+	Count             int                            `json:"count"`
+	RequestedSections []string                       `json:"requestedSections"`
+	ReturnedSections  []string                       `json:"returnedSections"`
+	Trades            []TradeDashboardTradeRow       `json:"trades"`
+	Clusters          []TradeDashboardClusterRow     `json:"clusters"`
+	Levels            []TradeLevelRow                `json:"levels"`
+	ClusterBombs      []TradeDashboardClusterBombRow `json:"clusterBombs,omitempty"`
 }
 
 // TradeDashboardSummary is the compact first-pass dashboard shape for agents.
 type TradeDashboardSummary struct {
 	Ticker            string                       `json:"ticker"`
+	Name              string                       `json:"name,omitempty"`
+	Sector            string                       `json:"sector,omitempty"`
+	Industry          *string                      `json:"industry,omitempty"`
 	DateRange         TradeDashboardDateRange      `json:"dateRange"`
 	Count             int                          `json:"count"`
 	RequestedSections []string                     `json:"requestedSections"`
@@ -33,6 +39,64 @@ type TradeDashboardSummary struct {
 	Clusters          []TradeDashboardCluster      `json:"clusters"`
 	Levels            []TradeLevelRow              `json:"levels"`
 	ClusterBombs      []TradeDashboardClusterBomb  `json:"clusterBombs"`
+}
+
+// TradeDashboardTradeRow is the dashboard-specific trade projection.
+// Dashboard output already scopes results to one ticker and hoists company
+// metadata onto the envelope, so rows keep only section-specific analysis data.
+type TradeDashboardTradeRow struct {
+	Date                   AspNetDate `json:"Date"`
+	FullDateTime           *string    `json:"FullDateTime"`
+	Price                  float64    `json:"Price"`
+	Volume                 int        `json:"Volume"`
+	Dollars                float64    `json:"Dollars"`
+	DollarsMultiplier      float64    `json:"DollarsMultiplier"`
+	PercentDailyVolume     float64    `json:"PercentDailyVolume"`
+	RelativeSize           float64    `json:"RelativeSize"`
+	CumulativeDistribution float64    `json:"CumulativeDistribution"`
+	TradeRank              int        `json:"TradeRank"`
+	DarkPool               FlexBool   `json:"DarkPool"`
+	Sweep                  FlexBool   `json:"Sweep"`
+	LatePrint              FlexBool   `json:"LatePrint"`
+	SignaturePrint         FlexBool   `json:"SignaturePrint"`
+	OpeningTrade           FlexBool   `json:"OpeningTrade"`
+	ClosingTrade           FlexBool   `json:"ClosingTrade"`
+	PhantomPrint           FlexBool   `json:"PhantomPrint"`
+}
+
+// TradeDashboardClusterRow is the dashboard-specific cluster projection.
+type TradeDashboardClusterRow struct {
+	Date                    AspNetDate `json:"Date"`
+	MinFullDateTime         string     `json:"MinFullDateTime"`
+	MaxFullDateTime         string     `json:"MaxFullDateTime"`
+	ClosePrice              float64    `json:"ClosePrice"`
+	Price                   float64    `json:"Price"`
+	Dollars                 float64    `json:"Dollars"`
+	AverageBlockSizeShares  int        `json:"AverageBlockSizeShares"`
+	AverageBlockSizeDollars float64    `json:"AverageBlockSizeDollars"`
+	Volume                  int        `json:"Volume"`
+	TradeCount              int        `json:"TradeCount"`
+	DollarsMultiplier       float64    `json:"DollarsMultiplier"`
+	CumulativeDistribution  float64    `json:"CumulativeDistribution"`
+	AverageDailyVolume      int        `json:"AverageDailyVolume"`
+	TradeClusterRank        int        `json:"TradeClusterRank"`
+}
+
+// TradeDashboardClusterBombRow is the dashboard-specific cluster-bomb projection.
+type TradeDashboardClusterBombRow struct {
+	Date                    AspNetDate `json:"Date"`
+	MinFullDateTime         string     `json:"MinFullDateTime"`
+	MaxFullDateTime         string     `json:"MaxFullDateTime"`
+	ClosePrice              float64    `json:"ClosePrice"`
+	Dollars                 float64    `json:"Dollars"`
+	AverageBlockSizeShares  int        `json:"AverageBlockSizeShares"`
+	AverageBlockSizeDollars float64    `json:"AverageBlockSizeDollars"`
+	Volume                  int        `json:"Volume"`
+	TradeCount              int        `json:"TradeCount"`
+	DollarsMultiplier       float64    `json:"DollarsMultiplier"`
+	CumulativeDistribution  float64    `json:"CumulativeDistribution"`
+	AverageDailyVolume      int        `json:"AverageDailyVolume"`
+	TradeClusterBombRank    int        `json:"TradeClusterBombRank"`
 }
 
 // TradeDashboardTradeSummary is a compact top trade row for dashboard summary output.
@@ -78,6 +142,150 @@ type TradeDashboardClusterBomb struct {
 	DollarsMultiplier      float64 `json:"DollarsMultiplier"`
 	CumulativeDistribution float64 `json:"CumulativeDistribution"`
 	TradeClusterBombRank   int     `json:"TradeClusterBombRank"`
+}
+
+// NewTradeDashboard builds the compact dashboard response for one ticker.
+func NewTradeDashboard(
+	ticker string,
+	dateRange TradeDashboardDateRange,
+	count int,
+	requestedSections, returnedSections []string,
+	trades []Trade,
+	clusters []TradeCluster,
+	levels []TradeLevel,
+	clusterBombs []TradeClusterBomb,
+) TradeDashboard {
+	dashboard := TradeDashboard{
+		Ticker:            ticker,
+		DateRange:         dateRange,
+		Count:             count,
+		RequestedSections: requestedSections,
+		ReturnedSections:  returnedSections,
+		Trades:            NewTradeDashboardTradeRows(trades),
+		Clusters:          NewTradeDashboardClusterRows(clusters),
+		Levels:            NewTradeLevelRows(levels),
+		ClusterBombs:      NewTradeDashboardClusterBombRows(clusterBombs),
+	}
+	populateTradeDashboardMetadata(&dashboard, trades, clusters, levels, clusterBombs)
+	return dashboard
+}
+
+// NewTradeDashboardSummary builds the compact first-pass dashboard response for one ticker.
+func NewTradeDashboardSummary(
+	ticker string,
+	dateRange TradeDashboardDateRange,
+	count int,
+	requestedSections, returnedSections []string,
+	trades []Trade,
+	clusters []TradeCluster,
+	levels []TradeLevel,
+	clusterBombs []TradeClusterBomb,
+) TradeDashboardSummary {
+	summary := TradeDashboardSummary{
+		Ticker:            ticker,
+		DateRange:         dateRange,
+		Count:             count,
+		RequestedSections: requestedSections,
+		ReturnedSections:  returnedSections,
+		Trades:            NewTradeDashboardTradeSummaries(trades),
+		Clusters:          NewTradeDashboardClusters(clusters),
+		Levels:            NewTradeLevelRows(levels),
+		ClusterBombs:      NewTradeDashboardClusterBombs(clusterBombs),
+	}
+	populateTradeDashboardSummaryMetadata(&summary, trades, clusters, levels, clusterBombs)
+	return summary
+}
+
+// NewTradeDashboardTradeRows projects full API trade rows into dashboard rows.
+func NewTradeDashboardTradeRows(trades []Trade) []TradeDashboardTradeRow {
+	rows := make([]TradeDashboardTradeRow, 0, len(trades))
+	for i := range trades {
+		rows = append(rows, NewTradeDashboardTradeRow(&trades[i]))
+	}
+
+	return rows
+}
+
+// NewTradeDashboardTradeRow projects one full API trade row into a dashboard row.
+func NewTradeDashboardTradeRow(trade *Trade) TradeDashboardTradeRow {
+	return TradeDashboardTradeRow{
+		Date:                   trade.Date,
+		FullDateTime:           trade.FullDateTime,
+		Price:                  trade.Price,
+		Volume:                 trade.Volume,
+		Dollars:                trade.Dollars,
+		DollarsMultiplier:      roundDollarsMultiplier(trade.DollarsMultiplier),
+		PercentDailyVolume:     trade.PercentDailyVolume,
+		RelativeSize:           trade.RelativeSize,
+		CumulativeDistribution: trade.CumulativeDistribution,
+		TradeRank:              trade.TradeRank,
+		DarkPool:               trade.DarkPool,
+		Sweep:                  trade.Sweep,
+		LatePrint:              trade.LatePrint,
+		SignaturePrint:         trade.SignaturePrint,
+		OpeningTrade:           trade.OpeningTrade,
+		ClosingTrade:           trade.ClosingTrade,
+		PhantomPrint:           trade.PhantomPrint,
+	}
+}
+
+// NewTradeDashboardClusterRows projects full API cluster rows into dashboard rows.
+func NewTradeDashboardClusterRows(clusters []TradeCluster) []TradeDashboardClusterRow {
+	rows := make([]TradeDashboardClusterRow, 0, len(clusters))
+	for i := range clusters {
+		rows = append(rows, NewTradeDashboardClusterRow(&clusters[i]))
+	}
+
+	return rows
+}
+
+// NewTradeDashboardClusterRow projects one full API cluster row into a dashboard row.
+func NewTradeDashboardClusterRow(cluster *TradeCluster) TradeDashboardClusterRow {
+	return TradeDashboardClusterRow{
+		Date:                    cluster.Date,
+		MinFullDateTime:         cluster.MinFullDateTime,
+		MaxFullDateTime:         cluster.MaxFullDateTime,
+		ClosePrice:              cluster.ClosePrice,
+		Price:                   cluster.Price,
+		Dollars:                 cluster.Dollars,
+		AverageBlockSizeShares:  cluster.AverageBlockSizeShares,
+		AverageBlockSizeDollars: cluster.AverageBlockSizeDollars,
+		Volume:                  cluster.Volume,
+		TradeCount:              cluster.TradeCount,
+		DollarsMultiplier:       roundDollarsMultiplier(cluster.DollarsMultiplier),
+		CumulativeDistribution:  cluster.CumulativeDistribution,
+		AverageDailyVolume:      cluster.AverageDailyVolume,
+		TradeClusterRank:        cluster.TradeClusterRank,
+	}
+}
+
+// NewTradeDashboardClusterBombRows projects full API cluster-bomb rows into dashboard rows.
+func NewTradeDashboardClusterBombRows(bombs []TradeClusterBomb) []TradeDashboardClusterBombRow {
+	rows := make([]TradeDashboardClusterBombRow, 0, len(bombs))
+	for i := range bombs {
+		rows = append(rows, NewTradeDashboardClusterBombRow(&bombs[i]))
+	}
+
+	return rows
+}
+
+// NewTradeDashboardClusterBombRow projects one full API cluster-bomb row into a dashboard row.
+func NewTradeDashboardClusterBombRow(bomb *TradeClusterBomb) TradeDashboardClusterBombRow {
+	return TradeDashboardClusterBombRow{
+		Date:                    bomb.Date,
+		MinFullDateTime:         bomb.MinFullDateTime,
+		MaxFullDateTime:         bomb.MaxFullDateTime,
+		ClosePrice:              bomb.ClosePrice,
+		Dollars:                 bomb.Dollars,
+		AverageBlockSizeShares:  bomb.AverageBlockSizeShares,
+		AverageBlockSizeDollars: bomb.AverageBlockSizeDollars,
+		Volume:                  bomb.Volume,
+		TradeCount:              bomb.TradeCount,
+		DollarsMultiplier:       roundDollarsMultiplier(bomb.DollarsMultiplier),
+		CumulativeDistribution:  bomb.CumulativeDistribution,
+		AverageDailyVolume:      bomb.AverageDailyVolume,
+		TradeClusterBombRank:    bomb.TradeClusterBombRank,
+	}
 }
 
 // NewTradeDashboardTradeSummaries projects full trade rows into compact dashboard summary rows.
@@ -144,4 +352,73 @@ func NewTradeDashboardClusterBombs(clusterBombs []TradeClusterBomb) []TradeDashb
 		})
 	}
 	return rows
+}
+
+func populateTradeDashboardMetadata(
+	dashboard *TradeDashboard,
+	trades []Trade,
+	clusters []TradeCluster,
+	levels []TradeLevel,
+	clusterBombs []TradeClusterBomb,
+) {
+	mergeTradeDashboardMetadata(&dashboard.Name, &dashboard.Sector, &dashboard.Industry, trades, clusters, levels, clusterBombs)
+}
+
+func populateTradeDashboardSummaryMetadata(
+	summary *TradeDashboardSummary,
+	trades []Trade,
+	clusters []TradeCluster,
+	levels []TradeLevel,
+	clusterBombs []TradeClusterBomb,
+) {
+	mergeTradeDashboardMetadata(&summary.Name, &summary.Sector, &summary.Industry, trades, clusters, levels, clusterBombs)
+}
+
+func mergeTradeDashboardMetadata(
+	name, sector *string,
+	industry **string,
+	trades []Trade,
+	clusters []TradeCluster,
+	levels []TradeLevel,
+	clusterBombs []TradeClusterBomb,
+) {
+	for i := range trades {
+		mergeTradeDashboardMetadataValues(name, sector, industry, trades[i].Name, trades[i].Sector, trades[i].Industry)
+	}
+	for i := range clusters {
+		mergeTradeDashboardMetadataValues(name, sector, industry, clusters[i].Name, clusters[i].Sector, clusters[i].Industry)
+	}
+	for i := range clusterBombs {
+		mergeTradeDashboardMetadataValues(name, sector, industry, clusterBombs[i].Name, clusterBombs[i].Sector, clusterBombs[i].Industry)
+	}
+	for i := range levels {
+		if levels[i].Name != nil {
+			mergeTradeDashboardMetadataValues(name, sector, industry, *levels[i].Name, "", nil)
+		}
+	}
+}
+
+func mergeTradeDashboardMetadataValues(
+	name, sector *string,
+	industry **string,
+	nextName, nextSector string,
+	nextIndustry *string,
+) {
+	if *name == "" {
+		*name = nextName
+	}
+	if *sector == "" {
+		*sector = nextSector
+	}
+	if *industry == nil && nextIndustry != nil && *nextIndustry != "" {
+		*industry = cloneStringPointer(nextIndustry)
+	}
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }

--- a/internal/models/dashboard_test.go
+++ b/internal/models/dashboard_test.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewTradeDashboardHoistsMetadataAndStripsRowIdentity(t *testing.T) {
+	industry := "Software"
+	dashboard := NewTradeDashboard(
+		"IGV",
+		TradeDashboardDateRange{Start: "2025-05-04", End: "2026-05-04"},
+		10,
+		[]string{"trades", "clusters", "clusterBombs"},
+		[]string{"trades", "clusters", "clusterBombs"},
+		[]Trade{{Ticker: "IGV", Name: "iShares Expanded Tech-Software Sector ETF", Sector: "Technology", Industry: &industry, Dollars: 1000, DollarsMultiplier: 1.234, Volume: 10}},
+		[]TradeCluster{{Ticker: "IGV", Name: "iShares Expanded Tech-Software Sector ETF", Sector: "Technology", Industry: &industry, Dollars: 2000, DollarsMultiplier: 2.345, Volume: 20, TradeCount: 2}},
+		nil,
+		[]TradeClusterBomb{{Ticker: "IGV", Name: "iShares Expanded Tech-Software Sector ETF", Sector: "Technology", Industry: &industry, Dollars: 3000, DollarsMultiplier: 3.456, Volume: 30, TradeCount: 3}},
+	)
+
+	if dashboard.Name != "iShares Expanded Tech-Software Sector ETF" || dashboard.Sector != "Technology" || dashboard.Industry == nil || *dashboard.Industry != "Software" {
+		t.Fatalf("NewTradeDashboard metadata = %#v, want hoisted IGV metadata", dashboard)
+	}
+	if dashboard.Trades[0].DollarsMultiplier != 1.23 || dashboard.Clusters[0].DollarsMultiplier != 2.35 || dashboard.ClusterBombs[0].DollarsMultiplier != 3.46 {
+		t.Fatalf("NewTradeDashboard dollars multipliers = (%v, %v, %v), want (1.23, 2.35, 3.46)", dashboard.Trades[0].DollarsMultiplier, dashboard.Clusters[0].DollarsMultiplier, dashboard.ClusterBombs[0].DollarsMultiplier)
+	}
+
+	encoded, err := json.Marshal(dashboard)
+	if err != nil {
+		t.Fatalf("json.Marshal(NewTradeDashboard) error = %v", err)
+	}
+	assertDashboardRowsOmitIdentityFields(t, encoded, "trades")
+	assertDashboardRowsOmitIdentityFields(t, encoded, "clusters")
+	assertDashboardRowsOmitIdentityFields(t, encoded, "clusterBombs")
+}
+
+func TestTradeDashboardOmitsEmptyClusterBombs(t *testing.T) {
+	dashboard := NewTradeDashboard("IGV", TradeDashboardDateRange{Start: "2025-05-04", End: "2026-05-04"}, 10, []string{"trades"}, []string{"trades"}, nil, nil, nil, nil)
+	encoded, err := json.Marshal(dashboard)
+	if err != nil {
+		t.Fatalf("json.Marshal(NewTradeDashboard) error = %v", err)
+	}
+
+	var output map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &output); err != nil {
+		t.Fatalf("json.Unmarshal(NewTradeDashboard) error = %v", err)
+	}
+	if _, ok := output["clusterBombs"]; ok {
+		t.Fatalf("NewTradeDashboard JSON keys include clusterBombs for empty cluster bombs: %s", string(encoded))
+	}
+}
+
+func assertDashboardRowsOmitIdentityFields(t *testing.T, encoded []byte, section string) {
+	t.Helper()
+
+	var dashboard map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &dashboard); err != nil {
+		t.Fatalf("json.Unmarshal(NewTradeDashboard) error = %v", err)
+	}
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal(dashboard[section], &rows); err != nil {
+		t.Fatalf("json.Unmarshal(NewTradeDashboard.%s) error = %v", section, err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("NewTradeDashboard.%s row count = %d, want 1", section, len(rows))
+	}
+	for _, field := range []string{"Ticker", "Name", "Sector", "Industry"} {
+		if _, ok := rows[0][field]; ok {
+			t.Fatalf("NewTradeDashboard.%s includes identity field %q", section, field)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #108.

## Summary
- Hoist dashboard ticker metadata (`name`, `sector`, `industry`) onto the full and summary dashboard envelopes.
- Use dashboard-specific trade, cluster, and cluster-bomb row projections so section rows do not repeat ticker identity fields.
- Omit empty `clusterBombs` from full dashboard JSON and cover compact row behavior with model and CLI regression tests.

## Validation
- `go test ./internal/models -run 'TestNewTradeDashboard|TestTradeDashboard' -v`
- `go test ./internal/cli/trade -run 'TestTradeDashboardFetchesChartOptimizedSections|TestTradeDashboardSummaryReturnsCompactTopRows|TestTradeDashboardSectionsFetchesOnlyRequestedSections' -v`
- `make test`
- `make build`
- `make lint`
- `./volumeleaders-agent outputschema trade dashboard >/tmp/opencode/volumeleaders-dashboard-outputschema-issue108.json`
- `./volumeleaders-agent --jsonschema=tree >/tmp/opencode/volumeleaders-jsonschema-tree-issue108.json`

## CodeRabbit
- Ran `coderabbit review --agent --base origin/main -c .coderabbit.yaml` once as requested. The CLI returned a recoverable rate-limit error before producing findings, so it was not rerun.