### PR TITLE
Fix trade cluster output noise

### DIFF
--- a/internal/cli/common/vldatatables.go
+++ b/internal/cli/common/vldatatables.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/url"
 
 	vlgo "github.com/major/volumeleaders-go/volumeleaders"
 
 	"github.com/spf13/cobra"
 )
+
+const dataTableOrderNameKey = "__volumeleaders_agent_order_name"
 
 // VLFetcher calls a typed vlgo endpoint with the given DataTables request and
 // filters. Each command package defines a thin wrapper that delegates to the
@@ -171,8 +174,29 @@ func NewVLDataTablesRequest(opts DataTableOptions) vlgo.DataTablesRequest {
 		Order: []vlgo.DataTablesOrder{{
 			Column: opts.OrderCol,
 			Dir:    string(opts.OrderDir),
+			Name:   dataTableOrderName(opts.Filters),
 		}},
 	}
+}
+
+// WithDataTableOrderName returns filters annotated with a DataTables order name.
+// The annotation is consumed while constructing the request and is never sent as
+// a VolumeLeaders filter value.
+func WithDataTableOrderName(filters map[string]string, orderName string) map[string]string {
+	if orderName == "" {
+		return filters
+	}
+	annotated := make(map[string]string, len(filters)+1)
+	maps.Copy(annotated, filters)
+	annotated[dataTableOrderNameKey] = orderName
+	return annotated
+}
+
+func dataTableOrderName(filters map[string]string) string {
+	if len(filters) == 0 {
+		return ""
+	}
+	return filters[dataTableOrderNameKey]
 }
 
 // FiltersToValues converts a string map to url.Values for vlgo request filters.
@@ -182,6 +206,9 @@ func FiltersToValues(filters map[string]string) url.Values {
 	}
 	values := make(url.Values, len(filters))
 	for k, v := range filters {
+		if k == dataTableOrderNameKey {
+			continue
+		}
 		values.Set(k, v)
 	}
 	return values

--- a/internal/cli/outputschema.go
+++ b/internal/cli/outputschema.go
@@ -137,7 +137,7 @@ func allOutputContracts() []outputContract {
 			outputVariant{When: "--fields is set or --format is csv or tsv", Formats: outputFormats(), Schema: arraySchema[models.TradeCluster](), FieldSelection: allFieldsSelection[models.TradeCluster](tradeClusterDefaultFields()), Notes: []string{"CSV and TSV include a header row matching the selected fields."}},
 		),
 		arrayOutputContract[models.TradeClusterBombRow]("trade cluster-bombs", "List bursty trade cluster bomb activity using a compact default row shape.", outputFormats(), nil, nil,
-			outputVariant{When: "--format is csv or tsv", Formats: []string{"csv", "tsv"}, Schema: arraySchema[models.TradeClusterBomb](), Notes: []string{"CSV and TSV include a header row for the full row shape."}},
+			outputVariant{When: "--fields is set or --format is csv or tsv", Formats: outputFormats(), Schema: arraySchema[models.TradeClusterBomb](), FieldSelection: allFieldsSelection[models.TradeClusterBomb](tradeClusterBombDefaultFields()), Notes: []string{"CSV and TSV include a header row matching the selected fields."}},
 		),
 		arrayOutputContract[models.TradeAlertRow]("trade alerts", "List system-generated trade alerts for one date using a compact default row shape.", outputFormats(), nil, nil,
 			outputVariant{When: "--format is csv or tsv", Formats: []string{"csv", "tsv"}, Schema: arraySchema[models.TradeAlert](), Notes: []string{"CSV and TSV include a header row for the full row shape."}},
@@ -370,6 +370,21 @@ func tradeClusterDefaultFields() []string {
 		"DollarsMultiplier",
 		"CumulativeDistribution",
 		"TradeClusterRank",
+		"MinFullDateTime",
+		"MaxFullDateTime",
+	}
+}
+
+func tradeClusterBombDefaultFields() []string {
+	return []string{
+		"Date",
+		"Ticker",
+		"Dollars",
+		"Volume",
+		"TradeCount",
+		"DollarsMultiplier",
+		"CumulativeDistribution",
+		"TradeClusterBombRank",
 		"MinFullDateTime",
 		"MaxFullDateTime",
 	}

--- a/internal/cli/report/report.go
+++ b/internal/cli/report/report.go
@@ -76,7 +76,7 @@ func NewCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Long: `Run curated VolumeLeaders trade reports using vetted browser presets. Start here before raw trade list filters: report commands keep the query shape small, documented, and close to the VolumeLeaders site so humans and LLMs do not need to reason about low-level filter parameters.
 
-Reports default to today-only scans and fetch results in the same browser-sized 100-row pages observed from VolumeLeaders. Broad multi-day scans without tickers are rejected to avoid expensive requests and backend timeouts. Add --tickers for multi-day lookbacks, or use trade list --preset only when you need advanced filters that are not exposed by reports.
+Reports default to today-only scans and fetch matching rows internally in fixed-size pages. Broad multi-day scans without tickers are rejected to avoid expensive requests and backend timeouts. Add --tickers for multi-day lookbacks, or use trade list --preset only when you need advanced filters that are not exposed by reports.
 
 PREREQUISITES: Browser authentication must be available.
 
@@ -499,7 +499,7 @@ func reportLong(title, description string) string {
 
 Reports are the recommended entry point for users and LLMs. They expose only safe overrides: tickers, dates, fields, summary grouping, limited ordered summary groups, and output format. Do not hand-build low-level filters unless this curated report cannot answer the question; use trade list --preset as the advanced escape hatch.
 
-Defaults to today only. Multi-day broad scans without tickers are rejected to avoid expensive requests and backend timeouts. Results are fetched in browser-sized 100-row pages and ordered by time descending.
+Defaults to today only. Multi-day broad scans without tickers are rejected to avoid expensive requests and backend timeouts. Results are fetched internally in fixed-size pages and ordered by time descending.
 
 RECOVERY: If the report is too broad, add --tickers or query one day at a time. If a custom filter is truly required, run report list to inspect the vetted filters, then use trade list --preset rather than assembling raw filter flags.`, title, description)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -77,7 +77,7 @@ GLOBAL CONVENTIONS
 
 Dates: YYYY-MM-DD. Commands with date ranges accept either --start-date D --end-date D or --days N. --days counts backward from today unless --end-date is also set, and cannot be combined with --start-date.
 
-Pagination: --start offset, --length count, --length -1 means all rows unless a capped endpoint rejects it. trade list does not expose --length; multi-day lookups whose effective filters include tickers return the top 10 long-period trades with VolumeLeaders' lightweight chart query shape, while trade list --summary, single-day trade scans, all-market trade scans, sector-only presets, trade clusters, and trade cluster-bombs fetch all rows internally in browser-sized 100-row pages. trade level-touches only allows 1 to 50 rows. trade dashboard count and trade levels/level-touches level counts only allow values of 5, 10, 20, or 50.
+Pagination: --start offset, --length count, --length -1 means all rows unless a capped endpoint rejects it. trade list does not expose --length; multi-day lookups whose effective filters include tickers return the top 10 long-period trades with VolumeLeaders' lightweight chart query shape, while trade list --summary, single-day trade scans, all-market trade scans, sector-only presets, trade clusters, and trade cluster-bombs fetch all matching rows internally in fixed-size pages. trade level-touches only allows 1 to 50 rows. trade dashboard count and trade levels/level-touches level counts only allow values of 5, 10, 20, or 50.
 
 Toggle filters: -1 means all/unfiltered, 0 means exclude, 1 means include/only.
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1092,15 +1092,15 @@ func TestOutputSchemaUsesCompactTradeRowsAcrossCommands(t *testing.T) {
 			wantModel:      "TradeClusterRow",
 			wantVariant:    "TradeCluster",
 			variantFormats: []string{"csv", "json", "tsv"},
-			trimmedFields:  []string{"MinFullTimeString24", "MaxFullTimeString24"},
+			trimmedFields:  []string{"MinFullTimeString24", "MaxFullTimeString24", "ClosePrice", "AverageBlockSizeShares", "AverageBlockSizeDollars", "AverageDailyVolume"},
 		},
 		{
 			name:           "trade cluster-bombs",
 			args:           []string{"outputschema", "trade", "cluster-bombs"},
 			wantModel:      "TradeClusterBombRow",
 			wantVariant:    "TradeClusterBomb",
-			variantFormats: []string{"csv", "tsv"},
-			trimmedFields:  []string{"MinFullTimeString24", "MaxFullTimeString24"},
+			variantFormats: []string{"csv", "json", "tsv"},
+			trimmedFields:  []string{"MinFullTimeString24", "MaxFullTimeString24", "ClosePrice", "AverageBlockSizeShares", "AverageBlockSizeDollars", "AverageDailyVolume"},
 		},
 		{
 			name:           "trade alerts",
@@ -1363,21 +1363,37 @@ func TestHelpOutputDisplaysFlagGroups(t *testing.T) {
 		name           string
 		args           []string
 		expectedGroups []string
+		forbidden      []string
 	}{
 		{
 			name:           "trade list help",
 			args:           []string{"trade", "list", "--help"},
 			expectedGroups: []string{"Dates Flags:", "Filters Flags:", "Input Flags:", "Output Flags:", "Pagination Flags:", "Ranges Flags:", "Sessions Flags:"},
+			forbidden:      []string{"\nFlags:\n"},
+		},
+		{
+			name:           "trade clusters help",
+			args:           []string{"trade", "clusters", "--help"},
+			expectedGroups: []string{"Dates Flags:", "Filters Flags:", "Input Flags:", "Output Flags:", "Pagination Flags:", "Ranges Flags:"},
+			forbidden:      []string{"\nFlags:\n", "DataTables", "browser-sized pages"},
+		},
+		{
+			name:           "trade cluster bombs help",
+			args:           []string{"trade", "cluster-bombs", "--help"},
+			expectedGroups: []string{"Dates Flags:", "Filters Flags:", "Input Flags:", "Output Flags:", "Pagination Flags:", "Ranges Flags:"},
+			forbidden:      []string{"\nFlags:\n", "DataTables", "browser-sized pages"},
 		},
 		{
 			name:           "alert create help",
 			args:           []string{"alert", "create", "--help"},
 			expectedGroups: []string{"After-Hours Filters Flags:", "Basic Flags:", "Closing Filters Flags:", "Cluster Filters Flags:", "Total Filters Flags:", "Trade Filters Flags:"},
+			forbidden:      []string{"\nFlags:\n"},
 		},
 		{
 			name:           "watchlist create help",
 			args:           []string{"watchlist", "create", "--help"},
 			expectedGroups: []string{"Basic Flags:", "Filters Flags:", "Print Types Flags:", "Ranges Flags:", "RSI Flags:", "Sessions Flags:", "Venues Flags:"},
+			forbidden:      []string{"\nFlags:\n"},
 		},
 	}
 
@@ -1392,6 +1408,42 @@ func TestHelpOutputDisplaysFlagGroups(t *testing.T) {
 			for _, expected := range tc.expectedGroups {
 				if !strings.Contains(helpText, expected) {
 					t.Fatalf("help output missing %q\nOutput: %s", expected, helpText)
+				}
+			}
+			for _, forbidden := range tc.forbidden {
+				if strings.Contains(helpText, forbidden) {
+					t.Fatalf("help output contains forbidden %q\nOutput: %s", forbidden, helpText)
+				}
+			}
+		})
+	}
+}
+
+func TestHelpOutputAvoidsInternalPaginationTerms(t *testing.T) {
+	t.Parallel()
+	binary := testBinary(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "root help", args: []string{"--help"}},
+		{name: "report help", args: []string{"report", "--help"}},
+		{name: "report preset help", args: []string{"report", "top-100-rank", "--help"}},
+		{name: "trade list help", args: []string{"trade", "list", "--help"}},
+		{name: "volume help", args: []string{"volume", "institutional", "--help"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := exec.Command(binary, tt.args...).CombinedOutput()
+			if err != nil {
+				t.Fatalf("%v failed: %v\nOutput: %s", tt.args, err, out)
+			}
+			helpText := string(out)
+			for _, forbidden := range []string{"DataTables", "browser-sized"} {
+				if strings.Contains(helpText, forbidden) {
+					t.Fatalf("help output contains forbidden %q\nOutput: %s", forbidden, helpText)
 				}
 			}
 		})

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -315,20 +315,55 @@ func installFlagGroupHelp(cmd *cobra.Command) {
 	if len(groups) == 0 {
 		return
 	}
-	defaultHelp := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		defaultHelp(cmd, args)
+		writeGroupedHelp(cmd)
 		for _, group := range groups {
-			fmt.Fprintf(cmd.OutOrStdout(), "\n%s Flags:\n", group)
-			groupFlags := pflag.NewFlagSet(group, pflag.ContinueOnError)
-			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-				if !flag.Hidden && common.FlagGroup(flag) == group {
-					groupFlags.AddFlag(flag)
-				}
-			})
-			fmt.Fprint(cmd.OutOrStdout(), groupFlags.FlagUsagesWrapped(80))
+			writeFlagGroup(cmd, group, func(flag *pflag.Flag) bool { return common.FlagGroup(flag) == group })
+		}
+		writeFlagGroup(cmd, "Other", func(flag *pflag.Flag) bool { return common.FlagGroup(flag) == "" })
+		writeInheritedFlagGroup(cmd)
+	})
+}
+
+func writeGroupedHelp(cmd *cobra.Command) {
+	if cmd.Long != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), cmd.Long)
+	} else if cmd.Short != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), cmd.Short)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nUsage:\n  %s\n", cmd.UseLine())
+	if len(cmd.Aliases) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "\nAliases:\n  %s\n", strings.Join(cmd.Aliases, ", "))
+	}
+	if cmd.Example != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "\nExamples:\n%s\n", cmd.Example)
+	}
+}
+
+func writeFlagGroup(cmd *cobra.Command, name string, include func(*pflag.Flag) bool) {
+	groupFlags := pflag.NewFlagSet(name, pflag.ContinueOnError)
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		if !flag.Hidden && include(flag) {
+			groupFlags.AddFlag(flag)
 		}
 	})
+	if groupFlags.HasFlags() {
+		fmt.Fprintf(cmd.OutOrStdout(), "\n%s Flags:\n", name)
+		fmt.Fprint(cmd.OutOrStdout(), groupFlags.FlagUsagesWrapped(80))
+	}
+}
+
+func writeInheritedFlagGroup(cmd *cobra.Command) {
+	inherited := pflag.NewFlagSet("Global", pflag.ContinueOnError)
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if !flag.Hidden {
+			inherited.AddFlag(flag)
+		}
+	})
+	if inherited.HasFlags() {
+		fmt.Fprint(cmd.OutOrStdout(), "\nGlobal Flags:\n")
+		fmt.Fprint(cmd.OutOrStdout(), inherited.FlagUsagesWrapped(80))
+	}
 }
 
 func flagGroupNames(cmd *cobra.Command) []string {

--- a/internal/cli/trade/trade.go
+++ b/internal/cli/trade/trade.go
@@ -33,6 +33,19 @@ var tradeClusterDefaultFields = []string{
 	"MaxFullDateTime",
 }
 
+var tradeClusterBombDefaultFields = []string{
+	"Date",
+	"Ticker",
+	"Dollars",
+	"Volume",
+	"TradeCount",
+	"DollarsMultiplier",
+	"CumulativeDistribution",
+	"TradeClusterBombRank",
+	"MinFullDateTime",
+	"MaxFullDateTime",
+}
+
 type tradesOptions struct {
 	tickers, startDate, endDate, sector            string
 	minVolume, maxVolume                           int
@@ -152,16 +165,16 @@ type tradeFilterFlags struct {
 }
 
 type tradePaginationFlags struct {
-	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
+	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"Result offset for paged requests"`
 	Length   int                   `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
-	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
-	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
+	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Legacy order column index; prefer field-name sorting where available"`
+	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction: asc or desc"`
 }
 
 type tradeFixedPageFlags struct {
-	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
-	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
-	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`
+	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"Result offset for paged requests"`
+	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Legacy order column index; prefer --sort for commands that expose it"`
+	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction: asc or desc"`
 }
 
 type tradeFormatFlag struct {
@@ -202,12 +215,13 @@ type tradeClustersOptions struct {
 	tradeTickersFlag
 	tradeDateRangeFlags
 	tradeRangeFlags
-	VCD              int    `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
-	SecurityType     int    `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key"`
-	RelativeSize     int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
-	TradeClusterRank int    `flag:"trade-cluster-rank" flaggroup:"Filters" flagdescr:"Trade cluster rank filter"`
+	VCD              int    `flag:"vcd" flaggroup:"Filters" flagdescr:"Volume confirmation distribution score filter; 0 means unfiltered, higher scores are stricter"`
+	SecurityType     int    `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key; -1 means all securities, 0 means the site default common-stock filter"`
+	RelativeSize     int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Minimum relative-size threshold; default 5"`
+	TradeClusterRank int    `flag:"trade-cluster-rank" flaggroup:"Filters" flagdescr:"Maximum cluster rank to include; -1 means all ranks"`
 	Sector           string `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
 	Fields           string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated TradeCluster fields to include in output, or 'all' for every field"`
+	Sort             string `flag:"sort" flaggroup:"Pagination" flagdescr:"Sort field name: Date, Price, Dollars, Volume, TradeCount, DollarsMultiplier, CumulativeDistribution, or TradeClusterRank"`
 	tradeFormatFlag
 	tradeFixedPageFlags
 }
@@ -216,11 +230,13 @@ type tradeClusterBombsOptions struct {
 	tradeTickersFlag
 	tradeDateRangeFlags
 	tradeVolumeDollarRangeFlags
-	VCD                  int    `flag:"vcd" flaggroup:"Filters" flagdescr:"VCD filter"`
-	SecurityType         int    `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key"`
-	RelativeSize         int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Relative size threshold"`
-	TradeClusterBombRank int    `flag:"trade-cluster-bomb-rank" flaggroup:"Filters" flagdescr:"Trade cluster bomb rank filter"`
+	VCD                  int    `flag:"vcd" flaggroup:"Filters" flagdescr:"Volume confirmation distribution score filter; 0 means unfiltered, higher scores are stricter"`
+	SecurityType         int    `flag:"security-type" flaggroup:"Filters" flagdescr:"Security type key; -1 means all securities, 0 means the site default common-stock filter"`
+	RelativeSize         int    `flag:"relative-size" flaggroup:"Filters" flagdescr:"Minimum relative-size threshold; default 0 means unfiltered for cluster bombs"`
+	TradeClusterBombRank int    `flag:"trade-cluster-bomb-rank" flaggroup:"Filters" flagdescr:"Maximum cluster bomb rank to include; -1 means all ranks"`
 	Sector               string `flag:"sector" flaggroup:"Input" flagdescr:"Sector/Industry filter"`
+	Fields               string `flag:"fields" flaggroup:"Output" flagdescr:"Comma-separated TradeClusterBomb fields to include in output, or 'all' for every field"`
+	Sort                 string `flag:"sort" flaggroup:"Pagination" flagdescr:"Sort field name: Date, Dollars, Volume, TradeCount, DollarsMultiplier, CumulativeDistribution, or TradeClusterBombRank"`
 	tradeFormatFlag
 	tradeFixedPageFlags
 }
@@ -400,7 +416,7 @@ Shared trade filters include volume, price, dollars, conditions, VCD, relative s
 
 PREREQUISITES: Browser authentication. For reproducible scans, pass explicit dates or --days plus tickers, preset, watchlist, or sector filters.
 
-RECOVERY: Multi-day lookups whose effective filters include tickers return the top 10 long-period trades with the same lightweight chart query shape VolumeLeaders uses in the browser. Single-day scans, all-market scans, sector-only presets, and --summary still fetch all matching rows in browser-sized 100-row pages. If --summary rejects --fields or --format, rerun summary as JSON without --fields. If date flags conflict, use either --days or --start-date with --end-date.
+RECOVERY: Multi-day lookups whose effective filters include tickers return the top 10 long-period trades with the same lightweight chart query shape VolumeLeaders uses in the browser. Single-day scans, all-market scans, sector-only presets, and --summary still fetch all matching rows internally in fixed-size pages. If --summary rejects --fields or --format, rerun summary as JSON without --fields. If date flags conflict, use either --days or --start-date with --end-date.
 
 NEXT STEPS: Use trade dashboard first for any single-ticker investigation, then trade levels for level-only support/resistance output, trade clusters when prints concentrate near a price, or trade sentiment for leveraged ETF bull/bear context.`,
 		Example: `volumeleaders-agent trade list AAPL MSFT
@@ -460,7 +476,7 @@ func newTradeClustersCommand() *cobra.Command {
 		Long: `Query aggregated trade clusters, which group multiple trades in a short window into a single cluster record. Filterable by ticker, date range, dollar amounts, sector, and trade cluster rank. Outputs compact JSON or CSV/TSV with --format.
 
 
-Results are fetched in browser-sized 100-row pages to match VolumeLeaders' frontend behavior. Use clusters when the question is about price-level concentration, not single prints. This command uses larger default dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price.`,
+Default JSON is compact and omits fields VolumeLeaders leaves empty for this endpoint. Use --fields FIELD1,FIELD2, --fields all, CSV, or TSV when raw API fields are needed. Use --sort with a field name such as Dollars or TradeClusterRank instead of the legacy --order-col index. Use clusters when the question is about price-level concentration, not single prints. This command uses larger default dollar thresholds than ordinary trade list. Use trade cluster-bombs instead when looking for sudden aggressive bursts tightly grouped in time and price.`,
 		Example:    "volumeleaders-agent trade clusters AAPL --days 7",
 		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"cluster", "clsters"},
@@ -484,7 +500,7 @@ func newTradeClusterBombsCommand() *cobra.Command {
 		Short: "Query trade cluster bombs",
 		Long: `Query trade cluster bombs, which are extreme-magnitude trade clusters that exceed normal institutional activity thresholds. Filterable by ticker, date range, dollar amounts, sector, and cluster bomb rank. Outputs compact JSON by default.
 
-Results are fetched in browser-sized 100-row pages to match VolumeLeaders' frontend behavior. Cluster bombs find sudden aggressive bursts tightly grouped in time and price, with different defaults and rank fields than trade clusters. Use this command when looking for extreme concentration events, not general price-level clustering.`,
+Default JSON is compact and omits fields VolumeLeaders leaves empty for this endpoint. Use --fields FIELD1,FIELD2, --fields all, CSV, or TSV when raw API fields are needed. Use --sort with a field name such as Dollars or TradeClusterBombRank instead of the legacy --order-col index. Cluster bombs find sudden aggressive bursts tightly grouped in time and price, with different defaults and rank fields than trade clusters. Use this command when looking for extreme concentration events, not general price-level clustering.`,
 		Example:    "volumeleaders-agent trade cluster-bombs TSLA --days 3",
 		Args:       cobra.ArbitraryArgs,
 		SuggestFor: []string{"clusterbombs", "cluster-bomb"},

--- a/internal/cli/trade/trade_clusters.go
+++ b/internal/cli/trade/trade_clusters.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
+	"strings"
 
 	vlgo "github.com/major/volumeleaders-go/volumeleaders"
 	"github.com/spf13/cobra"
@@ -21,9 +23,13 @@ func runTradeClusters(cmd *cobra.Command, opts *tradeClustersOptions) error {
 	if err != nil {
 		return fmt.Errorf("parsing fields flag: %w", err)
 	}
+	orderCol, orderName, err := tradeClusterSort(opts.Sort, opts.OrderCol)
+	if err != nil {
+		return fmt.Errorf("parsing sort flag: %w", err)
+	}
 	rangeFilters := tradeClusterRangeFilters(cmd, opts, startDate, endDate)
-	filters := rangeFilters.clusterMap(opts.SecurityType, opts.RelativeSize, opts.TradeClusterRank)
-	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Fields: fields, Filters: filters})
+	filters := common.WithDataTableOrderName(rangeFilters.clusterMap(opts.SecurityType, opts.RelativeSize, opts.TradeClusterRank), orderName)
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: orderCol, OrderDir: opts.OrderDir, Fields: fields, Filters: filters})
 	if opts.Fields == "" && opts.Format == common.OutputFormatJSON {
 		return runTradeClustersCompact(cmd, dtOpts)
 	}
@@ -35,10 +41,22 @@ func runTradeClusterBombs(cmd *cobra.Command, opts *tradeClusterBombsOptions) er
 	if err != nil {
 		return err
 	}
+	fields, err := common.OutputFields[models.TradeClusterBomb](opts.Fields, tradeClusterBombDefaultFields)
+	if err != nil {
+		return fmt.Errorf("parsing fields flag: %w", err)
+	}
+	outputFields := fields
+	if opts.Fields == "" && opts.Format == common.OutputFormatJSON {
+		outputFields = nil
+	}
+	orderCol, orderName, err := tradeClusterBombSort(opts.Sort, opts.OrderCol)
+	if err != nil {
+		return fmt.Errorf("parsing sort flag: %w", err)
+	}
 	rangeFilters := tradeClusterBombRangeFilters(cmd, opts, startDate, endDate)
-	filters := rangeFilters.clusterBombMap(opts.SecurityType, opts.RelativeSize, opts.TradeClusterBombRank)
-	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: opts.OrderCol, OrderDir: opts.OrderDir, Filters: filters})
-	if opts.Format != common.OutputFormatJSON {
+	filters := common.WithDataTableOrderName(rangeFilters.clusterBombMap(opts.SecurityType, opts.RelativeSize, opts.TradeClusterBombRank), orderName)
+	dtOpts := common.NewDataTableOptions(common.DataTableRequestConfig{Start: opts.Start, Length: -1, OrderCol: orderCol, OrderDir: opts.OrderDir, Fields: outputFields, Filters: filters})
+	if opts.Fields != "" || opts.Format != common.OutputFormatJSON {
 		return common.RunVLDataTablesCommandWithPageSize(cmd, dtOpts, opts.Format, tradeBrowserPageLength, "query trade cluster bombs", fetchTradeClusterBombs, common.MapVLTradeClusterBomb)
 	}
 	return common.RunVLDataTablesCommandWithPageSize(cmd, dtOpts, opts.Format, tradeBrowserPageLength, "query trade cluster bombs", fetchTradeClusterBombs, mapVLTradeClusterBombRow)
@@ -114,4 +132,46 @@ func tradeClusterRangeFilters(cmd *cobra.Command, opts *tradeClustersOptions, st
 
 func tradeClusterBombRangeFilters(cmd *cobra.Command, opts *tradeClusterBombsOptions, startDate, endDate string) tradeRangeFilters {
 	return tradeRangeFilters{Tickers: common.MultiTickerValue(cmd), StartDate: startDate, EndDate: endDate, MinVolume: opts.MinVolume, MaxVolume: opts.MaxVolume, MinDollars: opts.MinDollars, MaxDollars: opts.MaxDollars, VCD: opts.VCD, Sector: opts.Sector}
+}
+
+func tradeClusterSort(sortField string, legacyOrderCol int) (orderCol int, orderName string, err error) {
+	return namedTradeClusterSort(sortField, legacyOrderCol, map[string]int{
+		"Date":                   0,
+		"Price":                  1,
+		"TradeCount":             2,
+		"Volume":                 3,
+		"Dollars":                4,
+		"DollarsMultiplier":      5,
+		"CumulativeDistribution": 6,
+		"TradeClusterRank":       7,
+	})
+}
+
+func tradeClusterBombSort(sortField string, legacyOrderCol int) (orderCol int, orderName string, err error) {
+	return namedTradeClusterSort(sortField, legacyOrderCol, map[string]int{
+		"Date":                   0,
+		"TradeCount":             1,
+		"Volume":                 2,
+		"Dollars":                3,
+		"DollarsMultiplier":      4,
+		"CumulativeDistribution": 5,
+		"TradeClusterBombRank":   6,
+	})
+}
+
+func namedTradeClusterSort(sortField string, legacyOrderCol int, columns map[string]int) (orderCol int, orderName string, err error) {
+	if strings.TrimSpace(sortField) == "" {
+		return legacyOrderCol, "", nil
+	}
+	for field, column := range columns {
+		if strings.EqualFold(sortField, field) {
+			return column, field, nil
+		}
+	}
+	valid := make([]string, 0, len(columns))
+	for field := range columns {
+		valid = append(valid, field)
+	}
+	slices.Sort(valid)
+	return 0, "", fmt.Errorf("invalid --sort %q; valid fields: %s", sortField, strings.Join(valid, ","))
 }

--- a/internal/cli/trade/trade_test.go
+++ b/internal/cli/trade/trade_test.go
@@ -893,6 +893,147 @@ func TestTradeClusterCommandsFetchBrowserSizedPages(t *testing.T) {
 	}
 }
 
+func TestTradeClusterCommandsSupportNamedSort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		args            []string
+		path            string
+		wantOrderColumn string
+		wantOrderName   string
+	}{
+		{
+			name:            "clusters",
+			args:            []string{"clusters", "AAPL", "--days", "1", "--sort", "Dollars"},
+			path:            "/TradeClusters/GetTradeClusters",
+			wantOrderColumn: "4",
+			wantOrderName:   "Dollars",
+		},
+		{
+			name:            "cluster bombs",
+			args:            []string{"cluster-bombs", "AAPL", "--days", "1", "--sort", "TradeClusterBombRank"},
+			path:            "/TradeClusterBombs/GetTradeClusterBombs",
+			wantOrderColumn: "6",
+			wantOrderName:   "TradeClusterBombRank",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.path {
+					t.Errorf("path = %q, want %s", r.URL.Path, tt.path)
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+				}
+				got, _ = url.ParseQuery(string(body))
+				_, _ = w.Write([]byte(testutil.DataTablesJSONPage("[]", 0)))
+			}))
+			t.Cleanup(server.Close)
+
+			cmd := NewCmd()
+			ctx := testutil.ContextWithTestClient(t, server.URL)
+			_, _, err := testutil.ExecuteCommand(t, cmd, ctx, tt.args...)
+			testutil.AssertErrContains(t, err, "")
+			if got.Get("order[0][column]") != tt.wantOrderColumn {
+				t.Fatalf("order[0][column] = %q, want %s", got.Get("order[0][column]"), tt.wantOrderColumn)
+			}
+			if got.Get("order[0][name]") != tt.wantOrderName {
+				t.Fatalf("order[0][name] = %q, want %s", got.Get("order[0][name]"), tt.wantOrderName)
+			}
+			if got.Has("__volumeleaders_agent_order_name") {
+				t.Fatalf("request leaked internal order annotation: %v", got)
+			}
+		})
+	}
+}
+
+func TestTradeClusterBombsDefaultJSONMatchesCompactSchema(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/TradeClusterBombs/GetTradeClusterBombs" {
+			t.Errorf("path = %q, want /TradeClusterBombs/GetTradeClusterBombs", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(testutil.DataTablesJSON(`[
+			{"Date":"/Date(1745366400000)/","Ticker":"AAPL","Sector":"Technology","Industry":"Hardware","Name":"Apple Inc.","Dollars":1000000,"Volume":50000,"TradeCount":4,"DollarsMultiplier":1.2345,"CumulativeDistribution":0.99,"TradeClusterBombRank":4,"ClosePrice":0,"AverageBlockSizeShares":0,"AverageBlockSizeDollars":0,"AverageDailyVolume":0}
+		]`)))
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, server.URL)
+	stdout, _, err := testutil.ExecuteCommand(t, cmd, ctx, "cluster-bombs", "AAPL", "--days", "1")
+	testutil.AssertErrContains(t, err, "")
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("failed to unmarshal cluster-bombs output: %v\nstdout=%s", err, stdout)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	for _, field := range []string{"Sector", "Industry", "Name"} {
+		if _, ok := rows[0][field]; !ok {
+			t.Fatalf("default cluster-bombs output missing compact field %q: %#v", field, rows[0])
+		}
+	}
+	for _, field := range []string{"ClosePrice", "AverageBlockSizeShares", "AverageBlockSizeDollars", "AverageDailyVolume"} {
+		if _, ok := rows[0][field]; ok {
+			t.Fatalf("default cluster-bombs output includes noisy field %q: %#v", field, rows[0])
+		}
+	}
+}
+
+func TestTradeClusterBombsSupportsFieldSelection(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/TradeClusterBombs/GetTradeClusterBombs" {
+			t.Errorf("path = %q, want /TradeClusterBombs/GetTradeClusterBombs", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(testutil.DataTablesJSON(`[
+			{"Ticker":"AAPL","Dollars":1000000,"Volume":50000,"TradeClusterBombRank":4}
+		]`)))
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, server.URL)
+	stdout, _, err := testutil.ExecuteCommand(t, cmd, ctx, "cluster-bombs", "AAPL", "--days", "1", "--fields", "Ticker,Dollars")
+	testutil.AssertErrContains(t, err, "")
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("failed to unmarshal cluster-bombs output: %v\nstdout=%s", err, stdout)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	for _, field := range []string{"Ticker", "Dollars"} {
+		if _, ok := rows[0][field]; !ok {
+			t.Fatalf("selected cluster-bomb output missing field %q: %#v", field, rows[0])
+		}
+	}
+	if _, ok := rows[0]["Volume"]; ok {
+		t.Fatalf("selected cluster-bomb output includes unselected Volume field: %#v", rows[0])
+	}
+}
+
+func TestTradeClusterCommandsRejectInvalidSort(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCmd()
+	ctx := testutil.ContextWithTestClient(t, "http://127.0.0.1")
+	_, _, err := testutil.ExecuteCommand(t, cmd, ctx, "clusters", "AAPL", "--days", "1", "--sort", "ClosePrice")
+	testutil.AssertErrContains(t, err, "invalid --sort \"ClosePrice\"")
+}
+
 func TestTradeLevelTouchesCapsLengthAndTradeLevelCount(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/volume/volume.go
+++ b/internal/cli/volume/volume.go
@@ -16,7 +16,7 @@ type volumeOptions struct {
 	Date     string                `flag:"date" flaggroup:"Dates" flagshort:"d" flagdescr:"Date YYYY-MM-DD" flagrequired:"true"`
 	Tickers  string                `flag:"tickers" flaggroup:"Input" flagshort:"t" flagdescr:"Comma-separated ticker symbols"`
 	Format   common.OutputFormat   `flag:"format" flaggroup:"Output" flagshort:"f" default:"json" flagdescr:"Output format: json, csv, or tsv"`
-	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"DataTables start offset"`
+	Start    int                   `flag:"start" flaggroup:"Pagination" flagdescr:"Result offset for paged requests"`
 	Length   int                   `flag:"length" flaggroup:"Pagination" flagshort:"l" flagdescr:"Number of results"`
 	OrderCol int                   `flag:"order-col" flaggroup:"Pagination" flagdescr:"Order column index"`
 	OrderDir common.OrderDirection `flag:"order-dir" flaggroup:"Pagination" flagdescr:"Order direction"`

--- a/internal/models/trade_cluster.go
+++ b/internal/models/trade_cluster.go
@@ -39,24 +39,20 @@ type TradeCluster struct {
 
 // TradeClusterRow is the compact default JSON shape for trade cluster output.
 type TradeClusterRow struct {
-	Date                    AspNetDate `json:"Date"`
-	Ticker                  string     `json:"Ticker"`
-	Sector                  string     `json:"Sector"`
-	Industry                *string    `json:"Industry"`
-	Name                    string     `json:"Name"`
-	MinFullDateTime         string     `json:"MinFullDateTime"`
-	MaxFullDateTime         string     `json:"MaxFullDateTime"`
-	ClosePrice              float64    `json:"ClosePrice"`
-	Price                   float64    `json:"Price"`
-	Dollars                 float64    `json:"Dollars"`
-	AverageBlockSizeShares  int        `json:"AverageBlockSizeShares"`
-	AverageBlockSizeDollars float64    `json:"AverageBlockSizeDollars"`
-	Volume                  int        `json:"Volume"`
-	TradeCount              int        `json:"TradeCount"`
-	DollarsMultiplier       float64    `json:"DollarsMultiplier"`
-	CumulativeDistribution  float64    `json:"CumulativeDistribution"`
-	AverageDailyVolume      int        `json:"AverageDailyVolume"`
-	TradeClusterRank        int        `json:"TradeClusterRank"`
+	Date                   string  `json:"Date"`
+	Ticker                 string  `json:"Ticker"`
+	Sector                 string  `json:"Sector"`
+	Industry               *string `json:"Industry"`
+	Name                   string  `json:"Name"`
+	MinFullDateTime        string  `json:"MinFullDateTime"`
+	MaxFullDateTime        string  `json:"MaxFullDateTime"`
+	Price                  float64 `json:"Price"`
+	Dollars                float64 `json:"Dollars"`
+	Volume                 int     `json:"Volume"`
+	TradeCount             int     `json:"TradeCount"`
+	DollarsMultiplier      float64 `json:"DollarsMultiplier"`
+	CumulativeDistribution float64 `json:"CumulativeDistribution"`
+	TradeClusterRank       int     `json:"TradeClusterRank"`
 }
 
 // NewTradeClusterRows projects full API cluster rows into compact output rows.
@@ -72,24 +68,20 @@ func NewTradeClusterRows(clusters []TradeCluster) []TradeClusterRow {
 // NewTradeClusterRow projects one full API cluster row into a compact output row.
 func NewTradeClusterRow(cluster *TradeCluster) TradeClusterRow {
 	return TradeClusterRow{
-		Date:                    cluster.Date,
-		Ticker:                  cluster.Ticker,
-		Sector:                  cluster.Sector,
-		Industry:                cluster.Industry,
-		Name:                    cluster.Name,
-		MinFullDateTime:         cluster.MinFullDateTime,
-		MaxFullDateTime:         cluster.MaxFullDateTime,
-		ClosePrice:              cluster.ClosePrice,
-		Price:                   cluster.Price,
-		Dollars:                 cluster.Dollars,
-		AverageBlockSizeShares:  cluster.AverageBlockSizeShares,
-		AverageBlockSizeDollars: cluster.AverageBlockSizeDollars,
-		Volume:                  cluster.Volume,
-		TradeCount:              cluster.TradeCount,
-		DollarsMultiplier:       roundDollarsMultiplier(cluster.DollarsMultiplier),
-		CumulativeDistribution:  cluster.CumulativeDistribution,
-		AverageDailyVolume:      cluster.AverageDailyVolume,
-		TradeClusterRank:        cluster.TradeClusterRank,
+		Date:                   compactDate(cluster.Date),
+		Ticker:                 cluster.Ticker,
+		Sector:                 cluster.Sector,
+		Industry:               cluster.Industry,
+		Name:                   cluster.Name,
+		MinFullDateTime:        cluster.MinFullDateTime,
+		MaxFullDateTime:        cluster.MaxFullDateTime,
+		Price:                  cluster.Price,
+		Dollars:                cluster.Dollars,
+		Volume:                 cluster.Volume,
+		TradeCount:             cluster.TradeCount,
+		DollarsMultiplier:      roundDollarsMultiplier(cluster.DollarsMultiplier),
+		CumulativeDistribution: cluster.CumulativeDistribution,
+		TradeClusterRank:       cluster.TradeClusterRank,
 	}
 }
 
@@ -131,23 +123,19 @@ type TradeClusterBomb struct {
 
 // TradeClusterBombRow is the compact default JSON shape for cluster bomb output.
 type TradeClusterBombRow struct {
-	Date                    AspNetDate `json:"Date"`
-	Ticker                  string     `json:"Ticker"`
-	Sector                  string     `json:"Sector"`
-	Industry                *string    `json:"Industry"`
-	Name                    string     `json:"Name"`
-	MinFullDateTime         string     `json:"MinFullDateTime"`
-	MaxFullDateTime         string     `json:"MaxFullDateTime"`
-	ClosePrice              float64    `json:"ClosePrice"`
-	Dollars                 float64    `json:"Dollars"`
-	AverageBlockSizeShares  int        `json:"AverageBlockSizeShares"`
-	AverageBlockSizeDollars float64    `json:"AverageBlockSizeDollars"`
-	Volume                  int        `json:"Volume"`
-	TradeCount              int        `json:"TradeCount"`
-	DollarsMultiplier       float64    `json:"DollarsMultiplier"`
-	CumulativeDistribution  float64    `json:"CumulativeDistribution"`
-	AverageDailyVolume      int        `json:"AverageDailyVolume"`
-	TradeClusterBombRank    int        `json:"TradeClusterBombRank"`
+	Date                   string  `json:"Date"`
+	Ticker                 string  `json:"Ticker"`
+	Sector                 string  `json:"Sector"`
+	Industry               *string `json:"Industry"`
+	Name                   string  `json:"Name"`
+	MinFullDateTime        string  `json:"MinFullDateTime"`
+	MaxFullDateTime        string  `json:"MaxFullDateTime"`
+	Dollars                float64 `json:"Dollars"`
+	Volume                 int     `json:"Volume"`
+	TradeCount             int     `json:"TradeCount"`
+	DollarsMultiplier      float64 `json:"DollarsMultiplier"`
+	CumulativeDistribution float64 `json:"CumulativeDistribution"`
+	TradeClusterBombRank   int     `json:"TradeClusterBombRank"`
 }
 
 // NewTradeClusterBombRows projects full API cluster bomb rows into compact output rows.
@@ -163,22 +151,25 @@ func NewTradeClusterBombRows(bombs []TradeClusterBomb) []TradeClusterBombRow {
 // NewTradeClusterBombRow projects one full API cluster bomb row into a compact output row.
 func NewTradeClusterBombRow(bomb *TradeClusterBomb) TradeClusterBombRow {
 	return TradeClusterBombRow{
-		Date:                    bomb.Date,
-		Ticker:                  bomb.Ticker,
-		Sector:                  bomb.Sector,
-		Industry:                bomb.Industry,
-		Name:                    bomb.Name,
-		MinFullDateTime:         bomb.MinFullDateTime,
-		MaxFullDateTime:         bomb.MaxFullDateTime,
-		ClosePrice:              bomb.ClosePrice,
-		Dollars:                 bomb.Dollars,
-		AverageBlockSizeShares:  bomb.AverageBlockSizeShares,
-		AverageBlockSizeDollars: bomb.AverageBlockSizeDollars,
-		Volume:                  bomb.Volume,
-		TradeCount:              bomb.TradeCount,
-		DollarsMultiplier:       roundDollarsMultiplier(bomb.DollarsMultiplier),
-		CumulativeDistribution:  bomb.CumulativeDistribution,
-		AverageDailyVolume:      bomb.AverageDailyVolume,
-		TradeClusterBombRank:    bomb.TradeClusterBombRank,
+		Date:                   compactDate(bomb.Date),
+		Ticker:                 bomb.Ticker,
+		Sector:                 bomb.Sector,
+		Industry:               bomb.Industry,
+		Name:                   bomb.Name,
+		MinFullDateTime:        bomb.MinFullDateTime,
+		MaxFullDateTime:        bomb.MaxFullDateTime,
+		Dollars:                bomb.Dollars,
+		Volume:                 bomb.Volume,
+		TradeCount:             bomb.TradeCount,
+		DollarsMultiplier:      roundDollarsMultiplier(bomb.DollarsMultiplier),
+		CumulativeDistribution: bomb.CumulativeDistribution,
+		TradeClusterBombRank:   bomb.TradeClusterBombRank,
 	}
+}
+
+func compactDate(date AspNetDate) string {
+	if !date.Valid {
+		return ""
+	}
+	return date.Format("2006-01-02")
 }

--- a/internal/models/trade_cluster_test.go
+++ b/internal/models/trade_cluster_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestTradeCluster(t *testing.T) {
@@ -439,12 +440,16 @@ func TestNewTradeClusterRowsProjectsCompactFields(t *testing.T) {
 	t.Parallel()
 
 	rows := NewTradeClusterRows([]TradeCluster{{
-		Ticker:              "NVDA",
-		MinFullTimeString24: "09:30:00",
-		MaxFullTimeString24: "16:00:00",
-		DollarsMultiplier:   2.345,
-		TradeClusterRank:    3,
-		AverageDailyVolume:  50000000,
+		Ticker:                  "NVDA",
+		Date:                    AspNetDate{Time: time.Date(2025, 4, 23, 0, 0, 0, 0, time.UTC), Valid: true},
+		MinFullTimeString24:     "09:30:00",
+		MaxFullTimeString24:     "16:00:00",
+		ClosePrice:              875.50,
+		AverageBlockSizeShares:  50000,
+		AverageBlockSizeDollars: 43500000,
+		DollarsMultiplier:       2.345,
+		TradeClusterRank:        3,
+		AverageDailyVolume:      50000000,
 	}})
 	if len(rows) != 1 {
 		t.Fatalf("NewTradeClusterRows() length = %d, want 1", len(rows))
@@ -455,6 +460,9 @@ func TestNewTradeClusterRowsProjectsCompactFields(t *testing.T) {
 	if rows[0].DollarsMultiplier != 2.35 {
 		t.Errorf("NewTradeClusterRows()[0].DollarsMultiplier = %v, want 2.35", rows[0].DollarsMultiplier)
 	}
+	if rows[0].Date != "2025-04-23" {
+		t.Errorf("NewTradeClusterRows()[0].Date = %q, want 2025-04-23", rows[0].Date)
+	}
 
 	data, err := json.Marshal(rows[0])
 	if err != nil {
@@ -464,7 +472,7 @@ func TestNewTradeClusterRowsProjectsCompactFields(t *testing.T) {
 	if err := json.Unmarshal(data, &fields); err != nil {
 		t.Fatalf("json.Unmarshal(TradeClusterRow) error = %v", err)
 	}
-	for _, field := range []string{"MinFullTimeString24", "MaxFullTimeString24"} {
+	for _, field := range []string{"MinFullTimeString24", "MaxFullTimeString24", "ClosePrice", "AverageBlockSizeShares", "AverageBlockSizeDollars", "AverageDailyVolume"} {
 		if _, ok := fields[field]; ok {
 			t.Fatalf("TradeClusterRow includes trimmed field %q", field)
 		}
@@ -475,12 +483,16 @@ func TestNewTradeClusterBombRowsProjectsCompactFields(t *testing.T) {
 	t.Parallel()
 
 	rows := NewTradeClusterBombRows([]TradeClusterBomb{{
-		Ticker:               "AAPL",
-		MinFullTimeString24:  "09:30:00",
-		MaxFullTimeString24:  "16:00:00",
-		DollarsMultiplier:    3.456,
-		TradeClusterBombRank: 4,
-		AverageDailyVolume:   100000000,
+		Ticker:                  "AAPL",
+		Date:                    AspNetDate{Time: time.Date(2025, 4, 23, 0, 0, 0, 0, time.UTC), Valid: true},
+		MinFullTimeString24:     "09:30:00",
+		MaxFullTimeString24:     "16:00:00",
+		ClosePrice:              150.25,
+		AverageBlockSizeShares:  50000,
+		AverageBlockSizeDollars: 7512500,
+		DollarsMultiplier:       3.456,
+		TradeClusterBombRank:    4,
+		AverageDailyVolume:      100000000,
 	}})
 	if len(rows) != 1 {
 		t.Fatalf("NewTradeClusterBombRows() length = %d, want 1", len(rows))
@@ -491,6 +503,9 @@ func TestNewTradeClusterBombRowsProjectsCompactFields(t *testing.T) {
 	if rows[0].DollarsMultiplier != 3.46 {
 		t.Errorf("NewTradeClusterBombRows()[0].DollarsMultiplier = %v, want 3.46", rows[0].DollarsMultiplier)
 	}
+	if rows[0].Date != "2025-04-23" {
+		t.Errorf("NewTradeClusterBombRows()[0].Date = %q, want 2025-04-23", rows[0].Date)
+	}
 
 	data, err := json.Marshal(rows[0])
 	if err != nil {
@@ -500,7 +515,7 @@ func TestNewTradeClusterBombRowsProjectsCompactFields(t *testing.T) {
 	if err := json.Unmarshal(data, &fields); err != nil {
 		t.Fatalf("json.Unmarshal(TradeClusterBombRow) error = %v", err)
 	}
-	for _, field := range []string{"MinFullTimeString24", "MaxFullTimeString24"} {
+	for _, field := range []string{"MinFullTimeString24", "MaxFullTimeString24", "ClosePrice", "AverageBlockSizeShares", "AverageBlockSizeDollars", "AverageDailyVolume"} {
 		if _, ok := fields[field]; ok {
 			t.Fatalf("TradeClusterBombRow includes trimmed field %q", field)
 		}


### PR DESCRIPTION
## Summary
- Compact trade cluster and cluster-bomb JSON output by formatting dates as YYYY-MM-DD and omitting noisy empty fields.
- Add cluster-bomb field selection plus named `--sort` support for both cluster commands while keeping legacy `--order-col`.
- Fix grouped help duplication and remove internal pagination wording from user-facing help.

## Verification
- `make lint`
- `make test`
- `make build`
- Focused cluster/help/outputschema tests
- Generated `--help`, `outputschema`, and `--jsonschema=tree` outputs
- CodeRabbit local review run once with findings addressed

Fixes #112